### PR TITLE
fix(importer): skip the scroll walk for Context.dev captures so imports stop hanging

### DIFF
--- a/server/importer.ts
+++ b/server/importer.ts
@@ -528,36 +528,42 @@ export async function importPage(rawUrl: string, options: { includePreview?: boo
       await assertPublicNetworkUrl(page.url())
     }
     /* walk the page before capturing: scroll-reveal animations and lazy
-       images only materialize once their elements have been in view */
-    await page.evaluate(async () => {
-      /* the window isn't always the scroller — app-shell pages scroll an
+       images only materialize once their elements have been in view. Skip it
+       for Context.dev captures: scripts are disabled there, which makes
+       Chromium load loading="lazy" images eagerly, run no scroll-reveal
+       code — and never fire the timers this walk awaits, so the evaluate
+       promise would hang until Chromium collects it and the import fails. */
+    if (!contextCapture) {
+      await page.evaluate(async () => {
+        /* the window isn't always the scroller — app-shell pages scroll an
          overflow container. Walk the tallest scrollables too. */
-      const scrollables: (Element | null)[] = [document.scrollingElement]
-      for (const el of Array.from(document.querySelectorAll('body, body *')).slice(0, 4000)) {
-        if (el.scrollHeight > el.clientHeight + 300 && el.clientHeight > 200) {
-          const o = getComputedStyle(el).overflowY
-          if (o === 'auto' || o === 'scroll') scrollables.push(el)
+        const scrollables: (Element | null)[] = [document.scrollingElement]
+        for (const el of Array.from(document.querySelectorAll('body, body *')).slice(0, 4000)) {
+          if (el.scrollHeight > el.clientHeight + 300 && el.clientHeight > 200) {
+            const o = getComputedStyle(el).overflowY
+            if (o === 'auto' || o === 'scroll') scrollables.push(el)
+          }
         }
-      }
-      const targets = scrollables
-        .filter((el): el is Element => !!el)
-        .sort((a, b) => b.scrollHeight - a.scrollHeight)
-        .slice(0, 3)
-      for (const el of targets) {
-        let y = 0
-        for (let i = 0; i < 40; i++) {
-          y += 700
-          el.scrollTop = y
-          window.scrollTo(0, y)
-          await new Promise((r) => setTimeout(r, 120))
-          if (y >= el.scrollHeight) break
+        const targets = scrollables
+          .filter((el): el is Element => !!el)
+          .sort((a, b) => b.scrollHeight - a.scrollHeight)
+          .slice(0, 3)
+        for (const el of targets) {
+          let y = 0
+          for (let i = 0; i < 40; i++) {
+            y += 700
+            el.scrollTop = y
+            window.scrollTo(0, y)
+            await new Promise((r) => setTimeout(r, 120))
+            if (y >= el.scrollHeight) break
+          }
+          el.scrollTop = 0
         }
-        el.scrollTop = 0
-      }
-      window.scrollTo(0, 0)
-      await new Promise((r) => setTimeout(r, 400))
-    })
-    await new Promise((r) => setTimeout(r, 600)) // late layout/lazy paint
+        window.scrollTo(0, 0)
+        await new Promise((r) => setTimeout(r, 400))
+      })
+      await new Promise((r) => setTimeout(r, 600)) // late layout/lazy paint
+    }
 
     const snap = await page.evaluate((maxHeight: number) => {
       for (const el of document.querySelectorAll(

--- a/tests/importer.test.ts
+++ b/tests/importer.test.ts
@@ -39,12 +39,16 @@ interface PageStubOptions {
   preview?: { description: string; text: string; pageHeight: number; hasVisualContent?: boolean }
   screenshot?: Buffer
   snapshot?: { baseUrl?: string; sheets: string[]; title: string; height: number; html: string }
+  /** Context.dev captures render with scripts disabled, so importPage skips
+   *  the scroll-walk evaluate — the stub's call sequence must match. */
+  contextPath?: boolean
 }
 
 function stubPage(options: PageStubOptions = {}) {
   const finalUrl = options.finalUrl ?? 'https://example.com/final'
   const mainFrame = {}
-  const evaluate = vi.fn().mockResolvedValueOnce(undefined)
+  const evaluate = vi.fn()
+  if (!options.contextPath) evaluate.mockResolvedValueOnce(undefined)
   evaluate.mockResolvedValueOnce(
     options.snapshot ?? {
       sheets: [],
@@ -197,6 +201,7 @@ describe('webpage capture', () => {
     })
     const page = stubPage({
       finalUrl: 'about:blank',
+      contextPath: true,
       snapshot: {
         baseUrl: 'https://www.example.com/assets/',
         sheets: [],
@@ -242,6 +247,7 @@ describe('webpage capture', () => {
     )
     const page = stubPage({
       finalUrl: 'about:blank',
+      contextPath: true,
       snapshot: {
         sheets: ['https://example.com/app.css'],
         title: 'Context title',
@@ -276,6 +282,7 @@ describe('webpage capture', () => {
       )
     const page = stubPage({
       finalUrl: 'about:blank',
+      contextPath: true,
       snapshot: {
         sheets: ['https://example.com/reset.css', 'https://example.com/app.css'],
         title: 'Context title',
@@ -333,6 +340,7 @@ describe('webpage capture', () => {
     const screenshot = Buffer.from('local-preview')
     const page = stubPage({
       finalUrl: 'about:blank',
+      contextPath: true,
       preview: { description: '', text: 'Rendered Context page', pageHeight: 700 },
       screenshot,
     })


### PR DESCRIPTION
Context.dev captures render locally with JavaScript disabled, and Chromium never fires `setTimeout` callbacks inside `page.evaluate` when script execution is disabled. The lazy-load scroll walk awaits those timers, so its evaluate promise hung until Chromium collected it and every Context.dev-backed import failed with the generic "could not finish rendering" error.

The walk is also unnecessary on that path: with scripting disabled there is no scroll-reveal code to trigger and `loading="lazy"` images load eagerly. The no-key local Chromium path keeps the walk unchanged.

Ported from the upstream private repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)