### PR TITLE
feat: import complete websites with page review

### DIFF
--- a/server/importer.ts
+++ b/server/importer.ts
@@ -1,11 +1,10 @@
 import { getBrowser } from './screenshot.ts'
 
 /**
- * Landing-page importer: load a URL in the shared Chromium, snapshot the
- * rendered DOM, inline every stylesheet, and return a self-contained HTML
- * document sized to the page. Scripts are stripped — imported frames are
- * static snapshots, which also keeps them editable (WYSIWYG and the agents
- * both refuse script-bearing frames).
+ * Website importer: discover a bounded set of same-site pages, or load one
+ * URL in the shared Chromium and turn it into a self-contained frame. Scripts
+ * are stripped from imported frames so they stay editable (WYSIWYG and the
+ * agents both refuse script-bearing frames).
  */
 
 const UA =
@@ -14,6 +13,13 @@ const VIEWPORT_WIDTH = 1280
 const MAX_HEIGHT = 6000
 const MAX_SHEET_BYTES = 600_000
 const MAX_TOTAL_BYTES = 2_000_000
+const MAX_DISCOVERY_BYTES = 2_000_000
+const MAX_SITEMAPS = 12
+const DISCOVERY_CONCURRENCY = 6
+export const MAX_SITE_PAGES = 100
+
+const NON_PAGE_EXTENSIONS =
+  /\.(?:avif|bmp|css|csv|docx?|eot|gif|gz|ico|jpe?g|js|json|map|mov|mp3|mp4|mpeg|ogg|otf|pdf|png|pptx?|rar|rss|svg|tar|tiff?|txt|wav|webm|webp|woff2?|xlsx?|xml|zip)$/i
 
 /** Basic SSRF guard: public http(s) hosts only. */
 export function assertPublicHttpUrl(raw: string): URL {
@@ -40,6 +46,295 @@ export function assertPublicHttpUrl(raw: string): URL {
     /^172\.(1[6-9]|2\d|3[01])\./.test(h)
   if (privateHost) throw new Error('that host cannot be imported')
   return url
+}
+
+/** A website is scoped to one hostname and (when explicit) port. We allow an
+ * http URL on a page to resolve to https without treating it as another site. */
+export function isSameSiteUrl(candidate: URL, site: URL): boolean {
+  return candidate.hostname.toLowerCase() === site.hostname.toLowerCase() && candidate.port === site.port
+}
+
+/** Normalize a navigable page URL and reject links that cannot represent an
+ * importable web page. Exported because the crawler rules are useful to test
+ * without making network requests. */
+export function normalizePageUrl(raw: string, base: URL, site: URL): URL | null {
+  let url: URL
+  try {
+    url = new URL(raw, base)
+  } catch {
+    return null
+  }
+  if ((url.protocol !== 'http:' && url.protocol !== 'https:') || !isSameSiteUrl(url, site)) return null
+  if (url.username || url.password || NON_PAGE_EXTENSIONS.test(url.pathname)) return null
+  if (site.protocol === 'https:' && url.protocol === 'http:') url.protocol = 'https:'
+  url.hash = ''
+  for (const key of [...url.searchParams.keys()]) {
+    if (/^(?:utm_.+|fbclid|gclid|dclid|msclkid)$/i.test(key)) url.searchParams.delete(key)
+  }
+  url.searchParams.sort()
+  return url
+}
+
+function pageKey(url: URL): string {
+  const path = url.pathname === '/' ? '/' : url.pathname.replace(/\/+$/, '')
+  return `${url.protocol}//${url.host}${path}${url.search}`
+}
+
+function decodeEntities(value: string): string {
+  const named: Record<string, string> = { amp: '&', apos: "'", gt: '>', lt: '<', quot: '"', nbsp: ' ' }
+  return value.replace(/&(#x[\da-f]+|#\d+|[a-z]+);/gi, (all, entity: string) => {
+    if (entity[0] === '#') {
+      const hex = entity[1].toLowerCase() === 'x'
+      const parsed = Number.parseInt(entity.slice(hex ? 2 : 1), hex ? 16 : 10)
+      return Number.isFinite(parsed) && parsed >= 0 && parsed <= 0x10ffff ? String.fromCodePoint(parsed) : all
+    }
+    return named[entity.toLowerCase()] ?? all
+  })
+}
+
+function cleanTitle(value: string): string {
+  return decodeEntities(
+    value
+      .replace(/<[^>]*>/g, ' ')
+      .replace(/\s+/g, ' ')
+      .trim(),
+  ).slice(0, 160)
+}
+
+export function parseHtmlPage(html: string, pageUrl: URL): { title: string; links: string[] } {
+  const title = cleanTitle(html.match(/<title\b[^>]*>([\s\S]*?)<\/title>/i)?.[1] ?? '')
+  const baseHref = html.match(/<base\b[^>]*\bhref\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'=<>`]+))/i)
+  let base = pageUrl
+  try {
+    if (baseHref) base = new URL(baseHref[1] ?? baseHref[2] ?? baseHref[3], pageUrl)
+  } catch {
+    /* malformed base; ordinary document-relative resolution is safer */
+  }
+  const links: string[] = []
+  const hrefs = html.matchAll(/<a\b[^>]*\bhref\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'=<>`]+))/gi)
+  for (const match of hrefs) {
+    try {
+      links.push(new URL(decodeEntities(match[1] ?? match[2] ?? match[3]), base).href)
+    } catch {
+      /* malformed link */
+    }
+  }
+  return { title, links }
+}
+
+export function parseSitemap(xml: string): { index: boolean; urls: string[] } {
+  const urls: string[] = []
+  for (const match of xml.matchAll(/<loc\b[^>]*>([\s\S]*?)<\/loc>/gi)) {
+    let value = match[1].trim()
+    if (value.startsWith('<![CDATA[') && value.endsWith(']]>')) value = value.slice(9, -3)
+    value = decodeEntities(value.trim())
+    if (value) urls.push(value)
+  }
+  return { index: /<sitemapindex\b/i.test(xml), urls }
+}
+
+function fallbackTitle(url: URL): string {
+  if (url.pathname === '/') return 'Home'
+  const last = url.pathname.split('/').filter(Boolean).pop() ?? url.hostname
+  try {
+    return decodeURIComponent(last)
+      .replace(/[-_]+/g, ' ')
+      .replace(/\b\w/g, (c) => c.toUpperCase())
+  } catch {
+    return last
+  }
+}
+
+/** Homepage first, then shallower paths before deeper descendants. Within a
+ * level, keep the deterministic alphabetical/numeric order users expect. */
+export function comparePageUrlsByDepth(a: string, b: string): number {
+  const left = new URL(a)
+  const right = new URL(b)
+  const leftDepth = left.pathname.split('/').filter(Boolean).length
+  const rightDepth = right.pathname.split('/').filter(Boolean).length
+  if (leftDepth !== rightDepth) return leftDepth - rightDepth
+  return `${left.pathname}${left.search}`.localeCompare(`${right.pathname}${right.search}`, undefined, {
+    numeric: true,
+  })
+}
+
+interface TextResponse {
+  url: URL
+  text: string
+  contentType: string
+}
+
+/** Follow redirects manually so every hop is re-checked before it is fetched. */
+async function fetchSiteText(rawUrl: string, site: URL, timeout = 8_000): Promise<TextResponse | null> {
+  let url = assertPublicHttpUrl(rawUrl)
+  for (let redirects = 0; redirects <= 5; redirects++) {
+    if (!isSameSiteUrl(url, site)) return null
+    let res: Response
+    try {
+      res = await fetch(url, {
+        redirect: 'manual',
+        headers: { 'user-agent': UA, accept: 'text/html,application/xhtml+xml,application/xml,text/xml,*/*;q=0.1' },
+        signal: AbortSignal.timeout(timeout),
+      })
+    } catch {
+      return null
+    }
+    if (res.status >= 300 && res.status < 400) {
+      const location = res.headers.get('location')
+      if (!location) return null
+      try {
+        url = assertPublicHttpUrl(new URL(location, url).href)
+      } catch {
+        return null
+      }
+      continue
+    }
+    if (!res.ok) return null
+    const declared = Number(res.headers.get('content-length') || 0)
+    if (declared > MAX_DISCOVERY_BYTES) return null
+    const text = (await res.text()).slice(0, MAX_DISCOVERY_BYTES)
+    return { url, text, contentType: res.headers.get('content-type') ?? '' }
+  }
+  return null
+}
+
+async function sitemapPages(site: URL): Promise<string[]> {
+  const sitemapQueue = [`${site.origin}/sitemap.xml`]
+  const robots = await fetchSiteText(`${site.origin}/robots.txt`, site)
+  if (robots) {
+    for (const match of robots.text.matchAll(/^\s*sitemap:\s*(\S+)\s*$/gim)) sitemapQueue.push(match[1])
+  }
+
+  const seen = new Set<string>()
+  const pages: string[] = []
+  while (sitemapQueue.length && seen.size < MAX_SITEMAPS && pages.length < MAX_SITE_PAGES) {
+    const raw = sitemapQueue.shift()!
+    let sitemapUrl: URL
+    try {
+      sitemapUrl = assertPublicHttpUrl(new URL(raw, site).href)
+    } catch {
+      continue
+    }
+    if (!isSameSiteUrl(sitemapUrl, site) || seen.has(sitemapUrl.href)) continue
+    seen.add(sitemapUrl.href)
+    const response = await fetchSiteText(sitemapUrl.href, site)
+    if (!response) continue
+    const parsed = parseSitemap(response.text)
+    if (parsed.index) sitemapQueue.push(...parsed.urls)
+    else pages.push(...parsed.urls)
+  }
+  return pages
+}
+
+export interface DiscoveredPage {
+  url: string
+  title: string
+}
+
+export interface DiscoveredSite {
+  siteUrl: string
+  pages: DiscoveredPage[]
+  truncated: boolean
+}
+
+/** Discover the homepage, sitemap entries, and recursively linked HTML pages.
+ * The hard cap keeps an accidental calendar/archive crawl from becoming an
+ * unbounded background job; the UI calls this out when it is reached. */
+export async function discoverSitePages(rawUrl: string): Promise<DiscoveredSite> {
+  assertPublicHttpUrl(rawUrl)
+  const browser = await getBrowser()
+  const page = await browser.newPage()
+  let seed: { url: URL; title: string; links: string[] }
+  try {
+    await page.setViewport({ width: VIEWPORT_WIDTH, height: 900 })
+    await page.setUserAgent(UA)
+    await page.goto(rawUrl, { waitUntil: 'domcontentloaded', timeout: 25_000 })
+    await new Promise((resolve) => setTimeout(resolve, 700))
+    const finalUrl = assertPublicHttpUrl(page.url())
+    const snapshot = await page.evaluate(() => ({
+      title: document.title,
+      links: Array.from(document.querySelectorAll<HTMLAnchorElement>('a[href]'), (a) => a.href),
+    }))
+    seed = { url: finalUrl, title: cleanTitle(snapshot.title), links: snapshot.links }
+  } finally {
+    await page.close().catch(() => {})
+  }
+
+  const pages = new Map<string, DiscoveredPage>()
+  let truncated = false
+  const add = (raw: string, base = seed.url, title = '') => {
+    const url = normalizePageUrl(raw, base, seed.url)
+    if (!url) return
+    const key = pageKey(url)
+    const existing = pages.get(key)
+    if (existing) {
+      if (title && !existing.title) existing.title = cleanTitle(title)
+      return
+    }
+    if (pages.size >= MAX_SITE_PAGES) {
+      truncated = true
+      return
+    }
+    pages.set(key, { url: url.href, title: cleanTitle(title) })
+  }
+
+  add(`${seed.url.origin}/`)
+  add(seed.url.href, seed.url, seed.title)
+  for (const link of seed.links) add(link)
+  for (const link of await sitemapPages(seed.url)) add(link)
+
+  /* The rendered seed already gave us its links. Fetch the remaining pages
+     in small batches to obtain titles and discover deeper static links. */
+  const scanned = new Set<string>([pageKey(seed.url)])
+  for (;;) {
+    const batch = [...pages.entries()].filter(([key]) => !scanned.has(key)).slice(0, DISCOVERY_CONCURRENCY)
+    if (!batch.length) break
+    batch.forEach(([key]) => scanned.add(key))
+    const results = await Promise.all(
+      batch.map(async ([key, found]) => ({ key, found, response: await fetchSiteText(found.url, seed.url) })),
+    )
+    for (const { key, found, response } of results) {
+      if (!response || (response.contentType && !/html|xhtml/i.test(response.contentType))) continue
+      const parsed = parseHtmlPage(response.text, response.url)
+      if (parsed.title) pages.get(key)!.title = parsed.title
+      for (const link of parsed.links) add(link, response.url)
+      /* Preserve the requested URL in the list; importPage follows the same
+         redirect and the label remains recognizable to the user. */
+      if (!pages.get(key)?.title) pages.get(key)!.title = fallbackTitle(new URL(found.url))
+    }
+  }
+
+  const result = [...pages.values()]
+    .map((found) => ({ ...found, title: found.title || fallbackTitle(new URL(found.url)) }))
+    .sort((a, b) => comparePageUrlsByDepth(a.url, b.url))
+
+  return { siteUrl: seed.url.origin, pages: result, truncated }
+}
+
+export interface ImportedPageResult {
+  url: string
+  page?: ImportedPage
+  error?: string
+}
+
+/** Capture several pages without opening an unbounded number of Chromium tabs. */
+export async function importSitePages(rawUrls: string[], concurrency = 3): Promise<ImportedPageResult[]> {
+  const results = new Array<ImportedPageResult>(rawUrls.length)
+  let cursor = 0
+  async function worker() {
+    for (;;) {
+      const index = cursor++
+      if (index >= rawUrls.length) return
+      const url = rawUrls[index]
+      try {
+        results[index] = { url, page: await importPage(url) }
+      } catch (error) {
+        results[index] = { url, error: error instanceof Error ? error.message : 'import failed' }
+      }
+    }
+  }
+  await Promise.all(Array.from({ length: Math.min(Math.max(concurrency, 1), rawUrls.length) }, () => worker()))
+  return results
 }
 
 /** Fetch a stylesheet, resolve depth-1 @imports, absolutize its url() refs. */

--- a/server/index.ts
+++ b/server/index.ts
@@ -782,21 +782,105 @@ app.post('/api/comments/:id/retry', (req, res) => {
   res.json(actions.retryComment(req.params.id, req.user!.name))
 })
 
-/* import a live web page as a static frame (rendered HTML + inlined CSS) */
+/* Import one page immediately, or discover + import a user-reviewed set of
+   same-site pages. Discovery and capture are separate requests on purpose:
+   nothing gets added to the canvas until the user confirms the page list. */
 const importHits = new Map<string, number[]>()
+function takeImportSlot(userId: string): boolean {
+  const now = Date.now()
+  const hits = (importHits.get(userId) ?? []).filter((t) => now - t < 60_000)
+  if (hits.length >= 5) return false
+  hits.push(now)
+  importHits.set(userId, hits)
+  return true
+}
+
+app.post('/api/canvases/:id/import/discover', async (req, res) => {
+  if (!requireCanvas(req, res, req.params.id)) return
+  try {
+    const { discoverSitePages, assertPublicHttpUrl } = await import('./importer.ts')
+    const url = String(req.body?.url ?? '')
+    assertPublicHttpUrl(url)
+    if (!takeImportSlot(req.user!.id)) return res.status(429).json({ error: 'too many imports — wait a minute' })
+    res.json(await discoverSitePages(url))
+  } catch (e) {
+    res.status(400).json({ error: e instanceof Error ? e.message : 'page discovery failed' })
+  }
+})
+
 app.post('/api/canvases/:id/import', async (req, res) => {
   const canvas = requireCanvas(req, res, req.params.id)
   if (!canvas) return
   try {
-    const { importPage, assertPublicHttpUrl } = await import('./importer.ts')
-    /* validate before consuming a rate-limit slot — typos shouldn't burn quota */
-    assertPublicHttpUrl(String(req.body?.url ?? ''))
-    const now = Date.now()
-    const hits = (importHits.get(req.user!.id) ?? []).filter((t) => now - t < 60_000)
-    if (hits.length >= 5) return res.status(429).json({ error: 'too many imports — wait a minute' })
-    hits.push(now)
-    importHits.set(req.user!.id, hits)
-    const imported = await importPage(String(req.body?.url ?? ''))
+    const { importPage, importSitePages, assertPublicHttpUrl, isSameSiteUrl, MAX_SITE_PAGES } =
+      await import('./importer.ts')
+    const requested: string[] | null = Array.isArray(req.body?.urls)
+      ? (req.body.urls as unknown[]).map((value) => String(value))
+      : null
+
+    if (requested) {
+      if (!requested.length) return res.status(400).json({ error: 'select at least one page' })
+      if (requested.length > MAX_SITE_PAGES) {
+        return res.status(400).json({ error: `a website import is limited to ${MAX_SITE_PAGES} pages` })
+      }
+      /* Validate the whole batch before consuming a slot or opening Chromium. */
+      const validated = requested.map((url) => assertPublicHttpUrl(url))
+      if (validated.some((url) => !isSameSiteUrl(url, validated[0]))) {
+        return res.status(400).json({ error: 'all selected pages must belong to the same website' })
+      }
+      const urls = [...new Set(validated.map((url) => url.href))]
+      if (!takeImportSlot(req.user!.id)) return res.status(429).json({ error: 'too many imports — wait a minute' })
+
+      const captures = await importSitePages(urls)
+      const actor = actions.resolveActor({ name: req.user!.name, kind: 'user' })
+      const frames = []
+      const failures: { url: string; error: string }[] = []
+      const rightmost = canvas.frames.reduce((right, frame) => Math.max(right, frame.x + frame.width), 0)
+      const startX = canvas.frames.length ? rightmost + 80 : 120
+      const columns = 3
+      let column = 0
+      let y = 120
+      let rowHeight = 0
+
+      for (const capture of captures) {
+        if (!capture.page) {
+          failures.push({ url: capture.url, error: capture.error ?? 'import failed' })
+          continue
+        }
+        const imported = capture.page
+        const frame = actions.createFrame(
+          canvas.id,
+          {
+            name: imported.title.slice(0, 80),
+            x: startX + column * (imported.width + 80),
+            y,
+            width: imported.width,
+            height: imported.height,
+            html: imported.html,
+          },
+          actor,
+        )
+        if (!frame) {
+          failures.push({ url: capture.url, error: 'canvas not found' })
+          continue
+        }
+        frames.push(frame)
+        rowHeight = Math.max(rowHeight, imported.height)
+        column++
+        if (column === columns) {
+          column = 0
+          y += rowHeight + 80
+          rowHeight = 0
+        }
+      }
+      return res.json({ frames, failures })
+    }
+
+    const url = String(req.body?.url ?? '')
+    /* Validate before consuming a rate-limit slot — typos shouldn't burn quota. */
+    assertPublicHttpUrl(url)
+    if (!takeImportSlot(req.user!.id)) return res.status(429).json({ error: 'too many imports — wait a minute' })
+    const imported = await importPage(url)
     const actor = actions.resolveActor({ name: req.user!.name, kind: 'user' })
     const frame = actions.createFrame(
       canvas.id,

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -8,6 +8,22 @@ export interface CanvasMember {
   email: string
   owner: boolean
 }
+
+export interface DiscoveredPage {
+  url: string
+  title: string
+}
+
+export interface DiscoveredSite {
+  siteUrl: string
+  pages: DiscoveredPage[]
+  truncated: boolean
+}
+
+export interface WebsiteImportResult {
+  frames: Frame[]
+  failures: { url: string; error: string }[]
+}
 import { getIdentity } from './identity'
 
 function actor() {
@@ -105,6 +121,16 @@ export const api = {
     req(`/api/tasks/${taskId}/feedback`, { method: 'POST', body: JSON.stringify({ text, from: getIdentity().name }) }),
   importPage: (canvasId: string, url: string) =>
     req<Frame>(`/api/canvases/${canvasId}/import`, { method: 'POST', body: JSON.stringify({ url }) }),
+  discoverSitePages: (canvasId: string, url: string) =>
+    req<DiscoveredSite>(`/api/canvases/${canvasId}/import/discover`, {
+      method: 'POST',
+      body: JSON.stringify({ url }),
+    }),
+  importSitePages: (canvasId: string, urls: string[]) =>
+    req<WebsiteImportResult>(`/api/canvases/${canvasId}/import`, {
+      method: 'POST',
+      body: JSON.stringify({ urls }),
+    }),
   agentAllowance: () => req<{ used: number; limit: number; connected: boolean }>('/api/agent-allowance'),
   addCard: (canvasId: string, title: string, agents: string[], attachments?: string[]) =>
     req(`/api/canvases/${canvasId}/cards`, { method: 'POST', body: JSON.stringify({ title, agents, attachments }) }),

--- a/src/pages/CanvasPage.tsx
+++ b/src/pages/CanvasPage.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useStore } from '../lib/store'
 import { connect, disconnect, sendWs } from '../lib/ws'
-import { api, ApiError, type CanvasMember } from '../lib/api'
+import { api, ApiError, type CanvasMember, type DiscoveredSite } from '../lib/api'
 import { navigate, Logo } from '../App'
 import { Stage } from '../components/Stage'
 import { Board } from '../components/Board'
@@ -316,11 +316,12 @@ export function CanvasPage({ canvasId }: { canvasId: string }) {
         <ImportModal
           canvasId={canvasId}
           onClose={() => setShowImport(false)}
-          onDone={(frameId) => {
+          onDone={(frameIds, failedCount) => {
             setShowImport(false)
             setView('canvas')
-            select(frameId)
-            showToast('Page imported as a frame')
+            select(frameIds[0] ?? null)
+            const imported = frameIds.length === 1 ? '1 page imported' : `${frameIds.length} pages imported`
+            showToast(failedCount ? `${imported} · ${failedCount} failed` : imported)
           }}
         />
       )}
@@ -345,56 +346,255 @@ function ImportModal({
 }: {
   canvasId: string
   onClose: () => void
-  onDone: (frameId: string) => void
+  onDone: (frameIds: string[], failedCount: number) => void
 }) {
   const [url, setUrl] = useState('')
-  const [busy, setBusy] = useState(false)
+  const [wholeSite, setWholeSite] = useState(false)
+  const [discovery, setDiscovery] = useState<DiscoveredSite | null>(null)
+  const [selected, setSelected] = useState<Set<string>>(new Set())
+  const [busy, setBusy] = useState<'discovering' | 'importing' | null>(null)
   const [error, setError] = useState<string | null>(null)
 
-  async function run() {
+  function errorMessage(caught: unknown, fallback: string) {
+    if (caught instanceof ApiError) return String(caught.body.error ?? fallback)
+    return caught instanceof Error ? caught.message.replace(/^\d+\s*/, '') : fallback
+  }
+
+  function normalizedUrl() {
     const clean = url.trim()
-    if (!clean || busy) return
-    setBusy(true)
+    return /^https?:\/\//i.test(clean) ? clean : `https://${clean}`
+  }
+
+  async function runSinglePage() {
+    if (!url.trim() || busy) return
+    setBusy('importing')
     setError(null)
     try {
-      const frame = await api.importPage(canvasId, /^https?:\/\//i.test(clean) ? clean : `https://${clean}`)
+      const frame = await api.importPage(canvasId, normalizedUrl())
       posthog.capture('page_imported')
-      onDone(frame.id)
+      onDone([frame.id], 0)
     } catch (e) {
-      setError(e instanceof Error ? e.message.replace(/^\d+\s*/, '') : 'import failed')
-      setBusy(false)
+      setError(errorMessage(e, 'import failed'))
+      setBusy(null)
     }
   }
+
+  async function discover() {
+    if (!url.trim() || busy) return
+    setBusy('discovering')
+    setError(null)
+    try {
+      const found = await api.discoverSitePages(canvasId, normalizedUrl())
+      setDiscovery(found)
+      setSelected(new Set(found.pages.map((page) => page.url)))
+      posthog.capture('site_pages_discovered', { page_count: found.pages.length, truncated: found.truncated })
+      setBusy(null)
+    } catch (e) {
+      setError(errorMessage(e, 'page discovery failed'))
+      setBusy(null)
+    }
+  }
+
+  async function importSelected() {
+    if (!discovery || !selected.size || busy) return
+    setBusy('importing')
+    setError(null)
+    const urls = discovery.pages.filter((page) => selected.has(page.url)).map((page) => page.url)
+    try {
+      const result = await api.importSitePages(canvasId, urls)
+      if (!result.frames.length) {
+        const reason = result.failures[0]?.error
+        setError(reason ? `No pages could be imported — ${reason}` : 'No pages could be imported')
+        setBusy(null)
+        return
+      }
+      posthog.capture('website_imported', {
+        requested_count: urls.length,
+        imported_count: result.frames.length,
+        failed_count: result.failures.length,
+      })
+      onDone(
+        result.frames.map((frame) => frame.id),
+        result.failures.length,
+      )
+    } catch (e) {
+      setError(errorMessage(e, 'website import failed'))
+      setBusy(null)
+    }
+  }
+
+  function togglePage(pageUrl: string) {
+    setSelected((current) => {
+      const next = new Set(current)
+      if (next.has(pageUrl)) next.delete(pageUrl)
+      else next.add(pageUrl)
+      return next
+    })
+  }
+
+  const selectedCount = selected.size
 
   return (
     <div className="modal-backdrop" onClick={() => !busy && onClose()}>
       <div className="modal import-modal" onClick={(e) => e.stopPropagation()}>
-        <h2>Import a page</h2>
-        <p className="lede">
-          Paste a URL and it lands on the canvas as a frame — the rendered HTML with every stylesheet inlined. Scripts
-          are stripped, so the snapshot stays editable and commentable like any other frame.
-        </p>
-        <input
-          className="import-url"
-          autoFocus
-          placeholder="https://example.com/pricing"
-          value={url}
-          disabled={busy}
-          onChange={(e) => setUrl(e.target.value)}
-          onKeyDown={(e) => {
-            if (e.key === 'Enter') run()
-            if (e.key === 'Escape' && !busy) onClose()
-          }}
-        />
-        {error && <p className="import-error">{error}</p>}
-        <div className="close-row">
-          <button className="btn ghost" disabled={busy} onClick={onClose}>
-            Cancel
-          </button>
-          <button className="btn primary" disabled={busy || !url.trim()} onClick={run}>
-            {busy ? 'Importing…' : '⤓ Import'}
-          </button>
-        </div>
+        {!discovery ? (
+          <>
+            <div className="import-heading">
+              <span className="import-kicker">Website capture</span>
+              <h2>Import from the web</h2>
+            </div>
+            <p className="lede">
+              Bring in one page, or discover a whole site and choose the pages you want before anything is added.
+            </p>
+            <label className="import-field-label" htmlFor="import-url">
+              Website URL
+            </label>
+            <input
+              id="import-url"
+              className="import-url"
+              autoFocus
+              placeholder="https://example.com"
+              value={url}
+              disabled={!!busy}
+              onChange={(e) => {
+                setUrl(e.target.value)
+                setError(null)
+              }}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                  if (wholeSite) discover()
+                  else runSinglePage()
+                }
+                if (e.key === 'Escape' && !busy) onClose()
+              }}
+            />
+            <label className={`site-import-option${wholeSite ? ' on' : ''}`}>
+              <input
+                type="checkbox"
+                checked={wholeSite}
+                disabled={!!busy}
+                onChange={(e) => {
+                  setWholeSite(e.target.checked)
+                  setError(null)
+                }}
+              />
+              <span className="site-import-check" aria-hidden="true">
+                {wholeSite ? '✓' : ''}
+              </span>
+              <span>
+                <span className="site-import-title">
+                  Import the entire website <em>Optional</em>
+                </span>
+                <span className="site-import-copy">Find public pages on the same site, then review the list.</span>
+              </span>
+            </label>
+            <p className="import-footnote">Snapshots stay editable and commentable. Scripts are removed.</p>
+            {error && <p className="import-error">{error}</p>}
+            <div className="close-row">
+              <button className="btn ghost" disabled={!!busy} onClick={onClose}>
+                Cancel
+              </button>
+              <button
+                className="btn primary"
+                disabled={!!busy || !url.trim()}
+                onClick={wholeSite ? discover : runSinglePage}
+              >
+                {busy === 'discovering'
+                  ? 'Finding pages…'
+                  : busy === 'importing'
+                    ? 'Importing…'
+                    : wholeSite
+                      ? 'Find pages →'
+                      : '⤓ Import page'}
+              </button>
+            </div>
+          </>
+        ) : (
+          <>
+            <div className="import-review-head">
+              <div>
+                <span className="import-kicker">Review before import</span>
+                <h2>Choose pages</h2>
+              </div>
+              <span className="import-domain">{new URL(discovery.siteUrl).hostname}</span>
+            </div>
+            <p className="lede">
+              {discovery.pages.length} {discovery.pages.length === 1 ? 'page' : 'pages'} found. Everything is selected
+              by default; uncheck anything you don’t need.
+            </p>
+            <div className="import-selection-bar">
+              <b>
+                {selectedCount} of {discovery.pages.length} selected
+              </b>
+              <span>
+                <button
+                  type="button"
+                  disabled={!!busy}
+                  onClick={() => setSelected(new Set(discovery.pages.map((p) => p.url)))}
+                >
+                  Select all
+                </button>
+                <button type="button" disabled={!!busy} onClick={() => setSelected(new Set())}>
+                  Clear
+                </button>
+              </span>
+            </div>
+            <div className={`import-page-list${busy ? ' busy' : ''}`} role="group" aria-label="Pages to import">
+              {discovery.pages.map((page, index) => {
+                const pageUrl = new URL(page.url)
+                let pathname = pageUrl.pathname
+                try {
+                  pathname = decodeURIComponent(pathname)
+                } catch {
+                  /* Keep the encoded path when a site contains a malformed escape. */
+                }
+                const path = pathname + pageUrl.search
+                return (
+                  <label className="import-page-row" key={page.url}>
+                    <input
+                      type="checkbox"
+                      checked={selected.has(page.url)}
+                      disabled={!!busy}
+                      onChange={() => togglePage(page.url)}
+                    />
+                    <span className="import-page-check" aria-hidden="true">
+                      {selected.has(page.url) ? '✓' : ''}
+                    </span>
+                    <span className="import-page-number">{String(index + 1).padStart(2, '0')}</span>
+                    <span className="import-page-info">
+                      <b>{page.title}</b>
+                      <span>{path || '/'}</span>
+                    </span>
+                  </label>
+                )
+              })}
+            </div>
+            {discovery.truncated && (
+              <p className="import-limit-note">Showing the first 100 pages found. Narrow the starting URL if needed.</p>
+            )}
+            {busy === 'importing' && (
+              <p className="import-progress">Capturing {selectedCount} pages — larger sites can take a few minutes.</p>
+            )}
+            {error && <p className="import-error">{error}</p>}
+            <div className="close-row import-review-actions">
+              <button
+                className="btn ghost"
+                disabled={!!busy}
+                onClick={() => {
+                  setDiscovery(null)
+                  setError(null)
+                }}
+              >
+                ← Back
+              </button>
+              <button className="btn primary" disabled={!!busy || !selectedCount} onClick={importSelected}>
+                {busy === 'importing'
+                  ? `Importing ${selectedCount}…`
+                  : `⤓ Import ${selectedCount} ${selectedCount === 1 ? 'page' : 'pages'}`}
+              </button>
+            </div>
+          </>
+        )}
       </div>
     </div>
   )

--- a/src/styles.css
+++ b/src/styles.css
@@ -2400,23 +2400,257 @@ textarea {
 }
 
 .import-modal {
-  max-width: 480px;
+  max-width: 660px;
+}
+.import-modal .btn:disabled,
+.import-selection-bar button:disabled {
+  cursor: default;
+  opacity: 0.48;
+  transform: none;
+  box-shadow: none;
+}
+.import-heading,
+.import-review-head > div {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+.import-kicker {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 650;
+  letter-spacing: 0.14em;
+  line-height: 1;
+  text-transform: uppercase;
+  color: var(--accent-ink);
+}
+.import-field-label {
+  display: block;
+  margin-top: 22px;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ink-soft);
 }
 .import-url {
   width: 100%;
-  margin-top: 18px;
+  margin-top: 7px;
   border: 1px solid var(--line);
   border-radius: 10px;
   background: var(--paper);
-  padding: 11px 14px;
+  padding: 13px 14px;
   font-family: var(--font-mono);
   font-size: 13px;
   color: var(--ink);
+  transition:
+    border-color 0.15s ease,
+    background 0.15s ease,
+    box-shadow 0.15s ease;
 }
 .import-url:focus {
   outline: none;
   border-color: var(--ink);
   background: #fff;
+  box-shadow: 3px 3px 0 var(--line);
+}
+.site-import-option {
+  position: relative;
+  display: grid;
+  grid-template-columns: 22px 1fr;
+  gap: 12px;
+  align-items: start;
+  margin-top: 14px;
+  padding: 15px;
+  border: 1px solid var(--line);
+  border-radius: 11px;
+  background: var(--surface);
+  cursor: pointer;
+  transition:
+    border-color 0.15s ease,
+    background 0.15s ease;
+}
+.site-import-option:hover {
+  border-color: var(--ink-faint);
+}
+.site-import-option.on {
+  border-color: var(--ink);
+  background: linear-gradient(110deg, rgba(229, 83, 60, 0.06), transparent 72%), var(--surface);
+}
+.site-import-option input,
+.import-page-row input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+.site-import-check,
+.import-page-check {
+  display: grid;
+  place-items: center;
+  flex: none;
+  width: 20px;
+  height: 20px;
+  border: 1px solid var(--ink-faint);
+  border-radius: 5px;
+  background: var(--surface);
+  color: #fff;
+  font-size: 12px;
+  font-weight: 800;
+}
+.site-import-option input:focus-visible + .site-import-check,
+.import-page-row input:focus-visible + .import-page-check {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+.site-import-option.on .site-import-check,
+.import-page-row input:checked + .import-page-check {
+  border-color: var(--ink);
+  background: var(--ink);
+}
+.site-import-title,
+.site-import-copy {
+  display: block;
+}
+.site-import-title {
+  font-size: 13.5px;
+  font-weight: 700;
+  color: var(--ink);
+}
+.site-import-title em {
+  margin-left: 7px;
+  padding: 2px 6px;
+  border-radius: 999px;
+  background: var(--paper-deep);
+  font-family: var(--font-mono);
+  font-size: 8.5px;
+  font-style: normal;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+}
+.site-import-copy {
+  margin-top: 4px;
+  font-size: 12px;
+  line-height: 1.4;
+  color: var(--ink-soft);
+}
+.import-footnote,
+.import-limit-note,
+.import-progress {
+  margin-top: 10px;
+  font-size: 11.5px;
+  line-height: 1.4;
+  color: var(--ink-faint);
+}
+.import-review-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 24px;
+}
+.import-domain {
+  max-width: 240px;
+  overflow: hidden;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: var(--paper);
+  padding: 5px 9px;
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  color: var(--ink-soft);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.import-selection-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-top: 20px;
+  padding: 0 2px 9px;
+}
+.import-selection-bar b {
+  font-size: 12px;
+  color: var(--ink-soft);
+}
+.import-selection-bar span {
+  display: flex;
+  gap: 12px;
+}
+.import-selection-bar button {
+  border: none;
+  background: none;
+  padding: 0;
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  color: var(--ink-faint);
+}
+.import-selection-bar button:hover:not(:disabled) {
+  color: var(--accent-ink);
+}
+.import-page-list {
+  max-height: min(350px, calc(100vh - 390px));
+  overflow-y: auto;
+  border: 1px solid var(--line);
+  border-radius: 11px;
+  background: var(--paper);
+  transition: opacity 0.15s ease;
+}
+.import-page-list.busy {
+  opacity: 0.58;
+}
+.import-page-row {
+  position: relative;
+  display: grid;
+  grid-template-columns: 20px 24px minmax(0, 1fr);
+  gap: 10px;
+  align-items: center;
+  min-height: 58px;
+  padding: 9px 12px;
+  border-bottom: 1px solid var(--line);
+  background: var(--surface);
+  cursor: pointer;
+}
+.import-page-row:first-child {
+  border-radius: 10px 10px 0 0;
+}
+.import-page-row:last-child {
+  border-bottom: none;
+  border-radius: 0 0 10px 10px;
+}
+.import-page-row:hover {
+  background: #fbfbfc;
+}
+.import-page-number {
+  font-family: var(--font-mono);
+  font-size: 9.5px;
+  color: var(--ink-faint);
+}
+.import-page-info {
+  min-width: 0;
+}
+.import-page-info b,
+.import-page-info span {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.import-page-info b {
+  font-size: 12.5px;
+  color: var(--ink);
+}
+.import-page-info span {
+  margin-top: 3px;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--ink-faint);
+}
+.import-progress {
+  color: var(--accent-ink);
+}
+.import-review-actions {
+  justify-content: space-between !important;
 }
 .import-error {
   margin-top: 10px;

--- a/tests/importer.test.ts
+++ b/tests/importer.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest'
+import { comparePageUrlsByDepth, normalizePageUrl, parseHtmlPage, parseSitemap } from '../server/importer.ts'
+
+describe('website page discovery helpers', () => {
+  const site = new URL('https://example.com/pricing')
+
+  it('keeps same-site pages while normalizing tracking parameters and fragments', () => {
+    const page = normalizePageUrl('http://example.com/docs/?utm_source=newsletter&b=2&a=1#overview', site, site)
+    expect(page?.href).toBe('https://example.com/docs/?a=1&b=2')
+    expect(normalizePageUrl('https://other.example/docs', site, site)).toBeNull()
+    expect(normalizePageUrl('/assets/diagram.svg', site, site)).toBeNull()
+    expect(normalizePageUrl('mailto:hello@example.com', site, site)).toBeNull()
+  })
+
+  it('extracts a readable title and resolves links against a document base', () => {
+    const parsed = parseHtmlPage(
+      `<!doctype html><title>Docs &amp; Guides</title>
+       <base href="/help/">
+       <a href="getting-started">Start</a>
+       <a href='/pricing?plan=pro&amp;cycle=annual'>Pricing</a>`,
+      new URL('https://example.com/docs'),
+    )
+    expect(parsed.title).toBe('Docs & Guides')
+    expect(parsed.links).toEqual([
+      'https://example.com/help/getting-started',
+      'https://example.com/pricing?plan=pro&cycle=annual',
+    ])
+  })
+
+  it('reads ordinary and CDATA sitemap locations', () => {
+    const parsed = parseSitemap(`
+      <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+        <sitemap><loc>https://example.com/pages.xml?part=1&amp;lang=en</loc></sitemap>
+        <sitemap><loc><![CDATA[https://example.com/pages-2.xml]]></loc></sitemap>
+      </sitemapindex>
+    `)
+    expect(parsed).toEqual({
+      index: true,
+      urls: ['https://example.com/pages.xml?part=1&lang=en', 'https://example.com/pages-2.xml'],
+    })
+  })
+
+  it('orders first-level paths before nested pages', () => {
+    const pages = [
+      'https://example.com/use-cases/education',
+      'https://example.com/blog/launch',
+      'https://example.com/privacy',
+      'https://example.com/',
+      'https://example.com/blog',
+      'https://example.com/use-cases',
+    ]
+    expect(pages.sort(comparePageUrlsByDepth)).toEqual([
+      'https://example.com/',
+      'https://example.com/blog',
+      'https://example.com/privacy',
+      'https://example.com/use-cases',
+      'https://example.com/blog/launch',
+      'https://example.com/use-cases/education',
+    ])
+  })
+})


### PR DESCRIPTION
## Summary

Add an optional whole-site mode to the existing website importer. Single-page import remains the default; whole-site import discovers candidate pages and requires explicit user review before creating any frames.

- discover pages from the rendered entry page, robots-declared sitemaps, sitemap indexes, and recursively linked HTML pages
- show a selectable review list with all pages selected by default, plus Select all and Clear controls
- order pages by path depth so top-level routes appear before nested routes
- import the confirmed selection with bounded concurrency and arrange resulting frames in a three-column grid
- preserve successful captures when individual pages fail and report the partial result

## Safety and operational limits

- accept public HTTP(S) URLs only and keep a batch on the same hostname and explicit port
- revalidate redirects during discovery
- ignore common non-page asset extensions and remove fragments and tracking parameters
- cap discovery and batch import at 100 pages
- bound sitemap traversal, response sizes, redirects, request timeouts, and concurrent Chromium pages
- strip scripts from captured frames, matching the existing single-page importer

## Verification

- npm run typecheck
- npm test (13 tests)
- npm run lint (passes with 8 pre-existing warnings)
- npm run format:check
- npm run build
- live single-page import verification
- live 100-page discovery and three-page batch import verification