### PR TITLE
fix: bill one requester per agent run, and stop two account races

### DIFF
--- a/server/actions.ts
+++ b/server/actions.ts
@@ -184,14 +184,27 @@ export function pendingWorkAgents(canvasId: string): string[] {
   return names
 }
 
-/** Account ids of the humans whose work this agent is about to claim, newest
- *  request last. Read-only on purpose: the harness picks a model credential
- *  from these before it claims anything. */
-export function pendingWorkUserIds(canvasId: string, agentName: string): string[] {
-  const ids: string[] = []
+/**
+ * Who pays for the next run: the account behind the OLDEST piece of work this
+ * agent can claim. A run bills exactly one person, so the queue is worked one
+ * requester at a time rather than sweeping several people's work into a single
+ * model call on whichever account happened to be found first.
+ *
+ * Returns '' when the oldest item predates per-user attribution (the caller
+ * falls back to the canvas owner), and undefined when nothing is claimable.
+ * `skip` holds payers already found to have no usable model this sweep, so one
+ * stalled requester never blocks everyone behind them.
+ */
+export function nextWorkPayer(canvasId: string, agentName: string, skip?: ReadonlySet<string>): string | undefined {
+  let oldest: { at: number; payer: string } | undefined
+  const consider = (at: number, userId: string | undefined) => {
+    const payer = userId ?? ''
+    if (skip?.has(payer)) return
+    if (!oldest || at < oldest.at) oldest = { at, payer }
+  }
   for (const card of taskLog.get(canvasId) ?? []) {
     if (card.queuedBy && !card.agentName && !card.failedAt && !card.endedAt && stageAgent(card) === agentName) {
-      if (card.queuedByUserId) ids.push(card.queuedByUserId)
+      consider(card.startedAt, card.queuedByUserId)
     }
   }
   for (const c of commentLog.get(canvasId) ?? []) {
@@ -200,18 +213,17 @@ export function pendingWorkUserIds(canvasId: string, agentName: string): string[
       !c.claimedBy &&
       !c.failedAt &&
       !c.resolvedAt &&
-      (c.targetAgent ?? roleName(DEFAULT_ROLE_ID)) === agentName &&
-      c.fromUserId
+      (c.targetAgent ?? roleName(DEFAULT_ROLE_ID)) === agentName
     ) {
-      ids.push(c.fromUserId)
+      consider(c.at, c.fromUserId)
     }
   }
   for (const f of feedbackLog.get(canvasId) ?? []) {
-    if (!f.deliveredAt && !f.failedAt && (!f.targetAgent || f.targetAgent === agentName) && f.fromUserId) {
-      ids.push(f.fromUserId)
+    if (!f.deliveredAt && !f.failedAt && (!f.targetAgent || f.targetAgent === agentName)) {
+      consider(f.at, f.fromUserId)
     }
   }
-  return [...new Set(ids)]
+  return oldest?.payer
 }
 
 /* ------------------------------------------------------------------ */
@@ -334,9 +346,13 @@ export function addTaskFeedback(
 /** Open feedback this agent may take: everything addressed to it, plus
  *  untargeted feedback — that part stays a canvas-level queue where the first
  *  identified agent call wins. */
-export function takeFeedbackFor(canvasId: string, agentName: string): TaskFeedback[] {
+export function takeFeedbackFor(canvasId: string, agentName: string, payer?: string): TaskFeedback[] {
   const pending = (feedbackLog.get(canvasId) ?? []).filter(
-    (f) => !f.deliveredAt && !f.failedAt && (!f.targetAgent || f.targetAgent === agentName),
+    (f) =>
+      !f.deliveredAt &&
+      !f.failedAt &&
+      (!f.targetAgent || f.targetAgent === agentName) &&
+      (payer === undefined || (f.fromUserId ?? '') === payer),
   )
   for (const f of pending) {
     f.deliveredAt = Date.now()
@@ -466,14 +482,15 @@ export function addElementComment(
 }
 
 /** Open comments @mentioning this agent, claimed by it. */
-export function takeAgentCommentsFor(canvasId: string, agentName: string): ElementComment[] {
+export function takeAgentCommentsFor(canvasId: string, agentName: string, payer?: string): ElementComment[] {
   const pending = (commentLog.get(canvasId) ?? []).filter(
     (c) =>
       c.forAgent &&
       !c.claimedBy &&
       !c.failedAt &&
       !c.resolvedAt &&
-      (c.targetAgent ?? roleName(DEFAULT_ROLE_ID)) === agentName,
+      (c.targetAgent ?? roleName(DEFAULT_ROLE_ID)) === agentName &&
+      (payer === undefined || (c.fromUserId ?? '') === payer),
   )
   for (const c of pending) {
     c.claimedBy = agentName
@@ -660,9 +677,15 @@ export function addQueuedCard(
 
 /** Cards waiting on THIS agent's stage, claimed by it. A card at another
  *  stage is invisible here — that is what keeps a pipeline in order. */
-export function takeQueuedCardsFor(canvasId: string, agentName: string): AgentTask[] {
+export function takeQueuedCardsFor(canvasId: string, agentName: string, payer?: string): AgentTask[] {
   const pending = (taskLog.get(canvasId) ?? []).filter(
-    (t) => t.queuedBy && !t.agentName && !t.failedAt && !t.endedAt && stageAgent(t) === agentName,
+    (t) =>
+      t.queuedBy &&
+      !t.agentName &&
+      !t.failedAt &&
+      !t.endedAt &&
+      stageAgent(t) === agentName &&
+      (payer === undefined || (t.queuedByUserId ?? '') === payer),
   )
   for (const c of pending) {
     c.agentName = agentName

--- a/server/agentModel.ts
+++ b/server/agentModel.ts
@@ -1,5 +1,5 @@
 import Anthropic from '@anthropic-ai/sdk'
-import { firstConnected, withFreshToken } from './modelAccounts.ts'
+import { getAccount, withFreshToken } from './modelAccounts.ts'
 import type { ModelAccount } from './modelAccounts.ts'
 import { modelFor, ModelAuthError, runOpenAiTurn } from './openaiAgent.ts'
 import type { StopReason, TurnBlock } from './openaiAgent.ts'
@@ -12,9 +12,10 @@ import type { StopReason, TurnBlock } from './openaiAgent.ts'
  * ChatGPT subscription or their own OpenAI key — their runs move onto it, and
  * the free-task meter stops applying to them entirely.
  *
- * A run is attributed to the humans whose cards, comments and feedback it
- * picked up, so the person who asked for the work is the person whose
- * subscription runs it.
+ * A run bills exactly ONE person: the requester behind the work it claims. The
+ * queue is worked one requester at a time rather than sweeping several people's
+ * cards into a single call, so nobody's subscription ever pays for someone
+ * else's request.
  */
 
 export type Provider = 'anthropic' | 'chatgpt' | 'openai-key'
@@ -111,21 +112,22 @@ function openaiModel(account: ModelAccount): AgentModel {
 }
 
 /**
- * Pick the model for one run. `userIds` are the humans whose work the run
- * claimed, most relevant first. Returns null when nothing can run it — no
- * server key and nobody connected an account of their own.
+ * Pick the model for one run, billed to exactly one person: `payerId` is the
+ * human whose work the run is about to claim. Returns null when nothing can
+ * run it — they have no account of their own and there is no server key.
  *
  * A connected account wins outright: someone who has just linked their ChatGPT
  * subscription expects the very next task to run on it, and the free tier is a
  * trial to get them here, not a balance to spend down first. It also means
  * connecting stops costing us anything from that moment on.
  */
-export async function pickModel(userIds: (string | undefined)[]): Promise<AgentModel | null> {
-  const candidates = [...new Set(userIds.filter((id): id is string => !!id))]
-  const account = await firstConnected(candidates).catch((err) => {
-    console.error('[doop-agent] could not read connected model accounts', err)
-    return null
-  })
+export async function pickModel(payerId?: string): Promise<AgentModel | null> {
+  const account = payerId
+    ? await getAccount(payerId).catch((err) => {
+        console.error('[doop-agent] could not read the connected model account', err)
+        return null
+      })
+    : null
   if (account) return openaiModel(account)
   const client = anthropicClient()
   return client ? anthropicModel(client) : null

--- a/server/modelAccounts.ts
+++ b/server/modelAccounts.ts
@@ -125,15 +125,6 @@ export async function setAccountModel(userId: string, model: string): Promise<Ac
   return getStatus(userId)
 }
 
-/** Which of these users has a model account, in the order given. */
-export async function firstConnected(userIds: string[]): Promise<ModelAccount | null> {
-  for (const userId of userIds) {
-    const account = await getAccount(userId)
-    if (account) return account
-  }
-  return null
-}
-
 async function save(account: Omit<ModelAccount, 'connectedAt'>): Promise<void> {
   const now = Date.now()
   const row = {
@@ -172,6 +163,29 @@ async function save(account: Omit<ModelAccount, 'connectedAt'>): Promise<void> {
 
 export async function disconnect(userId: string): Promise<void> {
   await db.delete(modelAccounts).where(eq(modelAccounts.userId, userId))
+}
+
+/**
+ * Write ONLY the refreshed token columns, and only if the row still exists.
+ * A full upsert here would race the user: disconnecting mid-refresh would see
+ * the row re-created, and changing the model mid-refresh would see it reverted
+ * to whatever this refresh started with.
+ */
+async function saveRefreshedTokens(
+  userId: string,
+  tokens: { accessToken: string; refreshToken: string; expiresAt: number; accountId?: string; plan?: string },
+): Promise<void> {
+  await db
+    .update(modelAccounts)
+    .set({
+      accessToken: tokens.accessToken,
+      refreshToken: tokens.refreshToken,
+      expiresAt: tokens.expiresAt,
+      ...(tokens.accountId ? { accountId: tokens.accountId } : {}),
+      ...(tokens.plan ? { plan: tokens.plan } : {}),
+      updatedAt: Date.now(),
+    })
+    .where(eq(modelAccounts.userId, userId))
 }
 
 /* ---------------------------------------------------------------- */
@@ -463,20 +477,30 @@ export async function beginDeviceAuth(userId: string): Promise<DeviceFlow> {
     at: Date.now(),
   }
   deviceFlows.set(userId, flow)
-  void pollDeviceAuth(userId, deviceAuthId, userCode, Math.max(1, Number(parsed.interval) || 5) * 1000)
+  /* the poller is handed the flow object it owns, so a restart's poller can
+     never write its outcome into the replacement flow */
+  void pollDeviceAuth(userId, flow, deviceAuthId, userCode, Math.max(1, Number(parsed.interval) || 5) * 1000)
   return { userCode: flow.userCode, verificationUrl: flow.verificationUrl, status: 'pending' }
 }
 
-async function pollDeviceAuth(userId: string, deviceAuthId: string, userCode: string, intervalMs: number) {
+async function pollDeviceAuth(
+  userId: string,
+  own: DeviceState,
+  deviceAuthId: string,
+  userCode: string,
+  intervalMs: number,
+) {
   const deadline = Date.now() + DEVICE_TTL_MS
+  /* this poller only ever owns the flow it was started for — if the user
+     restarted, `own` is no longer the live entry and its result is stale */
+  const live = () => (!own.cancelled && deviceFlows.get(userId) === own ? own : null)
   const fail = (message: string) => {
-    const flow = deviceFlows.get(userId)
-    if (flow && !flow.cancelled) Object.assign(flow, { status: 'error', error: message })
+    const flow = live()
+    if (flow) Object.assign(flow, { status: 'error', error: message })
   }
   while (Date.now() < deadline) {
     await new Promise((resolve) => setTimeout(resolve, intervalMs))
-    const flow = deviceFlows.get(userId)
-    if (!flow || flow.cancelled) return
+    if (!live()) return
     let res: Response
     try {
       res = await deviceRequest('/deviceauth/token', { device_auth_id: deviceAuthId, user_code: userCode })
@@ -504,8 +528,8 @@ async function pollDeviceAuth(userId: string, deviceAuthId: string, userCode: st
       /* the device flow hands back a normal PKCE pair; the exchange and the
          account write are exactly the browser flow's */
       await exchangeAndSave(userId, granted.authorization_code, granted.code_verifier, DEVICE_REDIRECT_URI)
-      const done = deviceFlows.get(userId)
-      if (done && !done.cancelled) done.status = 'connected'
+      const done = live()
+      if (done) done.status = 'connected'
     } catch (err) {
       fail(err instanceof Error ? err.message : 'Could not finish connecting that account')
     }
@@ -658,7 +682,13 @@ export async function withFreshToken(account: ModelAccount): Promise<ModelAccoun
       ...(auth.chatgpt_account_id ? { accountId: auth.chatgpt_account_id } : {}),
       ...(auth.chatgpt_plan_type ? { plan: auth.chatgpt_plan_type } : {}),
     }
-    await save(next)
+    await saveRefreshedTokens(account.userId, {
+      accessToken: next.accessToken!,
+      refreshToken: next.refreshToken!,
+      expiresAt: next.expiresAt!,
+      ...(auth.chatgpt_account_id ? { accountId: auth.chatgpt_account_id } : {}),
+      ...(auth.chatgpt_plan_type ? { plan: auth.chatgpt_plan_type } : {}),
+    })
     return next
   })().finally(() => refreshing.delete(account.userId))
   refreshing.set(account.userId, task)

--- a/server/resident.ts
+++ b/server/resident.ts
@@ -55,13 +55,18 @@ export function onFeedback(canvasId: string) {
  *  queue between runs is what carries a card into its next pipeline stage. */
 async function sweep(canvasId: string) {
   running.add(canvasId)
+  /* Requesters with no usable model right now. A run bills one person, so
+     without this a requester who cannot pay would be re-picked forever and
+     block everyone queued behind them. */
+  const stalled = new Set<string>()
   try {
     for (let i = 0; i < MAX_SWEEP_RUNS; i++) {
       const next = actions.pendingWorkAgents(canvasId)[0]
       if (!next) break
-      /* a run that claimed nothing leaves the queue exactly as it found it —
-         going round again would spin on the same work forever */
-      if (!(await runAgent(canvasId, next))) break
+      const outcome = await runAgent(canvasId, next, stalled)
+      /* 'idle' means nothing left this sweep can claim — going round again
+         would spin on the same work forever */
+      if (outcome === 'idle') break
     }
   } finally {
     running.delete(canvasId)
@@ -154,26 +159,38 @@ function strategyFor(text: string, frames: NonNullable<ReturnType<typeof store.g
   )
 }
 
-/** Returns false when the run claimed nothing — no model to run it, or no
- *  work actually waiting for this agent. */
-async function runAgent(canvasId: string, agentName: string): Promise<boolean> {
+type RunOutcome = 'ran' | 'idle' | 'no-model'
+
+/**
+ * Work one requester's queue for one agent. A run bills exactly one person:
+ * the account behind the oldest claimable item, resolved BEFORE anything is
+ * claimed so a server with no model at all leaves the queue untouched.
+ */
+async function runAgent(canvasId: string, agentName: string, stalled: Set<string>): Promise<RunOutcome> {
   const role = roleByAgentName(agentName) ?? roleById(DEFAULT_ROLE_ID)!
-  /* Whoever asked for this work is whose account runs it, once their free
-     tasks are gone. The canvas owner is the fallback for work queued before
-     requests carried an account id. Chosen BEFORE anything is claimed, so a
-     server with no model at all leaves the queue untouched. */
+  const payer = actions.nextWorkPayer(canvasId, role.name, stalled)
+  if (payer === undefined) return 'idle'
+  /* Only work that predates per-user attribution falls back to the canvas
+     owner — a real requester never bills a collaborator or the owner. */
   const canvasOwner = store.getCanvas(canvasId)?.ownerId
-  const model = await pickModel([...actions.pendingWorkUserIds(canvasId, role.name), canvasOwner])
-  if (!model) return false
+  const model = await pickModel(payer || canvasOwner)
+  if (!model) {
+    stalled.add(payer)
+    return 'no-model'
+  }
   const actor = actions.resolveActor({ name: role.name, kind: 'agent' })
 
   /* claim this agent's open work — the UI flips to "picked up" instantly.
      Claiming happens before the try so an agent with nothing to do never
      shows up in presence. */
-  const claimed = actions.takeFeedbackFor(canvasId, role.name)
-  const comments = actions.takeAgentCommentsFor(canvasId, role.name)
-  const cards = actions.takeQueuedCardsFor(canvasId, role.name)
-  if (claimed.length === 0 && comments.length === 0 && cards.length === 0) return false
+  const claimed = actions.takeFeedbackFor(canvasId, role.name, payer)
+  const comments = actions.takeAgentCommentsFor(canvasId, role.name, payer)
+  const cards = actions.takeQueuedCardsFor(canvasId, role.name, payer)
+  if (claimed.length === 0 && comments.length === 0 && cards.length === 0) {
+    /* nothing actually claimable for this payer — do not re-pick them */
+    stalled.add(payer)
+    return 'no-model'
+  }
 
   /* presence otherwise only refreshes on tool activity, and the sweep's TTL
      is shorter than a big generation turn */
@@ -448,7 +465,7 @@ async function runAgent(canvasId: string, agentName: string): Promise<boolean> {
     /* clear the status — this completes the agent's task in the panel */
     actions.setAgentStatus(canvasId, actor, '')
   }
-  return true
+  return 'ran'
 }
 
 const TOOLS: Anthropic.Tool[] = [

--- a/tests/residentQueue.test.ts
+++ b/tests/residentQueue.test.ts
@@ -1,0 +1,155 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { AgentTask, ElementComment, TaskFeedback } from '../shared/types.ts'
+
+/* The queue functions mirror every claim into Postgres and broadcast it; a
+   unit test only cares about which items get claimed, so both are stubbed. */
+vi.mock('../server/db/persist.ts', () => ({
+  saveTask: () => {},
+  saveFeedback: () => {},
+  saveComment: () => {},
+  saveActivity: () => {},
+  saveDecision: () => {},
+  saveProposal: () => {},
+}))
+
+const actions = await import('../server/actions.ts')
+const { DEFAULT_ROLE_ID, roleName } = await import('../shared/agents.ts')
+
+const AGENT = roleName(DEFAULT_ROLE_ID)
+const CANVAS = 'canvas-1'
+
+/**
+ * A run must bill exactly ONE person. Before this, a sweep claimed every
+ * pending item for a role and ran them all on whichever connected account was
+ * found first — so one collaborator's ChatGPT subscription paid for another's
+ * cards. These tests pin the ordering and the isolation between requesters.
+ */
+
+function card(id: string, userId: string | undefined, at: number): AgentTask {
+  return {
+    id,
+    agentName: '',
+    color: '#000',
+    status: `card ${id}`,
+    startedAt: at,
+    queuedBy: userId ?? 'legacy',
+    ...(userId ? { queuedByUserId: userId } : {}),
+    stage: 0,
+  }
+}
+
+function feedback(id: string, userId: string, at: number): TaskFeedback {
+  return {
+    id,
+    taskId: `t-${id}`,
+    canvasId: CANVAS,
+    agentName: AGENT,
+    targetAgent: AGENT,
+    from: userId,
+    fromUserId: userId,
+    text: id,
+    at,
+  }
+}
+
+function comment(id: string, userId: string, at: number): ElementComment {
+  return {
+    id,
+    canvasId: CANVAS,
+    frameId: 'f1',
+    selector: '.x',
+    snippet: '<p/>',
+    from: userId,
+    fromUserId: userId,
+    text: id,
+    at,
+    forAgent: true,
+    targetAgent: AGENT,
+  }
+}
+
+function seed(opts: { tasks?: AgentTask[]; feedback?: TaskFeedback[]; comments?: ElementComment[] }) {
+  actions.hydrateLogs({
+    tasks: new Map([[CANVAS, opts.tasks ?? []]]),
+    feedback: new Map([[CANVAS, opts.feedback ?? []]]),
+    comments: new Map([[CANVAS, opts.comments ?? []]]),
+    activity: new Map(),
+    decisions: new Map(),
+    proposals: new Map(),
+  })
+}
+
+beforeEach(() => {
+  actions.wire(
+    () => {},
+    () => {},
+  )
+  seed({})
+})
+
+describe('who pays for the next run', () => {
+  it('picks the requester behind the oldest claimable item', () => {
+    seed({ tasks: [card('newer', 'bob', 2000), card('older', 'alice', 1000)] })
+    expect(actions.nextWorkPayer(CANVAS, AGENT)).toBe('alice')
+  })
+
+  it('compares ages across cards, comments and feedback, not within each kind', () => {
+    seed({
+      tasks: [card('c1', 'bob', 3000)],
+      comments: [comment('m1', 'alice', 1000)],
+      feedback: [feedback('f1', 'carol', 2000)],
+    })
+    expect(actions.nextWorkPayer(CANVAS, AGENT)).toBe('alice')
+  })
+
+  it('reports work with no recorded requester as unattributed', () => {
+    seed({ tasks: [card('legacy', undefined, 1000)] })
+    expect(actions.nextWorkPayer(CANVAS, AGENT)).toBe('')
+  })
+
+  it('skips a requester who cannot pay so they never block the queue behind them', () => {
+    seed({ tasks: [card('c1', 'alice', 1000), card('c2', 'bob', 2000)] })
+    expect(actions.nextWorkPayer(CANVAS, AGENT, new Set(['alice']))).toBe('bob')
+    expect(actions.nextWorkPayer(CANVAS, AGENT, new Set(['alice', 'bob']))).toBeUndefined()
+  })
+
+  it('is undefined when nothing is waiting', () => {
+    expect(actions.nextWorkPayer(CANVAS, AGENT)).toBeUndefined()
+  })
+})
+
+describe('a run claims only its payer', () => {
+  it('leaves other requesters cards untouched', () => {
+    seed({ tasks: [card('a1', 'alice', 1000), card('b1', 'bob', 2000), card('a2', 'alice', 3000)] })
+    const claimed = actions.takeQueuedCardsFor(CANVAS, AGENT, 'alice')
+    expect(claimed.map((c) => c.id).sort()).toEqual(['a1', 'a2'])
+    /* bob's card is still open, so the next run picks him up and bills him */
+    expect(actions.nextWorkPayer(CANVAS, AGENT)).toBe('bob')
+  })
+
+  it('isolates comments and feedback by requester too', () => {
+    seed({
+      comments: [comment('m-alice', 'alice', 1000), comment('m-bob', 'bob', 1100)],
+      feedback: [feedback('f-alice', 'alice', 1200), feedback('f-bob', 'bob', 1300)],
+    })
+    expect(actions.takeAgentCommentsFor(CANVAS, AGENT, 'alice').map((c) => c.id)).toEqual(['m-alice'])
+    expect(actions.takeFeedbackFor(CANVAS, AGENT, 'alice').map((f) => f.id)).toEqual(['f-alice'])
+    expect(actions.nextWorkPayer(CANVAS, AGENT)).toBe('bob')
+  })
+
+  it('claims unattributed work without dragging in an identified requester', () => {
+    seed({ tasks: [card('legacy', undefined, 1000), card('a1', 'alice', 2000)] })
+    expect(actions.takeQueuedCardsFor(CANVAS, AGENT, '').map((c) => c.id)).toEqual(['legacy'])
+    expect(actions.nextWorkPayer(CANVAS, AGENT)).toBe('alice')
+  })
+
+  it('still claims everything when no payer is given (the pre-existing callers)', () => {
+    seed({ tasks: [card('a1', 'alice', 1000), card('b1', 'bob', 2000)] })
+    expect(
+      actions
+        .takeQueuedCardsFor(CANVAS, AGENT)
+        .map((c) => c.id)
+        .sort(),
+    ).toEqual(['a1', 'b1'])
+  })
+})


### PR DESCRIPTION
A run bills exactly one person: the account behind the oldest claimable item, resolved before anything is claimed, so a server with no model at all leaves the queue untouched. Only work that predates per-user attribution falls back to the canvas owner — a real requester never bills a collaborator or the owner.

Also closes two races around connecting/disconnecting a model account mid-run.

Stacked on #14 — this PR shows only its own commit and retargets to `main` when #14 merges.

Ported from the upstream private repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)