### PR TITLE
fix(agent): read Codex-backend output from streamed items, not the completed event

### DIFF
--- a/server/openaiAgent.ts
+++ b/server/openaiAgent.ts
@@ -240,12 +240,21 @@ function fromResponse(body: ResponseBody): TurnResult {
 /* transports                                                       */
 /* ---------------------------------------------------------------- */
 
-/** Pull the final response object out of a Responses SSE stream. */
+/**
+ * Pull the final response out of a Responses SSE stream.
+ *
+ * The output items are accumulated from `response.output_item.done` rather
+ * than read off the terminal event: ChatGPT's Codex backend sends a
+ * `response.completed` that carries only bookkeeping (id, usage, end_turn)
+ * and no output array, so trusting that event alone yields an empty turn.
+ * api.openai.com does include the array, and it wins when present.
+ */
 async function readEventStream(res: Response): Promise<ResponseBody> {
   if (!res.body) throw new Error('OpenAI returned no response body')
   const reader = res.body.getReader()
   const decoder = new TextDecoder()
   let buffer = ''
+  const streamed: NonNullable<ResponseBody['output']> = []
   let final: ResponseBody | undefined
   let failure: string | undefined
   for (;;) {
@@ -259,20 +268,27 @@ async function readEventStream(res: Response): Promise<ResponseBody> {
       if (!line.startsWith('data:')) continue
       const payload = line.slice(5).trim()
       if (!payload || payload === '[DONE]') continue
-      let event: { type?: string; response?: ResponseBody; error?: { message?: string }; message?: string }
+      let event: {
+        type?: string
+        response?: ResponseBody
+        item?: NonNullable<ResponseBody['output']>[number]
+        error?: { message?: string }
+        message?: string
+      }
       try {
         event = JSON.parse(payload)
       } catch {
         continue
       }
-      if (event.type === 'response.completed' || event.type === 'response.incomplete') final = event.response
+      if (event.type === 'response.output_item.done' && event.item) streamed.push(event.item)
+      else if (event.type === 'response.completed' || event.type === 'response.incomplete') final = event.response
       else if (event.type === 'response.failed') failure = event.response?.error?.message || 'the response failed'
       else if (event.type === 'error') failure = event.error?.message || event.message || 'stream error'
     }
   }
   if (failure) throw new Error(failure)
   if (!final) throw new Error('OpenAI stream ended without a completed response')
-  return final
+  return final.output?.length ? final : { ...final, output: streamed }
 }
 
 async function failure(res: Response, label: string): Promise<Error> {
@@ -342,4 +358,4 @@ export function runOpenAiTurn(account: ModelAccount, req: TurnRequest): Promise<
 }
 
 /* exported for tests */
-export const _internal = { toInput, toTools, fromResponse, flattenToolResult }
+export const _internal = { toInput, toTools, fromResponse, flattenToolResult, readEventStream }

--- a/tests/openaiAgent.test.ts
+++ b/tests/openaiAgent.test.ts
@@ -167,3 +167,63 @@ describe('ChatGPT redirect parsing', () => {
     expect(() => parseAuthCode('http://localhost:1455/auth/callback')).toThrow(/no \?code=/)
   })
 })
+
+describe('Codex-backend SSE stream', () => {
+  const sse = (lines: string[]) =>
+    new Response(
+      new ReadableStream({
+        start(controller) {
+          for (const l of lines) controller.enqueue(new TextEncoder().encode(l))
+          controller.close()
+        },
+      }),
+    )
+
+  /* The Codex backend's response.completed carries only bookkeeping — reading
+     output off it alone produced an empty turn on every real run. */
+  it('accumulates output items when the completed event carries no output', async () => {
+    const body = await _internal.readEventStream(
+      sse([
+        'data: {"type":"response.created","response":{"id":"resp_1"}}\n',
+        'data: {"type":"response.output_item.done","item":{"type":"reasoning","id":"rs_1"}}\n',
+        'data: {"type":"response.output_item.done","item":{"type":"function_call","call_id":"call_1","name":"set_status","arguments":"{\\"status\\":\\"Working\\"}"}}\n',
+        'data: {"type":"response.completed","response":{"id":"resp_1","status":"completed"}}\n',
+        'data: [DONE]\n',
+      ]),
+    )
+    const result = fromResponse(body)
+    expect(result.stop_reason).toBe('tool_use')
+    expect(result.content).toEqual([
+      { type: 'tool_use', id: 'call_1', name: 'set_status', input: { status: 'Working' } },
+    ])
+  })
+
+  it('prefers the completed event own output when it has one (api.openai.com)', async () => {
+    const body = await _internal.readEventStream(
+      sse([
+        'data: {"type":"response.output_item.done","item":{"type":"message","content":[{"type":"output_text","text":"streamed"}]}}\n',
+        'data: {"type":"response.completed","response":{"status":"completed","output":[{"type":"message","content":[{"type":"output_text","text":"authoritative"}]}]}}\n',
+      ]),
+    )
+    expect(fromResponse(body).content).toEqual([{ type: 'text', text: 'authoritative' }])
+  })
+
+  it('surfaces a failed stream instead of reporting an empty turn', async () => {
+    await expect(
+      _internal.readEventStream(
+        sse(['data: {"type":"response.failed","response":{"error":{"message":"model overloaded"}}}\n']),
+      ),
+    ).rejects.toThrow(/model overloaded/)
+  })
+
+  it('handles events split across chunk boundaries', async () => {
+    const body = await _internal.readEventStream(
+      sse([
+        'data: {"type":"response.output_item.done","item":{"type":"mess',
+        'age","content":[{"type":"output_text","text":"split"}]}}\n',
+        'data: {"type":"response.completed","response":{"status":"completed"}}\n',
+      ]),
+    )
+    expect(fromResponse(body).content).toEqual([{ type: 'text', text: 'split' }])
+  })
+})


### PR DESCRIPTION
The Codex backend's `response.completed` event does not carry the assembled output the way the standard Responses API does, so a run that clearly produced text ended with the agent reporting nothing. Assemble the output from the streamed items instead, which both backends deliver.

Stacked on #14 (only touches `server/openaiAgent.ts` + its tests).

Ported from the upstream private repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)