### PR TITLE
feat(admin): restyle /admin to match home and settings

### DIFF
--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -2,12 +2,15 @@ import { useEffect, useState } from 'react'
 import { adminApi, type AdminCanvas, type AdminUser } from '../lib/api'
 import { navigate, Logo } from '../App'
 import { timeAgo } from '../lib/time'
+import { AccountMenu, ConnectCard, IconBack, IconChevron, IconGrid, IconShare } from '../components/DashShell'
 
 /**
  * The instance index: every canvas, every account. Read-only — the way to
  * look inside someone's canvas is "view as", which hands you a real (but
  * read-only, 15-minute) session as its owner rather than granting admins a
  * privileged read path through the canvas gate.
+ *
+ * Same shell as home and settings; the rail's middle carries the two indexes.
  */
 export function Admin() {
   const [data, setData] = useState<{ total: number; canvases: AdminCanvas[] } | null>(null)
@@ -66,139 +69,173 @@ export function Admin() {
   )
 
   return (
-    <div className="home admin">
-      <div className="home-inner">
-        <div className="home-mark">
-          <Logo /> Doop
-          <span className="chip admin-chip">admin</span>
-          <span className="spacer" />
-          <button className="btn ghost" onClick={() => navigate('/')}>
-            Back to my canvases
+    <div className="dash">
+      <aside className="dash-rail">
+        <div className="home-mark dash-brand">
+          <Logo /> Doop <span className="chip admin-chip">admin</span>
+        </div>
+
+        <button className="dash-back" onClick={() => navigate('/')}>
+          <IconBack /> Back to my canvases
+        </button>
+
+        <div className="dash-label">Instance</div>
+        <nav className="dash-nav">
+          <button
+            className={`dash-nav-item${tab === 'canvases' ? ' on' : ''}`}
+            onClick={() => setTab('canvases')}
+            aria-current={tab === 'canvases' ? 'page' : undefined}
+          >
+            <IconGrid /> Canvases
+            <span className="dash-nav-count">{stats?.canvases ?? ''}</span>
           </button>
-        </div>
+          <button
+            className={`dash-nav-item${tab === 'users' ? ' on' : ''}`}
+            onClick={() => setTab('users')}
+            aria-current={tab === 'users' ? 'page' : undefined}
+          >
+            <IconShare /> Accounts
+            <span className="dash-nav-count">{stats?.users ?? ''}</span>
+          </button>
+        </nav>
 
-        <h1>
-          Everything on this instance<em>.</em>
-        </h1>
-        <p className="sub">
-          {stats
-            ? `${stats.users} ${stats.users === 1 ? 'account' : 'accounts'} · ${stats.canvases} ${
-                stats.canvases === 1 ? 'canvas' : 'canvases'
-              } · ${stats.frames} ${stats.frames === 1 ? 'frame' : 'frames'}`
-            : '…'}
-        </p>
+        <div className="dash-grow" />
+        <ConnectCard />
+      </aside>
 
-        <div className="admin-controls">
-          <div className="admin-tabs">
-            <button className={`btn ghost${tab === 'canvases' ? ' on' : ''}`} onClick={() => setTab('canvases')}>
-              Canvases
-            </button>
-            <button className={`btn ghost${tab === 'users' ? ' on' : ''}`} onClick={() => setTab('users')}>
-              Accounts
-            </button>
-          </div>
-          <input
-            className="admin-search"
-            placeholder={tab === 'canvases' ? 'Search canvases or owners…' : 'Search accounts…'}
-            value={q}
-            onChange={(e) => setQ(e.target.value)}
-          />
-        </div>
+      <section className="dash-main">
+        <header className="dash-top">
+          <nav className="dash-crumb" aria-label="Breadcrumb">
+            <button onClick={() => navigate('/')}>Home</button>
+            <IconChevron />
+            <b>Admin</b>
+          </nav>
+          <label className="dash-search">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+              <circle cx="11" cy="11" r="7" />
+              <path d="m20 20-3.2-3.2" />
+            </svg>
+            <input
+              value={q}
+              onChange={(e) => setQ(e.target.value)}
+              placeholder={tab === 'canvases' ? 'Search canvases or owners…' : 'Search accounts…'}
+              aria-label={tab === 'canvases' ? 'Search canvases or owners' : 'Search accounts'}
+            />
+          </label>
+          <span className="spacer" />
+          <AccountMenu />
+        </header>
 
-        {tab === 'canvases' && (
-          <>
-            {data && data.total > data.canvases.length && (
-              <p className="sub small">
-                Showing the {data.canvases.length} most recently updated of {data.total}.
+        <div className="dash-body">
+          <div className="dash-head">
+            <div>
+              <h1>
+                Everything on this instance<em>.</em>
+              </h1>
+              <p className="sub">
+                {stats
+                  ? `${stats.users} ${stats.users === 1 ? 'account' : 'accounts'} · ${stats.canvases} ${
+                      stats.canvases === 1 ? 'canvas' : 'canvases'
+                    } · ${stats.frames} ${stats.frames === 1 ? 'frame' : 'frames'}`
+                  : '…'}
               </p>
-            )}
-            <div className="canvas-grid">
-              {data === null &&
-                [0, 1, 2].map((i) => (
-                  <div key={i} className="canvas-card skeleton" style={{ animationDelay: `${i * 0.12}s` }} />
-                ))}
-              {canvases.map((c) => (
-                <div key={c.id} className="canvas-card admin-card">
-                  <div className="card-preview">
-                    {c.previewFrameId ? (
-                      <img
-                        src={`/i/${c.previewFrameId}.jpg`}
-                        alt=""
-                        loading="lazy"
-                        onError={(e) => {
-                          e.currentTarget.style.display = 'none'
-                        }}
-                      />
-                    ) : (
-                      <span className="card-blank">empty canvas</span>
-                    )}
-                  </div>
-                  <div className="card-info">
-                    <div className="name">{c.name}</div>
-                    <div className="meta">
-                      <span>{c.owner ? c.owner.name : 'unclaimed'}</span>
-                      <span className="dot">·</span>
-                      <span>
-                        {c.frameCount} frame{c.frameCount === 1 ? '' : 's'}
-                      </span>
-                      <span className="dot">·</span>
-                      <span>{timeAgo(c.updatedAt)}</span>
-                      {c.linkAccess === 'edit' && (
-                        <>
-                          <span className="dot">·</span>
-                          <span title="Anyone with the link can edit this canvas">link on</span>
-                        </>
-                      )}
-                      {c.memberCount > 0 && (
-                        <>
-                          <span className="dot">·</span>
-                          <span>{c.memberCount} invited</span>
-                        </>
+            </div>
+          </div>
+
+          {tab === 'canvases' ? (
+            <>
+              {data && data.total > data.canvases.length && (
+                <div className="dash-tools">
+                  <span className="dash-count">
+                    Showing the {data.canvases.length} most recently updated of {data.total}
+                  </span>
+                </div>
+              )}
+              <div className="canvas-grid">
+                {data === null &&
+                  [0, 1, 2, 3].map((i) => (
+                    <div key={i} className="canvas-card skeleton" style={{ animationDelay: `${i * 0.12}s` }} />
+                  ))}
+                {canvases.map((c) => (
+                  <div key={c.id} className="canvas-card admin-card">
+                    <div className="card-preview">
+                      {c.previewFrameId ? (
+                        <img
+                          src={`/i/${c.previewFrameId}.jpg`}
+                          alt=""
+                          loading="lazy"
+                          onError={(e) => {
+                            e.currentTarget.style.display = 'none'
+                          }}
+                        />
+                      ) : (
+                        <span className="card-blank">empty canvas</span>
                       )}
                     </div>
-                    {c.owner && (
-                      <button className="btn ghost small" onClick={() => viewAs(c.owner!.id)}>
-                        View as {c.owner.name.split(' ')[0]}
-                      </button>
-                    )}
+                    <div className="card-info">
+                      <div className="name">{c.name}</div>
+                      <div className="meta">
+                        <span>{c.owner ? c.owner.name : 'unclaimed'}</span>
+                        <span className="dot">·</span>
+                        <span>
+                          {c.frameCount} frame{c.frameCount === 1 ? '' : 's'}
+                        </span>
+                        <span className="dot">·</span>
+                        <span>{timeAgo(c.updatedAt)}</span>
+                        {c.linkAccess === 'edit' && (
+                          <span className="chip" title="Anyone with the link can edit this canvas">
+                            link on
+                          </span>
+                        )}
+                        {c.memberCount > 0 && (
+                          <>
+                            <span className="dot">·</span>
+                            <span>{c.memberCount} invited</span>
+                          </>
+                        )}
+                      </div>
+                      {c.owner && (
+                        <button className="btn ghost small" onClick={() => viewAs(c.owner!.id)}>
+                          View as {c.owner.name.split(' ')[0]}
+                        </button>
+                      )}
+                    </div>
                   </div>
+                ))}
+              </div>
+            </>
+          ) : (
+            <div className="dash-list admin-users">
+              {users === null && <p className="dash-none">…</p>}
+              {shownUsers.map((u) => (
+                <div key={u.id} className="admin-user-row">
+                  <div className="admin-user-info">
+                    <div className="name">
+                      {u.name}
+                      {u.role === 'admin' && <span className="chip admin-chip">admin</span>}
+                      {u.banned && <span className="chip banned-chip">banned</span>}
+                    </div>
+                    <div className="meta">
+                      <span>{u.email}</span>
+                      <span className="dot">·</span>
+                      <span>
+                        {u.canvasCount} {u.canvasCount === 1 ? 'canvas' : 'canvases'}
+                      </span>
+                      <span className="dot">·</span>
+                      <span>joined {timeAgo(u.createdAt)}</span>
+                    </div>
+                  </div>
+                  {u.role !== 'admin' && (
+                    <button className="btn ghost small" onClick={() => viewAs(u.id)}>
+                      View as
+                    </button>
+                  )}
                 </div>
               ))}
             </div>
-          </>
-        )}
-
-        {tab === 'users' && (
-          <section className="admin-users">
-            {users === null && <p className="sub">…</p>}
-            {shownUsers.map((u) => (
-              <div key={u.id} className="admin-user-row">
-                <div className="admin-user-info">
-                  <div className="name">
-                    {u.name}
-                    {u.role === 'admin' && <span className="chip admin-chip">admin</span>}
-                    {u.banned && <span className="chip banned-chip">banned</span>}
-                  </div>
-                  <div className="meta">
-                    <span>{u.email}</span>
-                    <span className="dot">·</span>
-                    <span>
-                      {u.canvasCount} {u.canvasCount === 1 ? 'canvas' : 'canvases'}
-                    </span>
-                    <span className="dot">·</span>
-                    <span>joined {timeAgo(u.createdAt)}</span>
-                  </div>
-                </div>
-                {u.role !== 'admin' && (
-                  <button className="btn ghost small" onClick={() => viewAs(u.id)}>
-                    View as
-                  </button>
-                )}
-              </div>
-            ))}
-          </section>
-        )}
-      </div>
+          )}
+        </div>
+      </section>
     </div>
   )
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -6752,66 +6752,55 @@ textarea {
   background: rgba(255, 184, 0, 0.12);
 }
 
-.admin-controls {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  margin: 28px 0 18px;
-  flex-wrap: wrap;
-}
-.admin-tabs {
-  display: inline-flex;
-  gap: 8px;
-}
-.admin-tabs .btn.on {
-  border-color: var(--ink);
-  color: var(--ink);
-}
-.admin-search {
-  flex: 1;
-  min-width: 200px;
-  font-family: var(--font-ui);
-  font-size: 14px;
-  padding: 8px 12px;
-  border: 1px solid var(--line);
-  border-radius: 10px;
-  background: var(--surface);
-  color: var(--ink);
-}
-.admin-search:focus {
-  outline: none;
-  border-color: var(--ink-faint);
-}
-
 /* the admin card is a container, not a button: its actions are inside it */
+.canvas-card.admin-card {
+  display: flex;
+  flex-direction: column;
+}
 .canvas-card.admin-card:hover {
   transform: none;
   box-shadow: var(--shadow-card);
   border-color: var(--line);
 }
-.admin-card .card-info .btn {
-  margin-top: 10px;
+.admin-card .card-preview {
+  aspect-ratio: 4 / 3;
 }
-
-.admin-users {
+.admin-card .card-info {
+  flex: 1;
   display: flex;
   flex-direction: column;
-  gap: 8px;
 }
-.admin-user-row {
+/* owner and counts wrap to two lines on some cards — reserving the space keeps
+   the "view as" buttons on one line across a row */
+.admin-card .card-info .meta {
+  min-height: 30px;
+  flex-wrap: wrap;
+  align-content: flex-start;
+}
+.admin-card .card-info .btn {
+  margin-top: auto;
+  align-self: flex-start;
+}
+.admin-card .card-info .meta .chip {
+  font-size: 10px;
+  padding: 1px 5px;
+}
+
+.admin-users .admin-user-row {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 16px;
-  padding: 12px 16px;
-  background: var(--surface);
-  border: 1px solid var(--line);
-  border-radius: 12px;
+  padding: 13px 18px;
+  border-bottom: 1px solid var(--line-soft);
+}
+.admin-users .admin-user-row:last-child {
+  border-bottom: 0;
 }
 .admin-user-row .name {
   font-family: var(--font-display);
   font-weight: 600;
-  font-size: 15px;
+  font-size: 14.5px;
   display: flex;
   align-items: center;
   gap: 8px;
@@ -6821,8 +6810,8 @@ textarea {
   display: flex;
   gap: 6px;
   align-items: center;
-  font-size: 13px;
-  color: var(--ink-soft);
+  font-size: 12.5px;
+  color: var(--ink-faint);
 }
 
 /* impersonation: deliberately loud, and it displaces the page rather than


### PR DESCRIPTION
Brings `/admin` into the workspace-rail visual language introduced in #18 — same shell, same list styling as Home and Settings.

Stacked on #18.

Ported from the upstream private repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)