### PR TITLE
fix(admin): back button during "view as" returns to admin instead of 404

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,6 +28,20 @@ export function App() {
     return () => window.removeEventListener('popstate', onPop)
   }, [])
 
+  /* Reaching /admin mid "view as" — usually the Back button, since /admin
+     stays in history when impersonation starts — can only mean "return to
+     being the admin": the borrowed session has no admin access, so rendering
+     the page would show its not-found screen. End the impersonation and
+     arrive as the admin instead. */
+  const returningToAdmin = !!me?.impersonating && path.startsWith('/admin')
+  useEffect(() => {
+    if (!returningToAdmin) return
+    adminApi
+      .stopImpersonating()
+      .then(() => location.assign('/admin'))
+      .catch(() => location.assign('/'))
+  }, [returningToAdmin])
+
   /* The session is the auth boundary: this covers both successful login and
      restoring an existing session after a page refresh. */
   useEffect(() => {
@@ -73,6 +87,12 @@ export function App() {
     if (path.startsWith('/auth') || path.startsWith('/c/') || oauthResume) return <AuthPage />
     return <Landing />
   }
+
+  /* /admin waits for /api/me: before it answers we can't tell an admin from
+     a borrowed "view as" session, and rendering Admin in the latter flashes
+     its not-found screen. Also blank while the effect above swaps the
+     session back and reloads. */
+  if (path.startsWith('/admin') && (!me || returningToAdmin)) return <div className="auth-page" />
 
   const canvasMatch = path.match(/^\/c\/([^/]+)/)
   const page = canvasMatch ? (

--- a/src/lib/me.ts
+++ b/src/lib/me.ts
@@ -42,11 +42,22 @@ export function useMe(userId: string | undefined): Me | null {
   useEffect(() => {
     if (!userId) return
     let live = true
-    loadMe(userId)
-      .then((m) => live && setMe(m))
-      .catch(() => {})
+    let timer: ReturnType<typeof setTimeout>
+    /* loadMe forgets failures so "the next call" retries — but with a stable
+       userId this effect never runs again, so a transient /api/me failure
+       would otherwise leave `me` null for the whole session (and blank any
+       screen gated on it). Keep calling until it answers. */
+    const attempt = () => {
+      loadMe(userId)
+        .then((m) => live && setMe(m))
+        .catch(() => {
+          if (live) timer = setTimeout(attempt, 3000)
+        })
+    }
+    attempt()
     return () => {
       live = false
+      clearTimeout(timer)
     }
   }, [userId])
   /* never hand back a `me` belonging to a previous identity */


### PR DESCRIPTION
Impersonation swaps the session cookie and navigates away, leaving `/admin` in browser history. Hitting Back landed on `/admin` under the borrowed non-admin session, so the Admin page's deny-as-404 screen fired. Landing on `/admin` mid view-as can only mean "return to being the admin", so end the impersonation and reload `/admin` as the admin. Also hold `/admin` rendering until `/api/me` answers, so the not-found screen can't flash while the session's identity is still unknown.

Also: retry `/api/me` every 3s on failure — a single transient failure left `me` null for the whole session, which the `/admin` gate turned into a permanently blank page.

Ported from the upstream private repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)