### PR TITLE
docs: document Doop Agent setup, and stop it failing silently

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,9 @@ activity feed.
 
 - **Design with agents, not prompts-and-refresh** — connect Claude Code (or any MCP client) once,
   then watch it sketch, stream and self-review designs on your canvas, next to your cursor.
-- **A built-in resident design team** — queue a card or @mention an agent; a scripted demo agent
-  performs on your first canvas even without an API key.
+- **A built-in Doop Agent** — queue a card or @mention a role and it designs on its own, no client
+  to connect. Needs an `ANTHROPIC_API_KEY` ([setup](#the-doop-agent)); the first-canvas welcome
+  performance is scripted and runs without one.
 - **True multiplayer** — live cursors, presence, per-frame editing indicators, undo/redo, comments
   pinned to elements, and an activity feed, all over one WebSocket room.
 - **Design memory** — pin exemplar frames, capture decisions, and let the distiller propose durable
@@ -45,8 +46,10 @@ npm run dev
 - API + WebSocket + MCP server: **http://localhost:4400** (the web port proxies `/api`, `/ws`, `/mcp` to it)
 
 Everything works with no configuration: data persists to an embedded Postgres (PGlite) in `data/pg`,
-and every optional integration (SMTP, Anthropic, stock photos, object storage, analytics) degrades
-gracefully until its variable in [.env.example](.env.example) is set.
+and every optional integration (SMTP, stock photos, object storage, analytics) degrades gracefully
+until its variable in [.env.example](.env.example) is set. The one you will most likely want is
+`ANTHROPIC_API_KEY`, which turns on the built-in [Doop Agent](#the-doop-agent) — agents you connect
+yourself over MCP need no key.
 
 Or self-host the production build with Docker:
 
@@ -79,13 +82,57 @@ the frame chip, the working strip, and the task in the Agents panel.
 
 ## Watch an agent design
 
-The first canvas after signup comes with a performance: the resident Doop agent streams a welcome
+The first canvas after signup comes with a performance: the Doop Agent streams a welcome
 design in while you watch — status in the working strip, a task in the panel, a pulsing border on
 the frame it's building.
 
 <p align="center">
-  <img src=".github/assets/agent-live.png" alt="The resident Doop agent streaming a design into a frame, live — working status, agent task panel and pulsing frame border" width="100%">
+  <img src=".github/assets/agent-live.png" alt="The Doop Agent streaming a design into a frame, live — working status, agent task panel and pulsing frame border" width="100%">
 </p>
+
+That welcome performance is **scripted** (`server/demo.ts`) — a pre-authored frame replayed through
+the same machinery real agents use, so it runs with no configuration at all. The Doop Agent proper
+needs a key.
+
+## The Doop Agent
+
+Doop ships a built-in design team that lives in the server and picks work up on its own: queue a
+board card, `@mention` a role on an element comment, or leave feedback on a task, and it runs
+without a human in the loop. Roles (Doop builds; specialists own one pass each — UX, copy, brand,
+accessibility) are defined in [`shared/agents.ts`](shared/agents.ts), and a card can be routed
+through several in order.
+
+It requires an Anthropic API key:
+
+```bash
+ANTHROPIC_API_KEY=sk-ant-...   # in .env, or the environment of your deployment
+```
+
+**Without it the Doop Agent is off**, and it fails quietly by design — queued cards and `@mentions`
+simply wait for some agent to claim them. The startup banner tells you which state you're in:
+
+```
+⟡ doop agent        off — set ANTHROPIC_API_KEY to enable (agents connected over MCP work regardless)
+```
+
+Same key gates the **guideline distiller** ([`server/distill.ts`](server/distill.ts)), which proposes
+durable style rules from your canvas.
+
+**This is separate from connecting your own agent.** Claude Code and any other MCP client authenticate
+over OAuth and run on your own subscription — they need no key here and are never metered. The two are
+complementary: the Doop Agent is the zero-setup path, MCP is the bring-your-own path.
+
+| Variable              | Default                     | What it does                                                   |
+| --------------------- | --------------------------- | -------------------------------------------------------------- |
+| `ANTHROPIC_API_KEY`   | _unset_                     | Enables the Doop Agent and the distiller. Unset = both off     |
+| `RESIDENT_TASK_LIMIT` | `5`                         | Free Doop Agent tasks per account. `0` = none (MCP users only) |
+| `DOOP_AGENT_MODEL`    | `claude-opus-5`             | Model for the Doop Agent                                       |
+| `DOOP_DISTILL_MODEL`  | `claude-haiku-4-5-20251001` | Model for the guideline distiller                              |
+
+`RESIDENT_TASK_LIMIT` is the free-tier meter for the hosted version. It counts only tasks a user
+_initiates_ — feedback replies and retries on existing work stay free — and users who have connected
+their own agent over MCP bypass it entirely. There is no "unlimited" value: self-hosting with your own
+key, set it to a large number, since you're paying Anthropic directly either way.
 
 ## Accounts
 

--- a/server/guide.ts
+++ b/server/guide.ts
@@ -32,18 +32,18 @@ your edits render for them the moment you make them, your presence appears under
 agent_name, and every action lands in a visible activity feed. Work like a considerate
 colleague, not a batch job.
 
-## The resident team
+## The Doop Agent
 
-Every canvas has resident agents that live in the server and pick work up on their own.
-Humans queue board cards addressed to them, and can route a card through several in
-order — design, then copy, then brand, then accessibility:
+Every canvas has a built-in Doop Agent: a set of roles that live in the server and pick
+work up on their own. Humans queue board cards addressed to them, and can route a card
+through several in order — design, then copy, then brand, then accessibility:
 
 ${AGENT_ROLES.map((r) => `- **${r.name}** (@${r.id}) — ${r.blurb}`).join('\n')}
 
 They only take work addressed to them: a board card at their stage, an element comment
 that @mentions them, or feedback on a task they ran. Anything left unaddressed is open
-to you. If a human asks you for something a resident owns, just do it — the routing is
-for the residents' benefit, not a lock on your work.
+to you. If a human asks you for something one of these roles owns, just do it — the
+routing is for their benefit, not a lock on your work.
 
 ## Narrate your work — set_status
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -1129,4 +1129,12 @@ server.listen(PORT, () => {
   console.log(`⟡ doop server     http://localhost:${PORT}`)
   console.log(`⟡ mcp endpoint      http://localhost:${PORT}/mcp`)
   console.log(`⟡ websocket         ws://localhost:${PORT}/ws`)
+  /* The Doop Agent failing silently is the one "why is nothing happening?"
+     a self-hoster cannot debug from the UI — board cards and @mentions just
+     sit there. Say so at boot, not only when the first card is queued. */
+  console.log(
+    process.env.ANTHROPIC_API_KEY
+      ? '⟡ doop agent        on'
+      : '⟡ doop agent        off — set ANTHROPIC_API_KEY to enable (agents connected over MCP work regardless)',
+  )
 })

--- a/server/resident.ts
+++ b/server/resident.ts
@@ -43,7 +43,9 @@ function getClient(): Anthropic | null {
   if (!process.env.ANTHROPIC_API_KEY) {
     if (!warned) {
       warned = true
-      console.log('[resident] ANTHROPIC_API_KEY not set — resident Doop agent disabled')
+      console.log(
+        '[doop-agent] ANTHROPIC_API_KEY not set — the Doop Agent is disabled, so queued cards and @mentions will not be picked up. See README → "The Doop Agent". Agents connected over MCP are unaffected.',
+      )
     }
     return null
   }

--- a/src/components/TeamAllowance.tsx
+++ b/src/components/TeamAllowance.tsx
@@ -52,7 +52,7 @@ export function LimitWall({ canvasId, onClose }: { canvasId: string; onClose: ()
         <p className="lede">
           The Doop Agent's first designs were on the house. To keep designing, connect your own agent —{' '}
           <b>Claude Code</b> or <b>Codex</b> takes a minute and runs on your existing subscription, with no limits here.
-          Once it arrives, the resident team unlocks again too.
+          Once it arrives, the Doop Agent unlocks again too.
         </p>
         <ConnectBody canvasId={canvasId} />
         <div className="close-row">

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -192,7 +192,7 @@ export function Home() {
                   <div className="agent-item-info">
                     <div className="agent-name">{a.name}</div>
                     <div className="agent-sub">
-                      {a.owner ? `belongs to ${a.owner}` : 'resident agent'} · {a.canvases}{' '}
+                      {a.owner ? `belongs to ${a.owner}` : 'built-in agent'} · {a.canvases}{' '}
                       {a.canvases === 1 ? 'canvas' : 'canvases'}
                       {a.lastAt > 0 && ` · ${timeAgo(a.lastAt)}`}
                     </div>


### PR DESCRIPTION
Nothing told a self-hoster that the built-in agent needs an API key.

`ANTHROPIC_API_KEY` was documented only in `.env.example`. The README's two mentions were oblique — "even without an API key" in a feature bullet, and "Anthropic" listed among optional integrations that "degrade gracefully". Without the key, `server/resident.ts` disables the agent, and queued board cards and `@mentions` simply wait for an agent that never arrives, with nothing in the UI to explain it.

The first-canvas welcome performance makes this harder to spot rather than easier: it's a **scripted replay** (`server/demo.ts`, no LLM involved), so a new self-hoster watches an agent design something, concludes agents work, and never suspects a missing key.

## Changes

**Docs** — new `## The Doop Agent` README section: the key, what it gates (board cards, `@mentions`, feedback pickup, and the guideline distiller in `server/distill.ts`), an env table, and an explicit note that this is orthogonal to connecting your own agent over MCP, which needs no key and is never metered. The feature bullet and Quickstart paragraph now name the variable and link to the section, and the welcome performance is identified as scripted.

**Logging** — the only existing signal was a lazy warning inside `getClient()`, which never fires for someone who boots the server and looks around before queueing any work. The startup banner now reports state either way:

```
⟡ doop agent        on
⟡ doop agent        off — set ANTHROPIC_API_KEY to enable (agents connected over MCP work regardless)
```

The lazy warning is kept — it's the teachable moment when a card is actually queued — and now points at the README section.

**Naming** — the UI already shipped "Doop Agent", but "resident" had leaked into three user-visible strings, including `server/guide.ts`, which every connected MCP agent reads. Standardised on "Doop Agent". Internal identifiers (`resident.ts`, `resident_usage`, `resident_limit`) are deliberately untouched: **no migration, no API change.**

`src/pages/Home.tsx` uses "built-in agent" rather than "Doop Agent" — that label sits directly under the agent's own name and the roster lists specialist roles individually, so a row named "Kit" subtitled "Doop Agent" would read wrong. The contrast being drawn there is with "belongs to ⟨user⟩", i.e. where the agent runs.

## Note for review

The env table defaults were read from source rather than from memory, which caught one thing worth flagging: `RESIDENT_TASK_LIMIT=0` does **not** disable the meter — `server/allowance.ts:54` denies at `0 >= 0`, so it means "no free tasks, MCP-connected users only". There is no unlimited value, so the README recommends a large number when self-hosting.

## Verification

- `npm run typecheck` — clean
- `npm test` — 13/13 pass
- `npm run format:check` — clean
- Booted the server both with and without the key and confirmed each banner line renders as shown above

🤖 Generated with [Claude Code](https://claude.com/claude-code)