### PR TITLE
fix(server): decode HTML-escaped frame writes

### DIFF
--- a/server/actions.ts
+++ b/server/actions.ts
@@ -3,6 +3,7 @@ import { store } from './store.ts'
 import * as persist from './db/persist.ts'
 import { colorFor } from '../shared/types.ts'
 import { DEFAULT_ROLE_ID, mentionedRole, normalizePipeline, roleByAgentName, roleName } from '../shared/agents.ts'
+import { decodeEscapedHtml, looksEscapedHtml, repairEscapedHtml } from './escapedHtml.ts'
 import type {
   Actor,
   ActivityItem,
@@ -703,6 +704,8 @@ interface RevealState {
   isStream: boolean
   /** the stream got its final chunk; finish once the reveal catches up */
   pendingDone: boolean
+  /** the opening chunk was HTML-escaped: decode every chunk of this stream */
+  escaped: boolean
   lastActivity: number
 }
 
@@ -735,7 +738,7 @@ function commonPrefixLen(a: string, b: string): number {
 }
 
 function startReveal(frame: Frame, actor: Actor, shown: number, isStream: boolean) {
-  reveals.set(frame.id, { actor, shown, isStream, pendingDone: false, lastActivity: Date.now() })
+  reveals.set(frame.id, { actor, shown, isStream, pendingDone: false, escaped: false, lastActivity: Date.now() })
   broadcast(frame.canvasId, { type: 'frame:streaming', frameId: frame.id, active: true, actor })
 }
 
@@ -787,7 +790,12 @@ export function appendFrameHtml(
   if (!before) return undefined
 
   const starting = opts.start || !reveals.has(frameId)
-  const html = opts.start ? chunk : before.html + chunk
+  /* an agent that escapes its opening chunk escapes the whole stream, so latch
+     the verdict there: a chunk mid-design can hold a legitimate `&lt;` (a code
+     sample) and must never be sniffed on its own */
+  const escaped = starting ? looksEscapedHtml(chunk) : (reveals.get(frameId)?.escaped ?? false)
+  const piece = escaped ? decodeEscapedHtml(chunk) : chunk
+  const html = opts.start ? piece : before.html + piece
   const frame = store.updateFrame(frameId, { html }, actor.name)!
 
   if (starting) {
@@ -798,6 +806,7 @@ export function appendFrameHtml(
   }
   const r = reveals.get(frameId)!
   r.lastActivity = Date.now()
+  r.escaped = escaped
   if (opts.done) r.pendingDone = true
 
   touch(frame.canvasId, actor, frameId)
@@ -811,6 +820,7 @@ export function createFrame(
   input: { name: string; x?: number; y?: number; width?: number; height?: number; html?: string },
   actor: Actor,
 ): Frame | undefined {
+  if (input.html !== undefined) input = { ...input, html: repairEscapedHtml(input.html) }
   const frame = store.createFrame(canvasId, input, actor.name)
   if (!frame) return undefined
   if (actor.kind === 'agent' && frame.html.length > 0) {
@@ -833,6 +843,7 @@ export function updateFrame(
 ): Frame | undefined {
   const before = store.getFrame(frameId)
   if (!before) return undefined
+  if (patch.html !== undefined) patch = { ...patch, html: repairEscapedHtml(patch.html) }
   const prevName = before.name
   const prevHtml = before.html
   const frame = store.updateFrame(frameId, patch, actor.name)!

--- a/server/escapedHtml.ts
+++ b/server/escapedHtml.ts
@@ -1,0 +1,37 @@
+/**
+ * Agents sometimes send HTML-escaped markup (`&lt;!doctype html&gt;…`) where raw
+ * tags belong. Stored verbatim, the frame renders those entities as text and the
+ * human watches the design's own source code appear on the canvas.
+ *
+ * A document that carries escaped tags and not one raw `<` has no elements at
+ * all, so it can only be a mis-encoded write — decode it rather than render
+ * source. Anything holding real markup is left untouched, which keeps escaped
+ * code samples inside a genuine design safe.
+ */
+
+/* a tag opener admits no space after the `<`, which keeps prose like
+   "widths under &lt; 600px" out of the match */
+const ESCAPED_TAG = /&(?:lt|#0*60|#[xX]0*3[cC]);[/!a-zA-Z]/
+
+/** True only for a payload that is markup, but entirely escaped. */
+export function looksEscapedHtml(html: string): boolean {
+  return !html.includes('<') && ESCAPED_TAG.test(html)
+}
+
+/** Reverse one level of HTML escaping. `&amp;` goes last so `&amp;lt;` → `&lt;`. */
+export function decodeEscapedHtml(html: string): string {
+  return html
+    .replace(/&(?:lt|#0*60|#[xX]0*3[cC]);/g, '<')
+    .replace(/&(?:gt|#0*62|#[xX]0*3[eE]);/g, '>')
+    .replace(/&(?:quot|#0*34|#[xX]0*22);/g, '"')
+    .replace(/&(?:apos|#0*39|#[xX]0*27);/g, "'")
+    .replace(/&(?:amp|#0*38|#[xX]0*26);/g, '&')
+}
+
+export function repairEscapedHtml(html: string): string {
+  return looksEscapedHtml(html) ? decodeEscapedHtml(html) : html
+}
+
+/** Told to the agent whenever a write was repaired, so it stops escaping. */
+export const ESCAPED_HTML_NOTE =
+  'That HTML arrived escaped (&lt;div&gt; where <div> belongs), which renders as visible source text on the canvas. Doop decoded it so the frame still shows a design — send raw markup from here on: these tools take HTML exactly as written, no escaping.'

--- a/server/mcp.ts
+++ b/server/mcp.ts
@@ -9,6 +9,7 @@ import { canAccessCanvas } from './access.ts'
 import { auth, getUserName, PUBLIC_ORIGIN } from './auth.ts'
 import { renderFrame } from './screenshot.ts'
 import { DOOP_GUIDE, GUIDE_TOPICS } from './guide.ts'
+import { ESCAPED_HTML_NOTE, looksEscapedHtml } from './escapedHtml.ts'
 import * as assets from './assets.ts'
 import * as imageSearch from './imageSearch.ts'
 import { viewWebsite, saveWebsiteReferenceFrame } from './website.ts'
@@ -59,6 +60,15 @@ function withStatusNudge<T extends { content: { type: 'text' | 'image'; [k: stri
     type: 'text' as const,
     text: 'You have not announced what you are working on. Call set_status with a one-line, present-tense summary (e.g. "Designing a pricing page, dark editorial style") — it shows live next to your name and builds your task history in the panel. Update it when your focus shifts; clear it with "" when done.',
   })
+  return result
+}
+
+/** Tells an agent its markup arrived escaped — actions.ts already decoded it. */
+function withEscapeNote<T extends { content: { type: 'text' | 'image'; [k: string]: unknown }[] }>(
+  result: T,
+  sent: string,
+): T {
+  if (looksEscapedHtml(sent)) result.content.push({ type: 'text' as const, text: ESCAPED_HTML_NOTE })
   return result
 }
 
@@ -507,10 +517,12 @@ export function buildMcpServer(owner?: string, ownerId?: string): McpServer {
       if (!canvasFor(canvas_id)) return noCanvas(canvas_id)
       const frame = actions.createFrame(canvas_id, { name, html, x, y, width, height }, actorFrom(agent_name))
       if (!frame) return noCanvas(canvas_id)
-      const result =
+      const result = withEscapeNote(
         frame.html.length > 0
           ? textWithNudge({ ok: true, frame: frameSummary(frame) }, REVIEW_NUDGE)
-          : text({ ok: true, frame: frameSummary(frame) })
+          : text({ ok: true, frame: frameSummary(frame) }),
+        html,
+      )
       return withGuidelinesNudge(
         withStatusNudge(withFeedback(result, canvas_id, actorFrom(agent_name)), canvas_id, actorFrom(agent_name)),
         canvas_id,
@@ -551,7 +563,7 @@ export function buildMcpServer(owner?: string, ownerId?: string): McpServer {
       return withGuidelinesNudge(
         withStatusNudge(
           withFeedback(
-            textWithNudge({ ok: true, frame: frameSummary(frame) }, REVIEW_NUDGE),
+            withEscapeNote(textWithNudge({ ok: true, frame: frameSummary(frame) }, REVIEW_NUDGE), html),
             frame.canvasId,
             actorFrom(agent_name),
           ),
@@ -911,7 +923,9 @@ export function buildMcpServer(owner?: string, ownerId?: string): McpServer {
         'Stream a design into a frame chunk by chunk, so viewers watch it build up live — prefer this over set_frame_html when creating or reworking a whole design. Send the HTML in order, in chunks of roughly 200–600 characters (e.g. head/styles first, then section by section). Set start=true on the FIRST chunk (replaces any existing content and shows a live "designing…" badge) and done=true on the LAST chunk. Partial HTML renders progressively, so structure chunks to end at reasonable boundaries when you can.',
       inputSchema: {
         frame_id: z.string(),
-        html_chunk: z.string().describe('The next piece of HTML, appended to what has been sent so far.'),
+        html_chunk: z
+          .string()
+          .describe('The next piece of HTML, appended to what has been sent so far. Raw markup — never escaped.'),
         start: z.boolean().optional().describe('true on the first chunk — clears the frame and starts the live stream'),
         done: z.boolean().optional().describe('true on the final chunk — ends the live stream'),
         agent_name: agentName,
@@ -927,8 +941,11 @@ export function buildMcpServer(owner?: string, ownerId?: string): McpServer {
             `Stream complete. ${REVIEW_NUDGE}`,
           )
         : text({ ok: true, streaming: true, htmlBytes: frame.html.length })
-      /* nudge only on the first chunk — mid-stream results should stay lean */
-      const nudged = start ? withGuidelinesNudge(result, frame.canvasId, actorFrom(agent_name)) : result
+      /* nudge only on the first chunk — mid-stream results should stay lean.
+         The escape check rides along: the opening chunk decides the stream. */
+      const nudged = start
+        ? withGuidelinesNudge(withEscapeNote(result, html_chunk), frame.canvasId, actorFrom(agent_name))
+        : result
       return withStatusNudge(
         withFeedback(nudged, frame.canvasId, actorFrom(agent_name)),
         frame.canvasId,

--- a/tests/escapedHtml.test.ts
+++ b/tests/escapedHtml.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+import { decodeEscapedHtml, looksEscapedHtml, repairEscapedHtml } from '../server/escapedHtml.ts'
+
+describe('escaped-html guard', () => {
+  it('catches a whole document sent as entities', () => {
+    const sent = '&lt;!doctype html&gt;&lt;html&gt;&lt;body&gt;&lt;h1&gt;Settings&lt;/h1&gt;&lt;/body&gt;&lt;/html&gt;'
+    expect(looksEscapedHtml(sent)).toBe(true)
+    expect(repairEscapedHtml(sent)).toBe('<!doctype html><html><body><h1>Settings</h1></body></html>')
+  })
+
+  it('leaves real markup alone, escaped code samples included', () => {
+    const design = '<!doctype html><html><body><code>&lt;div class="card"&gt;</code></body></html>'
+    expect(looksEscapedHtml(design)).toBe(false)
+    expect(repairEscapedHtml(design)).toBe(design)
+  })
+
+  it('ignores prose that merely mentions an entity', () => {
+    expect(looksEscapedHtml('Widths under &lt; 600px collapse the grid.')).toBe(false)
+    expect(looksEscapedHtml('a &lt; b &amp;&amp; b &gt; c')).toBe(false)
+  })
+
+  it('handles numeric entities and restores ampersands last', () => {
+    expect(repairEscapedHtml('&#60;a href=&quot;/x?a=1&amp;b=2&quot;&#62;Go&#60;/a&#62;')).toBe(
+      '<a href="/x?a=1&b=2">Go</a>',
+    )
+    /* one level only: an escaped code sample stays escaped after decoding */
+    expect(decodeEscapedHtml('&lt;p&gt;&amp;lt;br&amp;gt;&lt;/p&gt;')).toBe('<p>&lt;br&gt;</p>')
+  })
+})

--- a/tests/frameHtml.test.ts
+++ b/tests/frameHtml.test.ts
@@ -1,0 +1,63 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { Client, startServer, type Server } from './harness.ts'
+
+/**
+ * Frame HTML writes against the REAL server (see ./harness.ts). Agents have
+ * shipped whole documents as entities, which the frame iframe then renders as
+ * visible source text — these tests pin the repair down to what is stored.
+ */
+
+const PORT = 4979
+
+let server: Server
+
+beforeAll(async () => {
+  server = await startServer(PORT)
+}, 70_000)
+
+afterAll(() => server?.stop())
+
+describe('escaped HTML never reaches a frame', () => {
+  let client: Client
+  let canvasId: string
+  beforeAll(async () => {
+    client = new Client(server)
+    await client.signUp('frames@test.dev', 'Framer')
+    canvasId = (await (await client.post('/api/canvases', { name: 'HTML' })).json()).id
+  })
+
+  async function newFrame(name: string): Promise<string> {
+    return (await (await client.post(`/api/canvases/${canvasId}/frames`, { name })).json()).id
+  }
+  async function htmlOf(frameId: string): Promise<string> {
+    const canvas = await (await client.get(`/api/canvases/${canvasId}`)).json()
+    return canvas.frames.find((f: { id: string }) => f.id === frameId).html
+  }
+
+  it('decodes a one-shot write sent as entities', async () => {
+    const id = await newFrame('one-shot')
+    await client.patch(`/api/frames/${id}`, {
+      html: '&lt;!doctype html&gt;&lt;html&gt;&lt;body&gt;&lt;h1&gt;Hi&lt;/h1&gt;&lt;/body&gt;&lt;/html&gt;',
+    })
+    expect(await htmlOf(id)).toBe('<!doctype html><html><body><h1>Hi</h1></body></html>')
+  })
+
+  it('decodes every chunk of a stream whose opening chunk was escaped', async () => {
+    const id = await newFrame('escaped stream')
+    /* only the first chunk is sniffed; the rest ride the latch — the middle one
+       holds no entity at all and must still land in an unescaped document */
+    await client.post(`/api/frames/${id}/append`, { html_chunk: '&lt;!doctype html&gt;&lt;html&gt;', start: true })
+    await client.post(`/api/frames/${id}/append`, { html_chunk: '&lt;body class=&quot;p&quot;&gt;' })
+    await client.post(`/api/frames/${id}/append`, { html_chunk: 'plain text' })
+    await client.post(`/api/frames/${id}/append`, { html_chunk: '&lt;/body&gt;&lt;/html&gt;', done: true })
+    expect(await htmlOf(id)).toBe('<!doctype html><html><body class="p">plain text</body></html>')
+  })
+
+  it('leaves a raw stream untouched, escaped code samples included', async () => {
+    const id = await newFrame('raw stream')
+    const doc = '<!doctype html><html><body><code>&lt;div class="card"&gt;</code></body></html>'
+    await client.post(`/api/frames/${id}/append`, { html_chunk: doc.slice(0, 30), start: true })
+    await client.post(`/api/frames/${id}/append`, { html_chunk: doc.slice(30), done: true })
+    expect(await htmlOf(id)).toBe(doc)
+  })
+})

--- a/tests/harness.ts
+++ b/tests/harness.ts
@@ -1,0 +1,129 @@
+import { spawn, type ChildProcess } from 'node:child_process'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import WebSocket from 'ws'
+
+/**
+ * Shared rig for the integration tests: a REAL server, spawned as a child
+ * process on a fresh PGlite database in a temp directory, exercised over HTTP
+ * and WebSocket exactly like the browser and MCP clients. No mocks — this is
+ * the same surface a self-hoster exposes to the internet.
+ */
+
+const ROOT = process.cwd() // vitest runs from the repo root
+
+export interface Server {
+  base: string
+  port: number
+  /** PGlite lives here; pass it back to startServer to reboot the same database */
+  dataDir: string
+  stop(opts?: { keepData?: boolean }): void
+}
+
+export async function startServer(port: number, env: Record<string, string> = {}, reuseDir?: string): Promise<Server> {
+  const dataDir = reuseDir ?? mkdtempSync(path.join(tmpdir(), 'doop-test-'))
+  const proc: ChildProcess = spawn(
+    path.join(ROOT, 'node_modules', '.bin', 'tsx'),
+    [path.join(ROOT, 'server', 'index.ts')],
+    {
+      cwd: dataDir, // PGlite persists to <cwd>/data — isolated per run
+      env: { ...process.env, PORT: String(port), NODE_ENV: undefined as unknown as string, ...env },
+      stdio: 'ignore',
+    },
+  )
+  const base = `http://localhost:${port}`
+  const deadline = Date.now() + 60_000
+  for (;;) {
+    try {
+      const res = await fetch(`${base}/healthz`)
+      if (res.ok) break
+    } catch {
+      /* not up yet */
+    }
+    if (Date.now() > deadline) throw new Error('server did not boot within 60s')
+    await new Promise((r) => setTimeout(r, 500))
+  }
+  return {
+    base,
+    port,
+    dataDir,
+    stop({ keepData }: { keepData?: boolean } = {}) {
+      proc.kill()
+      if (!keepData) rmSync(dataDir, { recursive: true, force: true })
+    },
+  }
+}
+
+/** Minimal cookie-jar client: better-auth drives everything through cookies. */
+export class Client {
+  cookies = new Map<string, string>()
+
+  constructor(private server: Server) {}
+
+  header() {
+    return [...this.cookies.entries()].map(([k, v]) => `${k}=${v}`).join('; ')
+  }
+
+  async req(pathname: string, init: RequestInit = {}): Promise<Response> {
+    const res = await fetch(this.server.base + pathname, {
+      ...init,
+      headers: { 'Content-Type': 'application/json', Cookie: this.header(), ...init.headers },
+      redirect: 'manual',
+    })
+    for (const c of res.headers.getSetCookie()) {
+      const [pair] = c.split(';')
+      const idx = pair.indexOf('=')
+      this.cookies.set(pair.slice(0, idx).trim(), pair.slice(idx + 1).trim())
+    }
+    return res
+  }
+
+  get(p: string) {
+    return this.req(p)
+  }
+
+  post(p: string, body?: unknown) {
+    return this.req(p, { method: 'POST', body: body === undefined ? undefined : JSON.stringify(body) })
+  }
+
+  patch(p: string, body: unknown) {
+    return this.req(p, { method: 'PATCH', body: JSON.stringify(body) })
+  }
+
+  delete(p: string) {
+    return this.req(p, { method: 'DELETE' })
+  }
+
+  async signUp(email: string, name: string) {
+    const res = await this.post('/api/auth/sign-up/email', { email, password: 'password12345', name })
+    if (res.status !== 200) throw new Error(`sign-up failed: ${res.status} ${await res.text()}`)
+    return this
+  }
+
+  /** join a canvas room over WS; resolves with how the server answered */
+  joinWs(canvasId: string): Promise<{ kind: 'init' } | { kind: 'closed'; code: number }> {
+    return new Promise((resolve, reject) => {
+      const ws = new WebSocket(`ws://localhost:${this.server.port}/ws`, { headers: { Cookie: this.header() } })
+      const timer = setTimeout(() => {
+        ws.terminate()
+        reject(new Error('ws join timed out'))
+      }, 8000)
+      ws.on('open', () =>
+        ws.send(JSON.stringify({ type: 'join', canvasId, clientId: `t-${Math.random()}`, name: 't', kind: 'user' })),
+      )
+      ws.on('message', (d) => {
+        if (JSON.parse(String(d)).type === 'init') {
+          clearTimeout(timer)
+          ws.close()
+          resolve({ kind: 'init' })
+        }
+      })
+      ws.on('close', (code) => {
+        clearTimeout(timer)
+        resolve({ kind: 'closed', code })
+      })
+      ws.on('error', () => {}) // close event carries the verdict
+    })
+  }
+}


### PR DESCRIPTION
An agent that sends `&lt;!doctype html&gt;…` instead of raw markup gets exactly what it asked for: the frame stores the entities and the iframe renders the design's own source code as visible text on the canvas.

A payload carrying escaped tags and not one raw `<` has no elements at all, so it can only be a mis-encoded write — decode it rather than paint source at the human. Anything holding real markup is left alone, which keeps escaped code samples inside a genuine design safe.

The repair sits in actions.ts so MCP, REST and the Doop Agent are all covered. Streams latch the verdict on their opening chunk: a chunk mid-design can legitimately carry `&lt;` in a code sample and must never be sniffed on its own. Repaired writes tell the agent what happened, so it corrects itself mid-task instead of shipping a broken frame.

Includes the shared integration-test harness (`tests/harness.ts`) the new tests build on (also added by #11 with identical content — merges cleanly in either order).

Ported from the upstream private repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)