### PR TITLE
feat(admin): instance admin surface with read-only view-as

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,15 @@
 # Extra allowed origins for auth requests (comma-separated). Defaults to the
 # localhost dev origins.
 #TRUSTED_ORIGINS=
+# Instance admins (comma-separated emails). These accounts get the admin role
+# — at signup, and at boot for accounts that already exist — which unlocks
+# /admin: every canvas and account on the instance, plus read-only "view as".
+# Removing an email here does not demote anyone; that is an explicit action.
+# REQUIRES SMTP in production: an address only identifies someone once they
+# have verified it, and without a mailer signup is open, so a stranger could
+# claim your address and the role with it. Production without SMTP promotes
+# nobody and says so at boot; local development promotes without verifying.
+#ADMIN_EMAILS=you@example.com
 
 # ------------------------------------------------------------------- email
 # SMTP for verification and password-reset emails (works with any provider:

--- a/README.md
+++ b/README.md
@@ -158,6 +158,21 @@ email is printed to the server log, links included — the flows still work in d
 Env: `BETTER_AUTH_SECRET` (required in production), `TRUSTED_ORIGINS` (comma-separated,
 defaults to the localhost dev origins).
 
+### Instance admins
+
+`ADMIN_EMAILS` (comma-separated) names the accounts that get the `admin` role, applied at
+signup, on email verification, and at boot — so you can name an admin before or after they
+have an account. **This requires SMTP in production**: an address only identifies someone
+once they have proven they own it, and without a mailer signup is open, so anyone could sign
+up as your address and take the role with it. A production instance without SMTP promotes
+nobody and warns at boot; set the role directly in the database if that is your setup.
+Admins get `/admin`: every canvas and account on the instance, and "view as", which hands
+them a real but **read-only** 15-minute session as that user. Being an admin does not widen
+canvas access itself: the gate in [`server/access.ts`](server/access.ts) is shared with MCP,
+so a privileged read there would give every agent holding an admin's token the run of the
+instance. View-as sessions cannot write, cannot connect agents, and record who is behind
+them in `session.impersonated_by`.
+
 ## Agent auth (MCP OAuth)
 
 The `/mcp` endpoint requires OAuth. Adding the server in Claude Code / Codex triggers

--- a/server/access.ts
+++ b/server/access.ts
@@ -10,6 +10,18 @@ import type { Canvas } from '../shared/types.ts'
  * Every canvas-scoped surface — REST, the WS join, MCP tools — must gate
  * through this one helper.
  */
+/**
+ * Instance admins. Deliberately NOT consulted by canAccessCanvas: that gate
+ * is shared with MCP, so an admin branch there would hand every agent holding
+ * an admin's OAuth token read/write on every canvas in the instance. Admins
+ * get their own routes (server/admin.ts), and reach a specific canvas by
+ * impersonating its owner — which goes through the gate below as that owner,
+ * leaving session.impersonatedBy behind as the audit trail.
+ */
+export function isAdmin(user: { role?: string | null } | undefined): boolean {
+  return user?.role === 'admin'
+}
+
 export function canAccessCanvas(userId: string | undefined, canvas: Canvas): boolean {
   if (!canvas.ownerId) return true
   if (!userId) return false

--- a/server/admin.ts
+++ b/server/admin.ts
@@ -1,0 +1,73 @@
+import express from 'express'
+import { inArray, count } from 'drizzle-orm'
+import { store } from './store.ts'
+import { isAdmin } from './access.ts'
+import { db } from './db/index.ts'
+import * as authSchema from './db/auth-schema.ts'
+
+/**
+ * Instance-admin surface, mounted at /api/admin (so already behind the
+ * session gate in index.ts). Read-only by design: it lists what exists, and
+ * the way in to a specific canvas is impersonation — better-auth's own
+ * /api/auth/admin/impersonate-user — not a privileged read here. That keeps
+ * canAccessCanvas the single answer to "may this user see this canvas",
+ * which matters because MCP shares it.
+ */
+export const adminRouter = express.Router()
+
+/* 404 rather than 403: a non-admin should not learn the surface exists. */
+adminRouter.use((req, res, next) => {
+  if (!isAdmin(req.user)) return res.status(404).end()
+  next()
+})
+
+/** Every canvas on the instance, newest activity first, with its owner. */
+adminRouter.get('/canvases', async (req, res) => {
+  const { total, canvases } = store.listAllCanvases()
+  const ownerIds = [...new Set(canvases.map((c) => c.ownerId).filter((id): id is string => !!id))]
+  const owners = ownerIds.length
+    ? await db
+        .select({ id: authSchema.user.id, name: authSchema.user.name, email: authSchema.user.email })
+        .from(authSchema.user)
+        .where(inArray(authSchema.user.id, ownerIds))
+    : []
+  const byId = new Map(owners.map((o) => [o.id, o]))
+  res.json({
+    total,
+    canvases: canvases.map((c) => ({ ...c, owner: c.ownerId ? byId.get(c.ownerId) : undefined })),
+  })
+})
+
+/** The three numbers worth knowing at a glance. */
+adminRouter.get('/stats', async (req, res) => {
+  const [users] = await db.select({ n: count() }).from(authSchema.user)
+  const canvases = [...store.canvases.values()]
+  res.json({
+    users: users?.n ?? 0,
+    canvases: canvases.length,
+    frames: canvases.reduce((n, c) => n + c.frames.length, 0),
+  })
+})
+
+/** Accounts, for the "view as" picker and (later) ban/role management. */
+adminRouter.get('/users', async (req, res) => {
+  const rows = await db
+    .select({
+      id: authSchema.user.id,
+      name: authSchema.user.name,
+      email: authSchema.user.email,
+      role: authSchema.user.role,
+      banned: authSchema.user.banned,
+      createdAt: authSchema.user.createdAt,
+    })
+    .from(authSchema.user)
+  const owned = new Map<string, number>()
+  for (const c of store.canvases.values()) {
+    if (c.ownerId) owned.set(c.ownerId, (owned.get(c.ownerId) ?? 0) + 1)
+  }
+  res.json(
+    rows
+      .map((u) => ({ ...u, createdAt: u.createdAt.getTime(), canvasCount: owned.get(u.id) ?? 0 }))
+      .sort((a, b) => b.createdAt - a.createdAt),
+  )
+})

--- a/server/auth.ts
+++ b/server/auth.ts
@@ -1,6 +1,6 @@
 import { betterAuth } from 'better-auth'
-import { eq } from 'drizzle-orm'
-import { mcp } from 'better-auth/plugins'
+import { eq, inArray, or, isNull, ne, and, sql } from 'drizzle-orm'
+import { admin, mcp } from 'better-auth/plugins'
 import { drizzleAdapter } from 'better-auth/adapters/drizzle'
 import { db } from './db/index.ts'
 import * as authSchema from './db/auth-schema.ts'
@@ -15,6 +15,68 @@ import { mailerConfigured, sendMail } from './mailer.ts'
 
 /** The canonical public origin: OAuth authorize/token/login URLs live here. */
 export const PUBLIC_ORIGIN = process.env.BETTER_AUTH_URL || 'http://localhost:4300'
+
+/**
+ * Who gets the admin role, by email. Ids can't do this job: on a fresh
+ * deploy nobody has an id until they sign up, which would mean a redeploy
+ * to name the first admin. Emails are known in advance, so this reconciles
+ * into user.role at signup and at boot, and everything downstream — this
+ * plugin's own ban/impersonate endpoints included — reads only the role.
+ *
+ * Deliberately one-way: dropping an email here does not demote anyone.
+ * Demotion is an explicit setRole, so there's an actor behind it.
+ */
+const ADMIN_EMAILS = (process.env.ADMIN_EMAILS || '')
+  .split(',')
+  .map((s) => s.trim().toLowerCase())
+  .filter(Boolean)
+
+/**
+ * An email address only identifies someone once they have PROVEN they own it.
+ * Without SMTP nothing can ever be verified and signup is open (see
+ * requireEmailVerification below), so an unguarded ADMIN_EMAILS would hand
+ * the admin role to whoever signs up with the address first — a stranger can
+ * type your email as easily as you can. Outside development we therefore
+ * refuse to promote at all rather than promote an unproven claim.
+ */
+function mayPromote(user: { email: string; emailVerified: boolean }): boolean {
+  if (!ADMIN_EMAILS.includes(user.email.toLowerCase())) return false
+  if (user.emailVerified) return true
+  if (mailerConfigured) return false // verification is possible — wait for it
+  return process.env.NODE_ENV !== 'production'
+}
+
+async function promote(userId: string, email: string): Promise<void> {
+  await db.update(authSchema.user).set({ role: 'admin' }).where(eq(authSchema.user.id, userId))
+  console.log(`⟡ admin             ${email}`)
+}
+
+/** Promote listed users who already exist. Idempotent; runs at boot. */
+export async function syncAdmins(): Promise<void> {
+  if (!ADMIN_EMAILS.length) return
+  if (!mailerConfigured && process.env.NODE_ENV === 'production') {
+    console.warn(
+      '⚠ ADMIN_EMAILS is set but no SMTP is configured, so email ownership cannot be verified and nobody will be promoted. Configure SMTP_HOST, or set the admin role directly in the database.',
+    )
+    return
+  }
+  /* lower() on both sides: the signup path compares case-insensitively, and
+     an admin who silently isn't one because their address was capitalised is
+     the kind of bug nobody thinks to look for */
+  const candidates = await db
+    .select({ id: authSchema.user.id, email: authSchema.user.email, emailVerified: authSchema.user.emailVerified })
+    .from(authSchema.user)
+    .where(
+      and(
+        inArray(sql`lower(${authSchema.user.email})`, ADMIN_EMAILS),
+        /* role is NULL on accounts created before the admin plugin landed,
+           and `NULL != 'admin'` is NULL — not true — so isNull is required
+           or exactly the pre-existing accounts this exists for are skipped */
+        or(isNull(authSchema.user.role), ne(authSchema.user.role, 'admin')),
+      ),
+    )
+  for (const u of candidates) if (mayPromote(u)) await promote(u.id, u.email)
+}
 
 function buildAuth() {
   if (!process.env.BETTER_AUTH_SECRET && process.env.NODE_ENV === 'production') {
@@ -55,6 +117,12 @@ function buildAuth() {
     emailVerification: {
       sendOnSignUp: mailerConfigured,
       autoSignInAfterVerification: true,
+      /* the moment ownership is proven is the moment ADMIN_EMAILS may act on
+         it — without this, a listed admin would stay unprivileged until the
+         next restart picked them up in syncAdmins */
+      afterEmailVerification: async (user) => {
+        if (mayPromote({ email: user.email, emailVerified: true })) await promote(user.id, user.email)
+      },
       sendVerificationEmail: async ({ user, url }) => {
         await sendMail({
           to: user.email,
@@ -72,6 +140,11 @@ function buildAuth() {
             const first = (user.name || 'Your').split(/\s+/)[0]
             const canvas = store.createCanvas(`${first}'s first canvas`, user.id)
             demo.markPending(canvas.id)
+            /* the other half of the ADMIN_EMAILS reconcile: syncAdmins covers
+               people who already existed at boot, this covers signups after.
+               With SMTP on, a fresh signup is never verified yet, so the
+               promotion happens in afterEmailVerification instead. */
+            if (mayPromote(user)) await promote(user.id, user.email)
           },
         },
       },
@@ -79,7 +152,10 @@ function buildAuth() {
     /* OAuth provider for MCP clients: agents connect to /mcp with a bearer
        token their human approved in the browser. The SPA login gate lives
        at every path, so "/" works as the login page. */
-    plugins: [mcp({ loginPage: '/' })],
+    /* admin: role/ban/impersonate. 15 minutes rather than the default hour —
+       an expired impersonation session doesn't revert to the admin, it signs
+       them out entirely, so the window should be short and re-entered. */
+    plugins: [mcp({ loginPage: '/' }), admin({ impersonationSessionDuration: 15 * 60 })],
   })
 }
 

--- a/server/db/auth-schema.ts
+++ b/server/db/auth-schema.ts
@@ -11,6 +11,12 @@ export const user = pgTable('user', {
   image: text('image'),
   createdAt: timestamp('created_at').notNull().defaultNow(),
   updatedAt: timestamp('updated_at').notNull().defaultNow(),
+  /* admin plugin fields — all nullable so existing rows need no backfill.
+     'admin' is the only role we act on; everyone else is an ordinary user. */
+  role: text('role'),
+  banned: boolean('banned').default(false),
+  banReason: text('ban_reason'),
+  banExpires: timestamp('ban_expires'),
 })
 
 export const session = pgTable('session', {
@@ -24,6 +30,10 @@ export const session = pgTable('session', {
   userId: text('user_id')
     .notNull()
     .references(() => user.id, { onDelete: 'cascade' }),
+  /* set when an admin is viewing as this user: the admin's own user id.
+     It is the audit trail for impersonation and the flag every read-only
+     guard reads — see server/index.ts. */
+  impersonatedBy: text('impersonated_by'),
 })
 
 export const account = pgTable('account', {

--- a/server/db/migrations/0001_previous_master_mold.sql
+++ b/server/db/migrations/0001_previous_master_mold.sql
@@ -1,0 +1,5 @@
+ALTER TABLE "session" ADD COLUMN "impersonated_by" text;--> statement-breakpoint
+ALTER TABLE "user" ADD COLUMN "role" text;--> statement-breakpoint
+ALTER TABLE "user" ADD COLUMN "banned" boolean DEFAULT false;--> statement-breakpoint
+ALTER TABLE "user" ADD COLUMN "ban_reason" text;--> statement-breakpoint
+ALTER TABLE "user" ADD COLUMN "ban_expires" timestamp;

--- a/server/db/migrations/meta/0001_snapshot.json
+++ b/server/db/migrations/meta/0001_snapshot.json
@@ -1,0 +1,1765 @@
+{
+  "id": "e09114c4-ce9d-4d3e-8926-fac1a0c471ec",
+  "prevId": "3647689c-1135-43da-9450-4d252593f546",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.activity": {
+      "name": "activity",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "canvas_id": {
+          "name": "canvas_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_kind": {
+          "name": "actor_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_color": {
+          "name": "actor_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frame_id": {
+          "name": "frame_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "at": {
+          "name": "at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "activity_canvas_idx": {
+          "name": "activity_canvas_idx",
+          "columns": [
+            {
+              "expression": "canvas_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.asset_refs": {
+      "name": "asset_refs",
+      "schema": "",
+      "columns": {
+        "asset_id": {
+          "name": "asset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frame_id": {
+          "name": "frame_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "asset_refs_frame_idx": {
+          "name": "asset_refs_frame_idx",
+          "columns": [
+            {
+              "expression": "frame_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "asset_refs_asset_id_frame_id_pk": {
+          "name": "asset_refs_asset_id_frame_id_pk",
+          "columns": ["asset_id", "frame_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.assets": {
+      "name": "assets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "canvas_id": {
+          "name": "canvas_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mime": {
+          "name": "mime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ext": {
+          "name": "ext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "assets_canvas_idx": {
+          "name": "assets_canvas_idx",
+          "columns": [
+            {
+              "expression": "canvas_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.canvas_members": {
+      "name": "canvas_members",
+      "schema": "",
+      "columns": {
+        "canvas_id": {
+          "name": "canvas_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "added_by": {
+          "name": "added_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "canvas_members_canvas_id_user_id_pk": {
+          "name": "canvas_members_canvas_id_user_id_pk",
+          "columns": ["canvas_id", "user_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.canvases": {
+      "name": "canvases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_access": {
+          "name": "link_access",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.comments": {
+      "name": "comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "canvas_id": {
+          "name": "canvas_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frame_id": {
+          "name": "frame_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "selector": {
+          "name": "selector",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snippet": {
+          "name": "snippet",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_name": {
+          "name": "from_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "at": {
+          "name": "at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "for_agent": {
+          "name": "for_agent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "target_agent": {
+          "name": "target_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_by": {
+          "name": "claimed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failed_at": {
+          "name": "failed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "comments_canvas_idx": {
+          "name": "comments_canvas_idx",
+          "columns": [
+            {
+              "expression": "canvas_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.decisions": {
+      "name": "decisions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "canvas_id": {
+          "name": "canvas_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frame_id": {
+          "name": "frame_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_name": {
+          "name": "from_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "at": {
+          "name": "at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "distilled_at": {
+          "name": "distilled_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "decisions_canvas_idx": {
+          "name": "decisions_canvas_idx",
+          "columns": [
+            {
+              "expression": "canvas_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feedback": {
+      "name": "feedback",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canvas_id": {
+          "name": "canvas_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_agent": {
+          "name": "target_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_name": {
+          "name": "from_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "at": {
+          "name": "at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_by": {
+          "name": "claimed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failed_at": {
+          "name": "failed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "feedback_canvas_idx": {
+          "name": "feedback_canvas_idx",
+          "columns": [
+            {
+              "expression": "canvas_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.frames": {
+      "name": "frames",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "canvas_id": {
+          "name": "canvas_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "x": {
+          "name": "x",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "y": {
+          "name": "y",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "width": {
+          "name": "width",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "height": {
+          "name": "height",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "html": {
+          "name": "html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "frames_canvas_idx": {
+          "name": "frames_canvas_idx",
+          "columns": [
+            {
+              "expression": "canvas_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.guideline_versions": {
+      "name": "guideline_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "canvas_id": {
+          "name": "canvas_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "markdown": {
+          "name": "markdown",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "saved_at": {
+          "name": "saved_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "saved_by": {
+          "name": "saved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "guideline_versions_doc_idx": {
+          "name": "guideline_versions_doc_idx",
+          "columns": [
+            {
+              "expression": "canvas_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.guidelines": {
+      "name": "guidelines",
+      "schema": "",
+      "columns": {
+        "canvas_id": {
+          "name": "canvas_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "markdown": {
+          "name": "markdown",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "x": {
+          "name": "x",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "y": {
+          "name": "y",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "guidelines_canvas_id_name_pk": {
+          "name": "guidelines_canvas_id_name_pk",
+          "columns": ["canvas_id", "name"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.memory_proposals": {
+      "name": "memory_proposals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "canvas_id": {
+          "name": "canvas_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guide_name": {
+          "name": "guide_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guide_title": {
+          "name": "guide_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rule": {
+          "name": "rule",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rationale": {
+          "name": "rationale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "based_on": {
+          "name": "based_on",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "at": {
+          "name": "at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "memory_proposals_canvas_idx": {
+          "name": "memory_proposals_canvas_idx",
+          "columns": [
+            {
+              "expression": "canvas_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.memory_references": {
+      "name": "memory_references",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "canvas_id": {
+          "name": "canvas_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frame_id": {
+          "name": "frame_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "html": {
+          "name": "html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "width": {
+          "name": "width",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "height": {
+          "name": "height",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pinned_by": {
+          "name": "pinned_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pinned_at": {
+          "name": "pinned_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "memory_references_canvas_idx": {
+          "name": "memory_references_canvas_idx",
+          "columns": [
+            {
+              "expression": "canvas_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.resident_usage": {
+      "name": "resident_usage",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "used": {
+          "name": "used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tasks": {
+      "name": "tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "canvas_id": {
+          "name": "canvas_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto": {
+          "name": "auto",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "queued_by": {
+          "name": "queued_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failed_at": {
+          "name": "failed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pipeline": {
+          "name": "pipeline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stage": {
+          "name": "stage",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attachments": {
+          "name": "attachments",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "tasks_canvas_idx": {
+          "name": "tasks_canvas_idx",
+          "columns": [
+            {
+              "expression": "canvas_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_access_token": {
+      "name": "oauth_access_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_access_token_access_token_unique": {
+          "name": "oauth_access_token_access_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["access_token"]
+        },
+        "oauth_access_token_refresh_token_unique": {
+          "name": "oauth_access_token_refresh_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["refresh_token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_application": {
+      "name": "oauth_application",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_urls": {
+          "name": "redirect_urls",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_application_client_id_unique": {
+          "name": "oauth_application_client_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["client_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_consent": {
+      "name": "oauth_consent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "consent_given": {
+          "name": "consent_given",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/server/db/migrations/meta/_journal.json
+++ b/server/db/migrations/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1787419244554,
       "tag": "0000_init",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1787617484118,
+      "tag": "0001_previous_master_mold",
+      "breakpoints": true
     }
   ]
 }

--- a/server/index.ts
+++ b/server/index.ts
@@ -9,8 +9,9 @@ import { oAuthDiscoveryMetadata } from 'better-auth/plugins'
 import { WebSocketServer, WebSocket } from 'ws'
 import { store } from './store.ts'
 import * as actions from './actions.ts'
-import { canAccessCanvas } from './access.ts'
-import { auth, initAuth, PUBLIC_ORIGIN } from './auth.ts'
+import { canAccessCanvas, isAdmin } from './access.ts'
+import { auth, initAuth, syncAdmins, getUserName, PUBLIC_ORIGIN } from './auth.ts'
+import { adminRouter } from './admin.ts'
 import * as demo from './demo.ts'
 import { db, initDb } from './db/index.ts'
 import * as authSchema from './db/auth-schema.ts'
@@ -50,6 +51,7 @@ const BUILD_ID = (() => {
 /* boot: connect the DB, hydrate memory, import pre-DB store.json once */
 await initDb()
 initAuth()
+await syncAdmins() // ADMIN_EMAILS -> user.role, for accounts that already exist
 let data = await persist.hydrate()
 if (data.canvases.length === 0 && (await persist.importLegacyJson())) {
   data = await persist.hydrate()
@@ -111,6 +113,10 @@ interface Conn {
   ws: WebSocket
   canvasId: string
   presence: Presence
+  /** an admin viewing as someone else: receives updates, emits nothing.
+   *  Showing their borrowed identity as a live cursor would tell the room
+   *  the owner is here when they aren't. */
+  silent?: boolean
 }
 
 const conns = new Map<WebSocket, Conn>()
@@ -404,8 +410,29 @@ app.put('/u/:token', async (req, res) => {
 })
 
 /* better-auth handles /api/auth/* — mounted before express.json (it reads
-   the raw body itself) and before the session gate below */
-app.all('/api/auth/*', (req, res) => toNodeHandler(auth)(req, res))
+   the raw body itself) and before the session gate below. Being mounted
+   earlier means it also escapes the read-only rule on /api, so an admin
+   who is viewing as someone else is filtered here instead:
+     - the MCP OAuth flow authorises off the browser session, so it would
+       mint a long-lived agent token belonging to the person being viewed,
+       outliving the 15-minute view-as session entirely;
+     - every other write (update-user, change-email, revoke-sessions, …)
+       would edit the account of the person being viewed while the banner
+       says "read only".
+   An allowlist, not a blocklist: whatever endpoints a future better-auth
+   plugin adds are refused by default rather than discovered later. */
+const MCP_OAUTH_PATHS = /^\/api\/auth\/(mcp\/|oauth2\/(authorize|consent|token))/
+const VIEW_AS_ALLOWED = /^\/api\/auth\/(sign-out|admin\/stop-impersonating)$/
+app.all('/api/auth/*', async (req, res) => {
+  const restricted = MCP_OAUTH_PATHS.test(req.path) || (req.method !== 'GET' && !VIEW_AS_ALLOWED.test(req.path))
+  if (restricted) {
+    const session = await auth.api.getSession({ headers: fromNodeHeaders(req.headers) }).catch(() => null)
+    if (session && (session.session as { impersonatedBy?: string | null }).impersonatedBy) {
+      return res.status(403).json({ error: 'viewing as another user — read only' })
+    }
+  }
+  toNodeHandler(auth)(req, res)
+})
 
 app.use(express.json({ limit: '10mb' }))
 
@@ -429,11 +456,14 @@ interface SessionUser {
   id: string
   name: string
   email: string
+  role?: string | null
 }
 declare global {
   namespace Express {
     interface Request {
       user?: SessionUser
+      /** admin's user id when this session is a "view as" — see /api/admin */
+      impersonatedBy?: string
     }
   }
 }
@@ -442,13 +472,34 @@ app.use('/api', async (req, res, next) => {
     const session = await auth.api.getSession({ headers: fromNodeHeaders(req.headers) })
     if (!session) return res.status(401).json({ error: 'unauthorized' })
     req.user = session.user
+    req.impersonatedBy = (session.session as { impersonatedBy?: string | null }).impersonatedBy ?? undefined
+    /* Viewing as someone else is read-only, full stop. Every doop mutation is
+       a non-GET REST call — the websocket after `join` carries only cursor,
+       editing and frame:drag — so this single rule covers the whole surface.
+       better-auth's own routes are mounted earlier (/api/auth/*), so signing
+       out and stop-impersonating are unaffected. */
+    if (req.impersonatedBy && req.method !== 'GET') {
+      return res.status(403).json({ error: 'viewing as another user — read only' })
+    }
     next()
   } catch (err) {
     next(err)
   }
 })
 
-app.get('/api/me', (req, res) => res.json(req.user))
+app.get('/api/me', async (req, res) => {
+  const { id, name, email } = req.user!
+  res.json({
+    id,
+    name,
+    email,
+    admin: isAdmin(req.user),
+    /* the SPA cannot infer this: impersonation swaps the session cookie
+       outright, so everything else on this response describes the person
+       being viewed, not the admin doing the viewing */
+    impersonating: req.impersonatedBy ? { byName: (await getUserName(req.impersonatedBy)) ?? 'an admin' } : undefined,
+  })
+})
 
 /* Canvas access on the REST surface: resolve the canvas (or the frame's
    canvas) and run it through canAccessCanvas before touching anything.
@@ -479,6 +530,8 @@ function requireFrame(req: express.Request, res: express.Response, frameId: stri
   }
   return frame
 }
+
+app.use('/api/admin', adminRouter)
 
 /* free-tier meter for the resident team: {used, limit, connected} */
 app.get('/api/agent-allowance', (req, res) => {
@@ -1060,9 +1113,10 @@ wss.on('connection', (ws, upgradeReq) => {
         kind: 'user',
         activeFrameId: null,
       }
-      conns.set(ws, { ws, canvasId: msg.canvasId, presence })
+      const silent = !!(session.session as { impersonatedBy?: string | null }).impersonatedBy
+      conns.set(ws, { ws, canvasId: msg.canvasId, presence, silent })
       const others = room(msg.canvasId)
-        .filter((c) => c.ws !== ws)
+        .filter((c) => c.ws !== ws && !c.silent)
         .map((c) => c.presence)
       const agents = [...(agentPresences.get(msg.canvasId)?.values() ?? [])]
       send(ws, {
@@ -1078,6 +1132,12 @@ wss.on('connection', (ws, upgradeReq) => {
         selfColor: presence.color,
         serverBuild: BUILD_ID,
       })
+      /* An admin looking at a canvas must not act on it. Announcing presence
+         would impersonate the owner in the room; maybePlay would have the
+         demo agent perform on an untouched signup canvas; the card kick would
+         start the resident agent working. All three are things the owner's
+         own visit is supposed to trigger, not a support session. */
+      if (silent) return
       broadcast(msg.canvasId, { type: 'presence:join', presence }, presence.clientId)
       demo.maybePlay(msg.canvasId) // first visit to a fresh signup canvas: the demo agent performs
       /* Start never-attempted cards. Failed/interrupted cards are excluded. */
@@ -1088,6 +1148,7 @@ wss.on('connection', (ws, upgradeReq) => {
     }
 
     if (!conn) return
+    if (conn.silent) return // view-as connections receive updates but never emit
     const { canvasId, presence } = conn
 
     switch (msg.type) {
@@ -1121,6 +1182,7 @@ wss.on('connection', (ws, upgradeReq) => {
     const conn = conns.get(ws)
     if (!conn) return
     conns.delete(ws)
+    if (conn.silent) return // never announced a join, so nothing to leave
     broadcast(conn.canvasId, { type: 'presence:leave', clientId: conn.presence.clientId })
   })
 })

--- a/server/store.ts
+++ b/server/store.ts
@@ -18,6 +18,24 @@ class Store {
     }
   }
 
+  /** The dashboard row for one canvas. `viewerId` decides only whether the
+   *  canvas is marked as shared-with-me; pass undefined for views that have
+   *  no viewer-relative meaning (the admin index). */
+  private toMeta(c: Canvas, viewerId?: string) {
+    return {
+      id: c.id,
+      name: c.name,
+      ownerId: c.ownerId,
+      shared: viewerId !== undefined ? c.ownerId !== viewerId || undefined : undefined,
+      createdAt: c.createdAt,
+      updatedAt: c.updatedAt,
+      frameCount: c.frames.length,
+      /* most recently touched frame — the home dashboard renders it as the
+         canvas preview via the public /i/ image pipeline */
+      previewFrameId: c.frames.length ? c.frames.reduce((a, b) => (b.updatedAt > a.updatedAt ? b : a)).id : undefined,
+    }
+  }
+
   /** Canvases visible to a user: their own plus ones they were invited to.
    *  Unowned (legacy/seeded) canvases are NOT listed — listing them to
    *  everyone leaked one user's work onto every other user's dashboard.
@@ -26,18 +44,24 @@ class Store {
     return [...this.canvases.values()]
       .filter((c) => c.ownerId === userId || c.memberIds?.includes(userId))
       .sort((a, b) => b.updatedAt - a.updatedAt)
-      .map((c) => ({
-        id: c.id,
-        name: c.name,
-        ownerId: c.ownerId,
-        shared: c.ownerId !== userId || undefined,
-        createdAt: c.createdAt,
-        updatedAt: c.updatedAt,
-        frameCount: c.frames.length,
-        /* most recently touched frame — the home dashboard renders it as the
-           canvas preview via the public /i/ image pipeline */
-        previewFrameId: c.frames.length ? c.frames.reduce((a, b) => (b.updatedAt > a.updatedAt ? b : a)).id : undefined,
-      }))
+      .map((c) => this.toMeta(c, userId))
+  }
+
+  /** Every canvas on the instance, for the admin index only. Access is the
+   *  caller's problem — the only caller is server/admin.ts, behind isAdmin.
+   *  A deliberately separate method rather than a flag on listCanvases: a
+   *  boolean parameter is the kind of thing that eventually gets passed
+   *  `true` from a route that shouldn't. */
+  listAllCanvases(limit = 200) {
+    const all = [...this.canvases.values()].sort((a, b) => b.updatedAt - a.updatedAt)
+    return {
+      total: all.length,
+      canvases: all.slice(0, limit).map((c) => ({
+        ...this.toMeta(c),
+        linkAccess: c.linkAccess ?? 'none',
+        memberCount: c.memberIds?.length ?? 0,
+      })),
+    }
   }
 
   createCanvas(name: string, ownerId?: string): Canvas {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,9 +3,12 @@ import { Home } from './pages/Home'
 import { CanvasPage } from './pages/CanvasPage'
 import { AuthPage } from './pages/AuthPage'
 import { Landing } from './pages/Landing'
+import { Admin } from './pages/Admin'
 import { authClient } from './lib/auth'
 import { setName } from './lib/identity'
-import { posthog, syncReplayForUser } from './lib/posthog'
+import { posthog, syncReplayForUser, suspendAnalyticsWhileImpersonating } from './lib/posthog'
+import { useMe } from './lib/me'
+import { adminApi } from './lib/api'
 
 export function navigate(path: string) {
   history.pushState(null, '', path)
@@ -15,6 +18,7 @@ export function navigate(path: string) {
 export function App() {
   const [path, setPath] = useState(location.pathname)
   const { data: session, isPending } = authClient.useSession()
+  const me = useMe(session?.user.id)
   const identifiedUserId = useRef<string | null>(null)
 
   useEffect(() => {
@@ -34,13 +38,23 @@ export function App() {
       }
       return
     }
+    /* Wait for /api/me before identifying anyone. Impersonation swaps the
+       session cookie, so `user` here is the person being VIEWED — identifying
+       them would write an admin's support session into that customer's
+       profile and replay timeline. Only /api/me can tell the two apart. */
+    if (!me) return
+    if (me.impersonating) {
+      suspendAnalyticsWhileImpersonating()
+      identifiedUserId.current = null
+      return
+    }
 
     if (identifiedUserId.current === user.id) return
     if (identifiedUserId.current) posthog.reset()
     posthog.identify(user.id, { email: user.email, name: user.name })
     syncReplayForUser(user.email)
     identifiedUserId.current = user.id
-  }, [session?.user])
+  }, [session?.user, me])
 
   /* the account name is the identity shown on cursors and in the feed */
   useEffect(() => {
@@ -60,8 +74,51 @@ export function App() {
   }
 
   const canvasMatch = path.match(/^\/c\/([^/]+)/)
-  if (canvasMatch) return <CanvasPage canvasId={canvasMatch[1]} key={canvasMatch[1]} />
-  return <Home />
+  const page = canvasMatch ? (
+    <CanvasPage canvasId={canvasMatch[1]} key={canvasMatch[1]} />
+  ) : path.startsWith('/admin') ? (
+    <Admin />
+  ) : (
+    <Home />
+  )
+
+  /* The banner is not decoration: an impersonated session looks exactly like
+     being signed in as that person, and forgetting you are in one is how
+     support tools cause incidents. */
+  return me?.impersonating ? (
+    <>
+      <ImpersonationBanner name={session.user.name} />
+      <div className="impersonating-shell">{page}</div>
+    </>
+  ) : (
+    page
+  )
+}
+
+function ImpersonationBanner({ name }: { name: string }) {
+  const [leaving, setLeaving] = useState(false)
+  return (
+    <div className="impersonation-banner">
+      <span>
+        Viewing as <strong>{name}</strong> — read only, expires after 15 minutes.
+      </span>
+      <button
+        className="btn ghost small"
+        disabled={leaving}
+        onClick={() => {
+          setLeaving(true)
+          /* the cookie swaps back to the admin's own session; reload rather
+             than reconcile every piece of per-user state in memory */
+          adminApi
+            .stopImpersonating()
+            .then(() => location.assign('/admin'))
+            .catch(() => location.assign('/'))
+        }}
+      >
+        {leaving ? 'Leaving…' : 'Stop viewing'}
+      </button>
+    </div>
+  )
 }
 
 /** The layered D: two stacked frames — the human's layer over the agent's —

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -144,3 +144,33 @@ export const api = {
   retryComment: (commentId: string) => req(`/api/comments/${commentId}/retry`, { method: 'POST' }),
   retryTaskFeedback: (feedbackId: string) => req(`/api/feedback/${feedbackId}/retry`, { method: 'POST' }),
 }
+
+export interface AdminCanvas extends CanvasMeta {
+  linkAccess: 'edit' | 'none'
+  memberCount: number
+  owner?: { id: string; name: string; email: string }
+}
+
+export interface AdminUser {
+  id: string
+  name: string
+  email: string
+  role: string | null
+  banned: boolean | null
+  createdAt: number
+  canvasCount: number
+}
+
+/** Instance-admin surface. Every route 404s for non-admins, so a failure here
+ *  is indistinguishable from the feature not existing — which is the point. */
+export const adminApi = {
+  canvases: () => req<{ total: number; canvases: AdminCanvas[] }>('/api/admin/canvases'),
+  stats: () => req<{ users: number; canvases: number; frames: number }>('/api/admin/stats'),
+  users: () => req<AdminUser[]>('/api/admin/users'),
+
+  /* better-auth's own endpoints, not ours: they swap the session cookie, so
+     every caller reloads afterwards rather than trying to reconcile state. */
+  impersonate: (userId: string) =>
+    req('/api/auth/admin/impersonate-user', { method: 'POST', body: JSON.stringify({ userId }) }),
+  stopImpersonating: () => req('/api/auth/admin/stop-impersonating', { method: 'POST' }),
+}

--- a/src/lib/me.ts
+++ b/src/lib/me.ts
@@ -1,0 +1,54 @@
+import { useEffect, useState } from 'react'
+
+/** /api/me — the session as the server sees it. */
+export interface Me {
+  id: string
+  name: string
+  email: string
+  /** instance admin: renders the /admin entry point */
+  admin: boolean
+  /** set when this session is an admin viewing as someone else. The rest of
+   *  this object then describes the person being viewed, not the admin —
+   *  impersonation replaces the session cookie outright — so this flag is the
+   *  only way the app can tell it is in a borrowed session. */
+  impersonating?: { byName: string }
+}
+
+/* Keyed by the signed-in user id, and never caching a failure. Both matter:
+   the app mounts on the signed-out auth page, where /api/me is a 401, and
+   signing in does not remount it — a cached rejection would leave every
+   later caller with no `me` for the rest of the session. The key also makes
+   entering and leaving a "view as" session refetch, since impersonation
+   changes who the session belongs to. */
+let cache: { key: string; promise: Promise<Me> } | null = null
+
+export function loadMe(key: string): Promise<Me> {
+  if (cache?.key !== key) {
+    const promise = fetch('/api/me').then((r) => {
+      if (!r.ok) throw new Error(`me ${r.status}`)
+      return r.json() as Promise<Me>
+    })
+    promise.catch(() => {
+      if (cache?.promise === promise) cache = null // retry on the next call
+    })
+    cache = { key, promise }
+  }
+  return cache.promise
+}
+
+/** Pass the session's user id; null until /api/me answers for that identity. */
+export function useMe(userId: string | undefined): Me | null {
+  const [me, setMe] = useState<Me | null>(null)
+  useEffect(() => {
+    if (!userId) return
+    let live = true
+    loadMe(userId)
+      .then((m) => live && setMe(m))
+      .catch(() => {})
+    return () => {
+      live = false
+    }
+  }, [userId])
+  /* never hand back a `me` belonging to a previous identity */
+  return me && me.id === userId ? me : null
+}

--- a/src/lib/posthog.ts
+++ b/src/lib/posthog.ts
@@ -76,4 +76,18 @@ export function syncReplayForUser(email: string | null | undefined) {
   }
 }
 
+/** An admin viewing as another user. Their navigation must not be written to
+ *  the customer's PostHog profile, and must not be recorded at all.
+ *
+ *  Deliberately does NOT go through syncReplayForUser: that function keys the
+ *  persisted NO_REPLAY_KEY flag off the account email, so a borrowed email
+ *  would rewrite whose browser this is — an internal operator viewing as an
+ *  external user would clear their own exclusion and keep recording after the
+ *  support session ended. */
+export function suspendAnalyticsWhileImpersonating() {
+  if (!key) return
+  posthog.reset() // subsequent events are anonymous, not the customer's
+  posthog.stopSessionRecording()
+}
+
 export { posthog }

--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -1,0 +1,204 @@
+import { useEffect, useState } from 'react'
+import { adminApi, type AdminCanvas, type AdminUser } from '../lib/api'
+import { navigate, Logo } from '../App'
+import { timeAgo } from '../lib/time'
+
+/**
+ * The instance index: every canvas, every account. Read-only — the way to
+ * look inside someone's canvas is "view as", which hands you a real (but
+ * read-only, 15-minute) session as its owner rather than granting admins a
+ * privileged read path through the canvas gate.
+ */
+export function Admin() {
+  const [data, setData] = useState<{ total: number; canvases: AdminCanvas[] } | null>(null)
+  const [users, setUsers] = useState<AdminUser[] | null>(null)
+  const [stats, setStats] = useState<{ users: number; canvases: number; frames: number } | null>(null)
+  const [tab, setTab] = useState<'canvases' | 'users'>('canvases')
+  const [q, setQ] = useState('')
+  const [denied, setDenied] = useState(false)
+
+  useEffect(() => {
+    adminApi
+      .canvases()
+      .then(setData)
+      .catch(() => setDenied(true))
+    adminApi
+      .stats()
+      .then(setStats)
+      .catch(() => {})
+    adminApi
+      .users()
+      .then(setUsers)
+      .catch(() => {})
+  }, [])
+
+  async function viewAs(userId: string) {
+    await adminApi.impersonate(userId)
+    /* the session cookie has been replaced — every piece of client state now
+       belongs to the wrong person. Reload rather than reconcile. */
+    location.assign('/')
+  }
+
+  if (denied) {
+    return (
+      <div className="home">
+        <div className="home-inner">
+          <h1>Not found</h1>
+          <p className="sub">This page does not exist for this account.</p>
+          <button className="btn ghost" onClick={() => navigate('/')}>
+            Back
+          </button>
+        </div>
+      </div>
+    )
+  }
+
+  const needle = q.trim().toLowerCase()
+  const canvases = (data?.canvases ?? []).filter(
+    (c) =>
+      !needle ||
+      c.name.toLowerCase().includes(needle) ||
+      c.owner?.name.toLowerCase().includes(needle) ||
+      c.owner?.email.toLowerCase().includes(needle),
+  )
+  const shownUsers = (users ?? []).filter(
+    (u) => !needle || u.name.toLowerCase().includes(needle) || u.email.toLowerCase().includes(needle),
+  )
+
+  return (
+    <div className="home admin">
+      <div className="home-inner">
+        <div className="home-mark">
+          <Logo /> Doop
+          <span className="chip admin-chip">admin</span>
+          <span className="spacer" />
+          <button className="btn ghost" onClick={() => navigate('/')}>
+            Back to my canvases
+          </button>
+        </div>
+
+        <h1>
+          Everything on this instance<em>.</em>
+        </h1>
+        <p className="sub">
+          {stats
+            ? `${stats.users} ${stats.users === 1 ? 'account' : 'accounts'} · ${stats.canvases} ${
+                stats.canvases === 1 ? 'canvas' : 'canvases'
+              } · ${stats.frames} ${stats.frames === 1 ? 'frame' : 'frames'}`
+            : '…'}
+        </p>
+
+        <div className="admin-controls">
+          <div className="admin-tabs">
+            <button className={`btn ghost${tab === 'canvases' ? ' on' : ''}`} onClick={() => setTab('canvases')}>
+              Canvases
+            </button>
+            <button className={`btn ghost${tab === 'users' ? ' on' : ''}`} onClick={() => setTab('users')}>
+              Accounts
+            </button>
+          </div>
+          <input
+            className="admin-search"
+            placeholder={tab === 'canvases' ? 'Search canvases or owners…' : 'Search accounts…'}
+            value={q}
+            onChange={(e) => setQ(e.target.value)}
+          />
+        </div>
+
+        {tab === 'canvases' && (
+          <>
+            {data && data.total > data.canvases.length && (
+              <p className="sub small">
+                Showing the {data.canvases.length} most recently updated of {data.total}.
+              </p>
+            )}
+            <div className="canvas-grid">
+              {data === null &&
+                [0, 1, 2].map((i) => (
+                  <div key={i} className="canvas-card skeleton" style={{ animationDelay: `${i * 0.12}s` }} />
+                ))}
+              {canvases.map((c) => (
+                <div key={c.id} className="canvas-card admin-card">
+                  <div className="card-preview">
+                    {c.previewFrameId ? (
+                      <img
+                        src={`/i/${c.previewFrameId}.jpg`}
+                        alt=""
+                        loading="lazy"
+                        onError={(e) => {
+                          e.currentTarget.style.display = 'none'
+                        }}
+                      />
+                    ) : (
+                      <span className="card-blank">empty canvas</span>
+                    )}
+                  </div>
+                  <div className="card-info">
+                    <div className="name">{c.name}</div>
+                    <div className="meta">
+                      <span>{c.owner ? c.owner.name : 'unclaimed'}</span>
+                      <span className="dot">·</span>
+                      <span>
+                        {c.frameCount} frame{c.frameCount === 1 ? '' : 's'}
+                      </span>
+                      <span className="dot">·</span>
+                      <span>{timeAgo(c.updatedAt)}</span>
+                      {c.linkAccess === 'edit' && (
+                        <>
+                          <span className="dot">·</span>
+                          <span title="Anyone with the link can edit this canvas">link on</span>
+                        </>
+                      )}
+                      {c.memberCount > 0 && (
+                        <>
+                          <span className="dot">·</span>
+                          <span>{c.memberCount} invited</span>
+                        </>
+                      )}
+                    </div>
+                    {c.owner && (
+                      <button className="btn ghost small" onClick={() => viewAs(c.owner!.id)}>
+                        View as {c.owner.name.split(' ')[0]}
+                      </button>
+                    )}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </>
+        )}
+
+        {tab === 'users' && (
+          <section className="admin-users">
+            {users === null && <p className="sub">…</p>}
+            {shownUsers.map((u) => (
+              <div key={u.id} className="admin-user-row">
+                <div className="admin-user-info">
+                  <div className="name">
+                    {u.name}
+                    {u.role === 'admin' && <span className="chip admin-chip">admin</span>}
+                    {u.banned && <span className="chip banned-chip">banned</span>}
+                  </div>
+                  <div className="meta">
+                    <span>{u.email}</span>
+                    <span className="dot">·</span>
+                    <span>
+                      {u.canvasCount} {u.canvasCount === 1 ? 'canvas' : 'canvases'}
+                    </span>
+                    <span className="dot">·</span>
+                    <span>joined {timeAgo(u.createdAt)}</span>
+                  </div>
+                </div>
+                {u.role !== 'admin' && (
+                  <button className="btn ghost small" onClick={() => viewAs(u.id)}>
+                    View as
+                  </button>
+                )}
+              </div>
+            ))}
+          </section>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -8,10 +8,12 @@ import { timeAgo } from '../lib/time'
 import { CodeBlock } from '../components/ConnectModal'
 import { AgentIcon } from '../components/AgentIcon'
 import { posthog } from '../lib/posthog'
+import { useMe } from '../lib/me'
 
 export function Home() {
   const [canvases, setCanvases] = useState<CanvasMeta[] | null>(null)
   const { data: session } = authClient.useSession()
+  const me = useMe(session?.user.id)
 
   useEffect(() => {
     api.listCanvases().then(setCanvases).catch(console.error)
@@ -52,6 +54,11 @@ export function Home() {
           <span className="spacer" />
           {session && (
             <span className="home-account">
+              {me?.admin && (
+                <button className="btn ghost" onClick={() => navigate('/admin')}>
+                  Admin
+                </button>
+              )}
               {session.user.name}
               <button
                 className="btn ghost"

--- a/src/styles.css
+++ b/src/styles.css
@@ -5779,3 +5779,129 @@ textarea {
     transform: scale(0.7);
   }
 }
+
+/* ---------- admin ---------- */
+
+.btn.small {
+  font-size: 12px;
+  padding: 5px 10px;
+}
+.sub.small {
+  font-size: 13px;
+  color: var(--ink-faint);
+}
+
+.chip.admin-chip {
+  color: var(--accent-ink);
+  border-color: rgba(194, 58, 37, 0.4);
+  background: rgba(229, 83, 60, 0.08);
+}
+.chip.banned-chip {
+  color: #8a5b00;
+  border-color: rgba(138, 91, 0, 0.35);
+  background: rgba(255, 184, 0, 0.12);
+}
+
+.admin-controls {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin: 28px 0 18px;
+  flex-wrap: wrap;
+}
+.admin-tabs {
+  display: inline-flex;
+  gap: 8px;
+}
+.admin-tabs .btn.on {
+  border-color: var(--ink);
+  color: var(--ink);
+}
+.admin-search {
+  flex: 1;
+  min-width: 200px;
+  font-family: var(--font-ui);
+  font-size: 14px;
+  padding: 8px 12px;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  background: var(--surface);
+  color: var(--ink);
+}
+.admin-search:focus {
+  outline: none;
+  border-color: var(--ink-faint);
+}
+
+/* the admin card is a container, not a button: its actions are inside it */
+.canvas-card.admin-card:hover {
+  transform: none;
+  box-shadow: var(--shadow-card);
+  border-color: var(--line);
+}
+.admin-card .card-info .btn {
+  margin-top: 10px;
+}
+
+.admin-users {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.admin-user-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 12px 16px;
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: 12px;
+}
+.admin-user-row .name {
+  font-family: var(--font-display);
+  font-weight: 600;
+  font-size: 15px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.admin-user-row .meta {
+  margin-top: 4px;
+  display: flex;
+  gap: 6px;
+  align-items: center;
+  font-size: 13px;
+  color: var(--ink-soft);
+}
+
+/* impersonation: deliberately loud, and it displaces the page rather than
+   floating over it — a banner you can scroll past is a banner you forget */
+.impersonation-banner {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 900;
+  height: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 16px;
+  font-size: 13px;
+  background: repeating-linear-gradient(-45deg, rgba(229, 83, 60, 0.16) 0 10px, rgba(229, 83, 60, 0.08) 10px 20px);
+  border-bottom: 1px solid var(--accent);
+  color: var(--accent-ink);
+  backdrop-filter: blur(6px);
+}
+.impersonating-shell {
+  padding-top: 40px;
+  height: 100vh;
+  box-sizing: border-box;
+  overflow: auto;
+}
+/* the canvas is `position: fixed; inset: 0`, so it ignores the shell's
+   padding — move its inset instead, or it renders under the banner */
+.impersonating-shell .workspace {
+  inset: 40px 0 0;
+}

--- a/tests/access.test.ts
+++ b/tests/access.test.ts
@@ -1,124 +1,35 @@
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
-import { spawn, type ChildProcess } from 'node:child_process'
-import { mkdtempSync, rmSync } from 'node:fs'
-import { tmpdir } from 'node:os'
-import path from 'node:path'
-import WebSocket from 'ws'
+import { Client, startServer, type Server } from './harness.ts'
 
 /**
- * Integration tests for the canvas access model, run against the REAL server:
- * spawned as a child process on a fresh PGlite database in a temp directory,
- * exercised over HTTP and WebSocket exactly like the browser and MCP clients.
- * No mocks — this is the same surface a self-hoster exposes to the internet.
+ * Integration tests for the canvas access model, run against the REAL server
+ * (see ./harness.ts): a child process on a fresh PGlite database, exercised
+ * over HTTP and WebSocket exactly like the browser and MCP clients. No mocks
+ * — this is the same surface a self-hoster exposes to the internet.
  */
 
 const PORT = 4977
-const BASE = `http://localhost:${PORT}`
-const ROOT = process.cwd() // vitest runs from the repo root
 
-let server: ChildProcess
-let dataDir: string
-
-/** Minimal cookie-jar client: better-auth drives everything through cookies. */
-class Client {
-  cookies = new Map<string, string>()
-
-  private header() {
-    return [...this.cookies.entries()].map(([k, v]) => `${k}=${v}`).join('; ')
-  }
-
-  async req(pathname: string, init: RequestInit = {}): Promise<Response> {
-    const res = await fetch(BASE + pathname, {
-      ...init,
-      headers: { 'Content-Type': 'application/json', Cookie: this.header(), ...init.headers },
-      redirect: 'manual',
-    })
-    for (const c of res.headers.getSetCookie()) {
-      const [pair] = c.split(';')
-      const idx = pair.indexOf('=')
-      this.cookies.set(pair.slice(0, idx).trim(), pair.slice(idx + 1).trim())
-    }
-    return res
-  }
-
-  get(p: string) {
-    return this.req(p)
-  }
-
-  post(p: string, body?: unknown) {
-    return this.req(p, { method: 'POST', body: body === undefined ? undefined : JSON.stringify(body) })
-  }
-
-  patch(p: string, body: unknown) {
-    return this.req(p, { method: 'PATCH', body: JSON.stringify(body) })
-  }
-
-  delete(p: string) {
-    return this.req(p, { method: 'DELETE' })
-  }
-
-  async signUp(email: string, name: string) {
-    const res = await this.post('/api/auth/sign-up/email', { email, password: 'password12345', name })
-    expect(res.status).toBe(200)
-    return this
-  }
-
-  /** join a canvas room over WS; resolves with how the server answered */
-  joinWs(canvasId: string): Promise<{ kind: 'init' } | { kind: 'closed'; code: number }> {
-    return new Promise((resolve, reject) => {
-      const ws = new WebSocket(`ws://localhost:${PORT}/ws`, { headers: { Cookie: this.header() } })
-      const timer = setTimeout(() => {
-        ws.terminate()
-        reject(new Error('ws join timed out'))
-      }, 8000)
-      ws.on('open', () =>
-        ws.send(JSON.stringify({ type: 'join', canvasId, clientId: `t-${Math.random()}`, name: 't', kind: 'user' })),
-      )
-      ws.on('message', (d) => {
-        if (JSON.parse(String(d)).type === 'init') {
-          clearTimeout(timer)
-          ws.close()
-          resolve({ kind: 'init' })
-        }
-      })
-      ws.on('close', (code) => {
-        clearTimeout(timer)
-        resolve({ kind: 'closed', code })
-      })
-      ws.on('error', () => {}) // close event carries the verdict
-    })
-  }
-}
+let server: Server
+let BASE: string
 
 beforeAll(async () => {
-  dataDir = mkdtempSync(path.join(tmpdir(), 'doop-test-'))
-  server = spawn(path.join(ROOT, 'node_modules', '.bin', 'tsx'), [path.join(ROOT, 'server', 'index.ts')], {
-    cwd: dataDir, // PGlite persists to <cwd>/data — isolated per run
-    env: { ...process.env, PORT: String(PORT), NODE_ENV: undefined as unknown as string },
-    stdio: 'ignore',
-  })
-  const deadline = Date.now() + 60_000
-  for (;;) {
-    try {
-      const res = await fetch(`${BASE}/healthz`)
-      if (res.ok) break
-    } catch {
-      /* not up yet */
-    }
-    if (Date.now() > deadline) throw new Error('server did not boot within 60s')
-    await new Promise((r) => setTimeout(r, 500))
-  }
+  server = await startServer(PORT)
+  BASE = server.base
 }, 70_000)
 
-afterAll(() => {
-  server?.kill()
-  rmSync(dataDir, { recursive: true, force: true })
-})
+afterAll(() => server?.stop())
 
 describe('canvas access model', () => {
-  const owner = new Client()
-  const invited = new Client()
-  const stranger = new Client()
+  /* assigned once the server is up — the clients need its base URL and port */
+  let owner: Client
+  let invited: Client
+  let stranger: Client
+  beforeAll(() => {
+    owner = new Client(server)
+    invited = new Client(server)
+    stranger = new Client(server)
+  })
   let canvasId: string
   let frameId: string
   let invitedId: string

--- a/tests/admin.test.ts
+++ b/tests/admin.test.ts
@@ -1,0 +1,168 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { Client, startServer, type Server } from './harness.ts'
+
+/**
+ * The admin surface, against the real server. Two things are being pinned
+ * down here, and the second matters more than the first:
+ *
+ *  1. an admin can see every canvas on the instance;
+ *  2. being an admin does NOT widen canAccessCanvas. The only way into
+ *     someone's canvas is impersonation — which is read-only, leaves
+ *     session.impersonatedBy behind, and cannot mint MCP tokens.
+ */
+
+const PORT = 4978
+
+let server: Server
+let boss: Client
+let alice: Client
+let mallory: Client
+let aliceId: string
+let canvasId: string
+
+beforeAll(async () => {
+  server = await startServer(PORT, { ADMIN_EMAILS: 'boss@test.dev' })
+  boss = new Client(server)
+  alice = new Client(server)
+  mallory = new Client(server)
+  await boss.signUp('boss@test.dev', 'Boss Person')
+  await alice.signUp('alice@test.dev', 'Alice')
+  await mallory.signUp('mallory@test.dev', 'Mallory')
+  aliceId = (await (await alice.get('/api/me')).json()).id
+  const canvas = await (await alice.post('/api/canvases', { name: "Alice's private work" })).json()
+  canvasId = canvas.id
+}, 70_000)
+
+afterAll(() => server?.stop())
+
+describe('admin surface', () => {
+  it('promotes ADMIN_EMAILS accounts at signup and nobody else', async () => {
+    expect((await (await boss.get('/api/me')).json()).admin).toBe(true)
+    expect((await (await alice.get('/api/me')).json()).admin).toBe(false)
+  })
+
+  it('still creates a first canvas on signup (the admin plugin adds its own db hooks)', async () => {
+    const list = await (await alice.get('/api/canvases')).json()
+    expect(list.some((c: { name: string }) => c.name === "Alice's first canvas")).toBe(true)
+  })
+
+  it('hides the admin surface from non-admins as 404, not 403', async () => {
+    expect((await mallory.get('/api/admin/canvases')).status).toBe(404)
+    expect((await mallory.get('/api/admin/users')).status).toBe(404)
+    expect((await mallory.get('/api/admin/stats')).status).toBe(404)
+  })
+
+  it('lists every canvas on the instance with its owner', async () => {
+    const { total, canvases } = await (await boss.get('/api/admin/canvases')).json()
+    const entry = canvases.find((c: { id: string }) => c.id === canvasId)
+    expect(entry?.name).toBe("Alice's private work")
+    expect(entry?.owner?.email).toBe('alice@test.dev')
+    expect(total).toBeGreaterThanOrEqual(4) // three first-canvases plus Alice's
+  })
+
+  it('does not leak other people’s canvases into the admin’s own dashboard', async () => {
+    const mine = await (await boss.get('/api/canvases')).json()
+    expect(mine.some((c: { id: string }) => c.id === canvasId)).toBe(false)
+  })
+
+  it('leaves canAccessCanvas untouched: an admin cannot open a private canvas', async () => {
+    expect((await boss.get(`/api/canvases/${canvasId}`)).status).toBe(403)
+    expect(await boss.joinWs(canvasId)).toEqual({ kind: 'closed', code: 4403 })
+  })
+
+  it('refuses to impersonate for non-admins', async () => {
+    const res = await mallory.post('/api/auth/admin/impersonate-user', { userId: aliceId })
+    expect(res.status).toBeGreaterThanOrEqual(400)
+    expect((await (await mallory.get('/api/me')).json()).email).toBe('mallory@test.dev')
+  })
+
+  describe('viewing as another user', () => {
+    it('swaps the session and reports who is behind it', async () => {
+      expect((await boss.post('/api/auth/admin/impersonate-user', { userId: aliceId })).status).toBe(200)
+      const me = await (await boss.get('/api/me')).json()
+      expect(me.email).toBe('alice@test.dev')
+      expect(me.admin).toBe(false) // the session is Alice's; only `impersonating` gives it away
+      expect(me.impersonating).toEqual({ byName: 'Boss Person' })
+    })
+
+    it('opens the canvas through the ordinary gate', async () => {
+      expect((await boss.get(`/api/canvases/${canvasId}`)).status).toBe(200)
+      expect(await boss.joinWs(canvasId)).toEqual({ kind: 'init' })
+    })
+
+    it('is read-only', async () => {
+      expect((await boss.patch(`/api/canvases/${canvasId}`, { name: 'renamed by admin' })).status).toBe(403)
+      expect((await boss.post(`/api/canvases/${canvasId}/frames`, { name: 'sneaky' })).status).toBe(403)
+      expect((await boss.post('/api/canvases', { name: 'as alice' })).status).toBe(403)
+      expect((await boss.delete(`/api/canvases/${canvasId}`)).status).toBe(403)
+      const canvas = await (await boss.get(`/api/canvases/${canvasId}`)).json()
+      expect(canvas.name).toBe("Alice's private work")
+    })
+
+    it('closes the admin surface, since the session is no longer an admin', async () => {
+      expect((await boss.get('/api/admin/canvases')).status).toBe(404)
+    })
+
+    it('cannot mint an MCP token as the person being viewed', async () => {
+      const res = await boss.get('/api/auth/mcp/authorize?client_id=x&response_type=code')
+      expect(res.status).toBe(403)
+    })
+
+    it('cannot edit the viewed account through better-auth either', async () => {
+      /* /api/auth/* is mounted before the /api gate, so these would otherwise
+         slip past the read-only rule and change someone else's account */
+      expect((await boss.post('/api/auth/update-user', { name: 'Renamed By Admin' })).status).toBe(403)
+      expect((await boss.post('/api/auth/change-email', { newEmail: 'stolen@test.dev' })).status).toBe(403)
+      expect((await boss.post('/api/auth/revoke-sessions')).status).toBe(403)
+      const me = await (await boss.get('/api/me')).json()
+      expect(me.name).toBe('Alice') // unchanged
+    })
+
+    it('restores the admin on stop', async () => {
+      expect((await boss.post('/api/auth/admin/stop-impersonating')).status).toBe(200)
+      const me = await (await boss.get('/api/me')).json()
+      expect(me.email).toBe('boss@test.dev')
+      expect(me.admin).toBe(true)
+      expect(me.impersonating).toBeUndefined()
+      expect((await boss.get('/api/admin/canvases')).status).toBe(200)
+    })
+  })
+
+  it('refuses to hand the role to an unverified claim on the address in production', async () => {
+    /* No SMTP means signup is open and nothing can ever be verified, so
+       whoever types the admin's address first would otherwise BE the admin.
+       Production must refuse; development keeps working for convenience. */
+    const prod = await startServer(PORT + 2, {
+      ADMIN_EMAILS: 'boss@test.dev',
+      NODE_ENV: 'production',
+      BETTER_AUTH_SECRET: 'test-secret-not-for-real-use',
+      BETTER_AUTH_URL: `http://localhost:${PORT + 2}`,
+    })
+    try {
+      const impostor = new Client(prod)
+      await impostor.signUp('boss@test.dev', 'Not The Boss')
+      const me = await (await impostor.get('/api/me')).json()
+      expect(me.email).toBe('boss@test.dev')
+      expect(me.admin).toBe(false)
+      expect((await impostor.get('/api/admin/canvases')).status).toBe(404)
+    } finally {
+      prod.stop()
+    }
+  }, 70_000)
+
+  it('promotes accounts that already existed when ADMIN_EMAILS gained them', async () => {
+    /* the real-world order: someone signs up first, and is named an admin
+       later. Reboot the same database with a wider ADMIN_EMAILS. */
+    server.stop({ keepData: true })
+    const rebooted = await startServer(PORT + 1, { ADMIN_EMAILS: 'boss@test.dev,alice@test.dev' }, server.dataDir)
+    try {
+      const promoted = new Client(rebooted)
+      await promoted.post('/api/auth/sign-in/email', { email: 'alice@test.dev', password: 'password12345' })
+      const me = await (await promoted.get('/api/me')).json()
+      expect(me.email).toBe('alice@test.dev')
+      expect(me.admin).toBe(true)
+    } finally {
+      rebooted.stop()
+    }
+  }, 70_000)
+})

--- a/tests/harness.ts
+++ b/tests/harness.ts
@@ -1,0 +1,129 @@
+import { spawn, type ChildProcess } from 'node:child_process'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import WebSocket from 'ws'
+
+/**
+ * Shared rig for the integration tests: a REAL server, spawned as a child
+ * process on a fresh PGlite database in a temp directory, exercised over HTTP
+ * and WebSocket exactly like the browser and MCP clients. No mocks — this is
+ * the same surface a self-hoster exposes to the internet.
+ */
+
+const ROOT = process.cwd() // vitest runs from the repo root
+
+export interface Server {
+  base: string
+  port: number
+  /** PGlite lives here; pass it back to startServer to reboot the same database */
+  dataDir: string
+  stop(opts?: { keepData?: boolean }): void
+}
+
+export async function startServer(port: number, env: Record<string, string> = {}, reuseDir?: string): Promise<Server> {
+  const dataDir = reuseDir ?? mkdtempSync(path.join(tmpdir(), 'doop-test-'))
+  const proc: ChildProcess = spawn(
+    path.join(ROOT, 'node_modules', '.bin', 'tsx'),
+    [path.join(ROOT, 'server', 'index.ts')],
+    {
+      cwd: dataDir, // PGlite persists to <cwd>/data — isolated per run
+      env: { ...process.env, PORT: String(port), NODE_ENV: undefined as unknown as string, ...env },
+      stdio: 'ignore',
+    },
+  )
+  const base = `http://localhost:${port}`
+  const deadline = Date.now() + 60_000
+  for (;;) {
+    try {
+      const res = await fetch(`${base}/healthz`)
+      if (res.ok) break
+    } catch {
+      /* not up yet */
+    }
+    if (Date.now() > deadline) throw new Error('server did not boot within 60s')
+    await new Promise((r) => setTimeout(r, 500))
+  }
+  return {
+    base,
+    port,
+    dataDir,
+    stop({ keepData }: { keepData?: boolean } = {}) {
+      proc.kill()
+      if (!keepData) rmSync(dataDir, { recursive: true, force: true })
+    },
+  }
+}
+
+/** Minimal cookie-jar client: better-auth drives everything through cookies. */
+export class Client {
+  cookies = new Map<string, string>()
+
+  constructor(private server: Server) {}
+
+  header() {
+    return [...this.cookies.entries()].map(([k, v]) => `${k}=${v}`).join('; ')
+  }
+
+  async req(pathname: string, init: RequestInit = {}): Promise<Response> {
+    const res = await fetch(this.server.base + pathname, {
+      ...init,
+      headers: { 'Content-Type': 'application/json', Cookie: this.header(), ...init.headers },
+      redirect: 'manual',
+    })
+    for (const c of res.headers.getSetCookie()) {
+      const [pair] = c.split(';')
+      const idx = pair.indexOf('=')
+      this.cookies.set(pair.slice(0, idx).trim(), pair.slice(idx + 1).trim())
+    }
+    return res
+  }
+
+  get(p: string) {
+    return this.req(p)
+  }
+
+  post(p: string, body?: unknown) {
+    return this.req(p, { method: 'POST', body: body === undefined ? undefined : JSON.stringify(body) })
+  }
+
+  patch(p: string, body: unknown) {
+    return this.req(p, { method: 'PATCH', body: JSON.stringify(body) })
+  }
+
+  delete(p: string) {
+    return this.req(p, { method: 'DELETE' })
+  }
+
+  async signUp(email: string, name: string) {
+    const res = await this.post('/api/auth/sign-up/email', { email, password: 'password12345', name })
+    if (res.status !== 200) throw new Error(`sign-up failed: ${res.status} ${await res.text()}`)
+    return this
+  }
+
+  /** join a canvas room over WS; resolves with how the server answered */
+  joinWs(canvasId: string): Promise<{ kind: 'init' } | { kind: 'closed'; code: number }> {
+    return new Promise((resolve, reject) => {
+      const ws = new WebSocket(`ws://localhost:${this.server.port}/ws`, { headers: { Cookie: this.header() } })
+      const timer = setTimeout(() => {
+        ws.terminate()
+        reject(new Error('ws join timed out'))
+      }, 8000)
+      ws.on('open', () =>
+        ws.send(JSON.stringify({ type: 'join', canvasId, clientId: `t-${Math.random()}`, name: 't', kind: 'user' })),
+      )
+      ws.on('message', (d) => {
+        if (JSON.parse(String(d)).type === 'init') {
+          clearTimeout(timer)
+          ws.close()
+          resolve({ kind: 'init' })
+        }
+      })
+      ws.on('close', (code) => {
+        clearTimeout(timer)
+        resolve({ kind: 'closed', code })
+      })
+      ws.on('error', () => {}) // close event carries the verdict
+    })
+  }
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,25 +1,33 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
+/* Dev ports. The defaults are the only ones anyone normally needs; the env
+   overrides exist so a second worktree can run its own pair without fighting
+   the first for :4300/:4400. PORT is the same variable the server reads, so
+   the proxy always points at whichever backend this `npm run dev` started. */
+const apiPort = Number(process.env.PORT || 4400)
+const webPort = Number(process.env.VITE_PORT || 4300)
+const api = `http://localhost:${apiPort}`
+
 export default defineConfig({
   plugins: [react()],
   server: {
-    port: 4300,
+    port: webPort,
     proxy: {
-      /* changeOrigin stays OFF so the backend sees Host localhost:4300 and
-         better-auth builds OAuth discovery/authorize URLs on this origin —
+      /* changeOrigin stays OFF so the backend sees the web origin's Host and
+         better-auth builds OAuth discovery/authorize URLs on that origin —
          the one that serves the login page and that MCP clients connect to */
-      '/api': { target: 'http://localhost:4400' },
-      '/mcp': { target: 'http://localhost:4400' },
-      '/i': { target: 'http://localhost:4400' },
-      '/a/': { target: 'http://localhost:4400' },
-      '/u/': { target: 'http://localhost:4400' },
-      '/relay': { target: 'http://localhost:4400' },
-      '/blog': { target: 'http://localhost:4400' },
-      '/robots.txt': { target: 'http://localhost:4400' },
-      '/sitemap.xml': { target: 'http://localhost:4400' },
-      '/.well-known': { target: 'http://localhost:4400' },
-      '/ws': { target: 'ws://localhost:4400', ws: true },
+      '/api': { target: api },
+      '/mcp': { target: api },
+      '/i': { target: api },
+      '/a/': { target: api },
+      '/u/': { target: api },
+      '/relay': { target: api },
+      '/blog': { target: api },
+      '/robots.txt': { target: api },
+      '/sitemap.xml': { target: api },
+      '/.well-known': { target: api },
+      '/ws': { target: `ws://localhost:${apiPort}`, ws: true },
     },
   },
 })


### PR DESCRIPTION
Adds `/admin`: every canvas and account on the instance, and a way to look inside a canvas you do not own.

`canAccessCanvas` is deliberately untouched. It is the shared gate for REST, the WS join and MCP, so an admin branch there would hand every agent holding an admin's OAuth token read/write on every canvas in the instance. Admins get their own routes, and reach a specific canvas by impersonating its owner — which goes through the ordinary gate as that owner and leaves `session.impersonated_by` behind as the audit trail.

Impersonated sessions are read-only, and the guarantee is enforced in two places because `/api/auth/*` is mounted before the `/api` gate: non-GET on `/api`, and an allowlist on `/api/auth/*` that also blocks the MCP OAuth flow (it would mint an agent token belonging to the person being viewed, outliving the 15-minute window). View-as connections join the websocket silently and skip the demo agent and resident card pickup, so looking at a canvas cannot act on it. PostHog identify and session replay are suppressed, or an admin's support session would be written to the customer's own profile.

`ADMIN_EMAILS` names admins by address, applied at signup, on email verification and at boot. An address only identifies someone once they have verified it: without SMTP nothing can be verified and signup is open, so production refuses to promote anyone and warns at boot rather than handing the role to whoever claims the address first.

Also includes: dev server ports from the environment (`PORT`/`VITE_PORT`), and drizzle-kit invoked via npx to keep lockfiles in sync.

Ported from the upstream private repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)