### PR TITLE
feat(auth): make email verification optional via REQUIRE_EMAIL_VERIFICATION

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,6 +40,17 @@
 #SMTP_PASS=
 # true forces implicit TLS (also implied by port 465)
 #SMTP_SECURE=
+# NOTE ON PORTS: many hosts (Railway, Fly, most PaaS) block outbound 25/465/587
+# to deter spam, and a blocked port shows up as a ~3 minute hang on any request
+# that sends mail, not as an error. Resend also listens on 2465 and 2587 for
+# exactly this reason — if signup or password reset hangs, try SMTP_PORT=2587.
+
+# Set to false to let people sign in before verifying their email — fewer
+# signups lost at the "check your inbox" step, at the cost of letting anyone
+# hold an address they don't own. The verification email is still sent, so
+# ADMIN_EMAILS (below) keeps working: promotion always requires a verified
+# address, whatever this is set to.
+#REQUIRE_EMAIL_VERIFICATION=false
 #EMAIL_FROM="doop <no-reply@doop.example.com>"
 
 # --------------------------------------------------------- resident agents

--- a/README.md
+++ b/README.md
@@ -155,6 +155,14 @@ With SMTP configured (`SMTP_HOST` etc. — see [.env.example](.env.example)), si
 verification and "forgot password" sends real reset links. Without it, signup stays open and every
 email is printed to the server log, links included — the flows still work in development.
 
+Set `REQUIRE_EMAIL_VERIFICATION=false` to let people in before they verify — the link is still
+emailed, it just stops gating sign-in. Admin promotion is deliberately not part of that trade:
+`ADMIN_EMAILS` only ever promotes a verified address (see below).
+
+If signup or password reset **hangs** rather than failing, the cause is almost always a host that
+blocks outbound SMTP: Railway and most PaaS block 25/465/587. Resend also serves 2465/2587, so
+`SMTP_PORT=2587` is the usual fix.
+
 Env: `BETTER_AUTH_SECRET` (required in production), `TRUSTED_ORIGINS` (comma-separated,
 defaults to the localhost dev origins).
 

--- a/server/auth.ts
+++ b/server/auth.ts
@@ -32,6 +32,18 @@ const ADMIN_EMAILS = (process.env.ADMIN_EMAILS || '')
   .filter(Boolean)
 
 /**
+ * Whether an unverified account may sign in. Set REQUIRE_EMAIL_VERIFICATION
+ * to "false" to let people use doop the moment they sign up — fewer people
+ * fall out of the funnel at a "check your inbox" screen, at the cost of
+ * letting anyone hold an address they don't own.
+ *
+ * The verification email still goes out either way: it becomes optional
+ * rather than absent, which keeps the ADMIN_EMAILS path below intact. An
+ * admin-to-be clicks the link once; nobody else has to.
+ */
+const REQUIRE_VERIFICATION = mailerConfigured && process.env.REQUIRE_EMAIL_VERIFICATION !== 'false'
+
+/**
  * An email address only identifies someone once they have PROVEN they own it.
  * Without SMTP nothing can ever be verified and signup is open (see
  * requireEmailVerification below), so an unguarded ADMIN_EMAILS would hand
@@ -75,7 +87,13 @@ export async function syncAdmins(): Promise<void> {
         or(isNull(authSchema.user.role), ne(authSchema.user.role, 'admin')),
       ),
     )
-  for (const u of candidates) if (mayPromote(u)) await promote(u.id, u.email)
+  for (const u of candidates) {
+    if (mayPromote(u)) await promote(u.id, u.email)
+    /* Say why, rather than leaving an operator staring at a missing Admin
+       button. Common once verification is optional: the account is fine,
+       it just never clicked the link. */
+    else console.warn(`⚠ ${u.email} is in ADMIN_EMAILS but its email is unverified — not promoted`)
+  }
 }
 
 function buildAuth() {
@@ -102,10 +120,11 @@ function buildAuth() {
     database: drizzleAdapter(db, { provider: 'pg', schema: authSchema }),
     /* Verification is enforced only when an SMTP mailer is configured —
        without one (dev, tiny self-hosts) signup stays open and every email
-       is printed to the server log instead, links included. */
+       is printed to the server log instead, links included — and only when
+       REQUIRE_EMAIL_VERIFICATION hasn't been turned off (see above). */
     emailAndPassword: {
       enabled: true,
-      requireEmailVerification: mailerConfigured,
+      requireEmailVerification: REQUIRE_VERIFICATION,
       sendResetPassword: async ({ user, url }) => {
         await sendMail({
           to: user.email,

--- a/tests/admin.test.ts
+++ b/tests/admin.test.ts
@@ -150,6 +150,33 @@ describe('admin surface', () => {
     }
   }, 70_000)
 
+  it('lets unverified accounts in when verification is optional, but still will not promote them', async () => {
+    /* REQUIRE_EMAIL_VERIFICATION=false trades proof-of-address for signup
+       conversion. The admin role must not be part of that trade: signing in
+       is opened up, promotion still demands a verified address. */
+    const open = await startServer(PORT + 3, {
+      ADMIN_EMAILS: 'boss@test.dev',
+      REQUIRE_EMAIL_VERIFICATION: 'false',
+      SMTP_HOST: 'smtp.invalid.test', // mailer "configured", so verification is possible
+      NODE_ENV: 'production',
+      BETTER_AUTH_SECRET: 'test-secret-not-for-real-use',
+      BETTER_AUTH_URL: `http://localhost:${PORT + 3}`,
+    })
+    try {
+      const eager = new Client(open)
+      await eager.signUp('boss@test.dev', 'Unverified Boss')
+      /* the point of the flag: usable immediately, no inbox round trip */
+      const me = await (await eager.get('/api/me')).json()
+      expect(me.email).toBe('boss@test.dev')
+      expect((await eager.get('/api/canvases')).status).toBe(200)
+      /* ...but the address is still unproven, so no admin */
+      expect(me.admin).toBe(false)
+      expect((await eager.get('/api/admin/canvases')).status).toBe(404)
+    } finally {
+      open.stop()
+    }
+  }, 70_000)
+
   it('promotes accounts that already existed when ADMIN_EMAILS gained them', async () => {
     /* the real-world order: someone signs up first, and is named an admin
        later. Reboot the same database with a wider ADMIN_EMAILS. */


### PR DESCRIPTION
Set `REQUIRE_EMAIL_VERIFICATION=false` to let people sign in the moment they sign up — fewer signups lost at the "check your inbox" step, at the cost of letting anyone hold an address they don't own. The verification email still goes out either way: it becomes optional rather than absent, which keeps the `ADMIN_EMAILS` path intact — promotion always requires a verified address, whatever this is set to.

Also documents the PaaS outbound-SMTP-port trap: blocked 25/465/587 shows up as a ~3 minute hang, not an error; Resend listens on 2465/2587 for exactly this reason.

Now that #11 is merged this is the complete upstream port, including the `syncAdmins` "unverified — not promoted" warning and the admin test asserting the flag never opens up admin promotion.

Ported from the upstream private repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)