### PR TITLE
feat(canvas): render append_frame_html chunks instantly instead of pacing them

### DIFF
--- a/server/actions.ts
+++ b/server/actions.ts
@@ -754,29 +754,47 @@ export function retryCard(canvasId: string, cardId: string, by: string): AgentTa
 }
 
 /* ------------------------------------------------------------------ */
-/* Typewriter reveal: agent HTML lands in the store immediately, but   */
-/* viewers see it revealed at a steady rate so even one-shot updates   */
-/* play back as a live stream (à la paper.design).                     */
+/* Live rendering of agent writes.                                     */
+/*                                                                     */
+/* Streams (append_frame_html): every chunk broadcasts the moment it   */
+/* arrives — viewers track the agent's real progress with no artificial*/
+/* pacing. Stream state only carries the "designing…" badge, the       */
+/* escape latch, and a timeout for agents that never send done=true.   */
+/*                                                                     */
+/* One-shot writes (set_frame_html, agent create_frame with html) play */
+/* back as a short typewriter reveal so a paste reads as designing     */
+/* rather than blinking in — drained against a fixed deadline so       */
+/* playback time never grows with document size.                       */
 /* ------------------------------------------------------------------ */
 
-interface RevealState {
+interface StreamState {
   actor: Actor
-  /** how many chars of the frame's html are currently revealed to viewers */
-  shown: number
-  /** originated from append_frame_html (logs "finished designing" when done) */
-  isStream: boolean
-  /** the stream got its final chunk; finish once the reveal catches up */
-  pendingDone: boolean
   /** the opening chunk was HTML-escaped: decode every chunk of this stream */
   escaped: boolean
   lastActivity: number
 }
 
+const streams = new Map<string, StreamState>() // frameId -> state
+
+interface RevealState {
+  actor: Actor
+  /** how many chars of the frame's html are currently revealed to viewers */
+  shown: number
+  /** when the playback should have fully drained */
+  deadline: number
+}
+
 const reveals = new Map<string, RevealState>() // frameId -> state
 
 const TICK_MS = 80
-const MIN_CHARS_PER_TICK = 40 // ~500 chars/s floor
-const CATCHUP_TICKS = 100 // aim to catch up on a backlog within ~8s
+const REVEAL_MIN_MS = 2500 // even a tiny one-shot plays for a beat
+const REVEAL_MAX_MS = 5000 // even a huge one-shot lands within 5s
+const REVEAL_CHARS_PER_MS = 8
+const STREAM_IDLE_MS = 30_000
+
+function revealDuration(chars: number): number {
+  return Math.min(REVEAL_MAX_MS, Math.max(REVEAL_MIN_MS, chars / REVEAL_CHARS_PER_MS))
+}
 
 /** Make partially-revealed HTML paint sensibly. */
 export function healPartialHtml(html: string): string {
@@ -800,23 +818,34 @@ function commonPrefixLen(a: string, b: string): number {
   return i
 }
 
-function startReveal(frame: Frame, actor: Actor, shown: number, isStream: boolean) {
-  reveals.set(frame.id, { actor, shown, isStream, pendingDone: false, escaped: false, lastActivity: Date.now() })
+function startReveal(frame: Frame, actor: Actor, shown: number) {
+  reveals.set(frame.id, { actor, shown, deadline: Date.now() + revealDuration(frame.html.length - shown) })
   broadcast(frame.canvasId, { type: 'frame:streaming', frameId: frame.id, active: true, actor })
 }
 
-function finishReveal(frameId: string, logDone: boolean) {
+function finishReveal(frameId: string) {
   const r = reveals.get(frameId)
   if (!r) return
   reveals.delete(frameId)
   const frame = store.getFrame(frameId)
   if (!frame) return
   broadcast(frame.canvasId, { type: 'frame:streaming', frameId, active: false, actor: r.actor })
-  if (logDone) logActivity(frame.canvasId, r.actor, `finished designing “${frame.name}”`, frameId)
   endAutoTask(frame.canvasId, r.actor)
 }
 
+function finishStream(frameId: string, logDone: boolean) {
+  const s = streams.get(frameId)
+  if (!s) return
+  streams.delete(frameId)
+  const frame = store.getFrame(frameId)
+  if (!frame) return
+  broadcast(frame.canvasId, { type: 'frame:streaming', frameId, active: false, actor: s.actor })
+  if (logDone) logActivity(frame.canvasId, s.actor, `finished designing “${frame.name}”`, frameId)
+  endAutoTask(frame.canvasId, s.actor)
+}
+
 setInterval(() => {
+  const now = Date.now()
   for (const [frameId, r] of reveals) {
     const frame = store.getFrame(frameId)
     if (!frame) {
@@ -827,19 +856,20 @@ setInterval(() => {
     const remaining = total - r.shown
 
     if (remaining <= 0) {
-      if (r.pendingDone || !r.isStream) {
-        /* fully revealed and the source is done: emit the exact html and close */
-        broadcast(frame.canvasId, { type: 'frame:updated', frame, actor: r.actor })
-        finishReveal(frameId, r.isStream && r.pendingDone)
-      } else if (Date.now() - r.lastActivity > 30_000) {
-        finishReveal(frameId, false) // agent died mid-stream
-      }
+      /* fully revealed: emit the exact html and close */
+      broadcast(frame.canvasId, { type: 'frame:updated', frame, actor: r.actor })
+      finishReveal(frameId)
       continue
     }
 
-    r.shown = Math.min(total, r.shown + Math.max(MIN_CHARS_PER_TICK, Math.ceil(remaining / CATCHUP_TICKS)))
+    /* drain the rest evenly so the playback lands exactly at the deadline */
+    const ticksLeft = Math.max(1, Math.ceil((r.deadline - now) / TICK_MS))
+    r.shown = Math.min(total, r.shown + Math.ceil(remaining / ticksLeft))
     const partial = r.shown >= total ? frame.html : healPartialHtml(frame.html.slice(0, r.shown))
     broadcast(frame.canvasId, { type: 'frame:updated', frame: { ...frame, html: partial }, actor: r.actor })
+  }
+  for (const [frameId, s] of streams) {
+    if (now - s.lastActivity > STREAM_IDLE_MS) finishStream(frameId, false) // agent died mid-stream
   }
 }, TICK_MS)
 
@@ -852,25 +882,33 @@ export function appendFrameHtml(
   const before = store.getFrame(frameId)
   if (!before) return undefined
 
-  const starting = opts.start || !reveals.has(frameId)
+  const starting = opts.start || !streams.has(frameId)
   /* an agent that escapes its opening chunk escapes the whole stream, so latch
      the verdict there: a chunk mid-design can hold a legitimate `&lt;` (a code
      sample) and must never be sniffed on its own */
-  const escaped = starting ? looksEscapedHtml(chunk) : (reveals.get(frameId)?.escaped ?? false)
+  const escaped = starting ? looksEscapedHtml(chunk) : (streams.get(frameId)?.escaped ?? false)
   const piece = escaped ? decodeEscapedHtml(chunk) : chunk
   const html = opts.start ? piece : before.html + piece
   const frame = store.updateFrame(frameId, { html }, actor.name)!
 
   if (starting) {
-    /* animate from where the old content diverges (0 for a fresh start) */
-    startReveal(frame, actor, opts.start ? commonPrefixLen(before.html, html) : before.html.length, true)
+    finishReveal(frameId) /* a live stream overrides any one-shot playback in flight */
+    streams.set(frameId, { actor, escaped, lastActivity: Date.now() })
+    broadcast(frame.canvasId, { type: 'frame:streaming', frameId, active: true, actor })
     logActivity(frame.canvasId, actor, `is designing “${frame.name}” live…`, frameId)
     autoTask(frame.canvasId, actor, `Designing “${frame.name}”`)
   }
-  const r = reveals.get(frameId)!
-  r.lastActivity = Date.now()
-  r.escaped = escaped
-  if (opts.done) r.pendingDone = true
+  const s = streams.get(frameId)!
+  s.lastActivity = Date.now()
+  s.escaped = escaped
+
+  /* the chunk renders the moment it arrives — viewers see the agent's real progress */
+  broadcast(frame.canvasId, {
+    type: 'frame:updated',
+    frame: opts.done ? frame : { ...frame, html: healPartialHtml(frame.html) },
+    actor,
+  })
+  if (opts.done) finishStream(frameId, true)
 
   touch(frame.canvasId, actor, frameId)
   return frame
@@ -889,7 +927,7 @@ export function createFrame(
   if (actor.kind === 'agent' && frame.html.length > 0) {
     /* agent one-shot creation still plays back as a reveal */
     broadcast(canvasId, { type: 'frame:created', frame: { ...frame, html: '' }, actor })
-    startReveal(frame, actor, 0, false)
+    startReveal(frame, actor, 0)
     autoTask(canvasId, actor, `Designing “${frame.name}”`)
   } else {
     broadcast(canvasId, { type: 'frame:created', frame, actor })
@@ -912,29 +950,33 @@ export function updateFrame(
   const frame = store.updateFrame(frameId, patch, actor.name)!
 
   const htmlChanged = patch.html !== undefined && patch.html !== prevHtml
-  const openReveal = reveals.get(frameId)
-
   if (htmlChanged && actor.kind === 'agent') {
+    finishStream(frameId, false) /* a full replace ends an open append stream */
     const prefix = commonPrefixLen(prevHtml, frame.html)
     /* mostly-unchanged replace (small tweak): broadcast at once — the client
        morphs the live DOM in place, so a reveal would only add churn */
     const smallTweak = prefix >= frame.html.length * 0.5 && prefix >= prevHtml.length * 0.5
+    const openReveal = reveals.get(frameId)
     if (openReveal) {
+      /* new content mid-playback: rewind to the divergence and re-arm the deadline */
       openReveal.actor = actor
       openReveal.shown = Math.min(openReveal.shown, prefix)
-      openReveal.lastActivity = Date.now()
-      openReveal.pendingDone = true // a full replace ends an open stream
+      openReveal.deadline = Date.now() + revealDuration(frame.html.length - openReveal.shown)
     } else if (smallTweak) {
       broadcast(frame.canvasId, { type: 'frame:updated', frame, actor })
       logActivity(frame.canvasId, actor, `tweaked the design of “${frame.name}”`, frame.id)
       autoTask(frame.canvasId, actor, `Tweaking “${frame.name}”`)
     } else {
-      startReveal(frame, actor, prefix, false)
+      startReveal(frame, actor, prefix)
       logActivity(frame.canvasId, actor, `updated the design of “${frame.name}”`, frame.id)
       autoTask(frame.canvasId, actor, `Redesigning “${frame.name}”`)
     }
   } else {
-    if (htmlChanged && openReveal) finishReveal(frameId, false) /* a human takes over: cancel the reveal */
+    if (htmlChanged) {
+      /* a human takes over: cancel any live stream or playback */
+      finishStream(frameId, false)
+      finishReveal(frameId)
+    }
     broadcast(frame.canvasId, { type: 'frame:updated', frame, actor })
     if (htmlChanged) {
       logActivity(frame.canvasId, actor, `updated the design of “${frame.name}”`, frame.id)
@@ -948,7 +990,10 @@ export function updateFrame(
 }
 
 export function deleteFrame(frameId: string, actor: Actor): Frame | undefined {
-  reveals.delete(frameId)
+  /* close any live stream or playback while the frame still exists,
+     so their auto “Designing…” tasks end with it */
+  finishStream(frameId, false)
+  finishReveal(frameId)
   const frame = store.deleteFrame(frameId)
   if (!frame) return undefined
   broadcast(frame.canvasId, { type: 'frame:deleted', frameId, actor })

--- a/server/guide.ts
+++ b/server/guide.ts
@@ -99,11 +99,13 @@ humans watching lose work they may have been reacting to.
 
 Viewers watch designs assemble live. Stream with append_frame_html:
 
-- ~300–500 characters per chunk, in document order.
+- ONE complete section per chunk, in document order: head+styles first, then the hero,
+  then each following section — roughly 1–4 KB each. Every chunk renders on the canvas
+  the moment it arrives, so each call should leave the frame in a sensible visual state.
 - start=true on the first chunk (clears the frame), done=true on the last.
-- Break at element boundaries when convenient. The server heals partial HTML either way
-  (closes an open <style>, trims a half-written tag, drops an unfinished <script>) and
-  paces the reveal smoothly for viewers, so never hold chunks back to "finish" something.
+- End chunks at element boundaries. If one lands mid-element anyway, the server heals it
+  (closes an open <style>, trims a half-written tag, drops an unfinished <script>), so
+  never hold a chunk back to "finish" something.
 - For small tweaks (copy, a color, one element's spacing) use edit_frame_html — an exact
   find/replace that morphs into the rendered frame in place, with no re-render. Resending
   a whole document via set_frame_html is for genuine redesigns.

--- a/server/mcp.ts
+++ b/server/mcp.ts
@@ -24,7 +24,7 @@ You MUST call get_guide({ topic: "doop-instructions" }) once before using other 
 - Context first: call get_canvas before adding or editing frames.
 - Identity: pick an agent_name and reuse the SAME name on every call — your presence and edits are attributed live.
 - Narrate: call set_status with a one-line summary when you start a task and whenever your focus shifts — people watching the canvas see it live next to your name.
-- Creating: create_frame, then stream the design with append_frame_html in ~300–500 character chunks (start=true on the first, done=true on the last). Viewers watch you work.
+- Creating: create_frame, then stream the design with append_frame_html one complete section at a time (~1–4 KB chunks; start=true on the first, done=true on the last). Each chunk renders the moment it arrives — viewers watch you work.
 - Review: after every create or significant edit you MUST call get_frame_screenshot and fix what looks wrong before moving on.
 - Small edits: edit_frame_html (exact find/replace — the change morphs into the rendered frame in place). Full redesigns: set_frame_html or a new stream. Rename/move/resize: update_frame.
 - Images: real imagery makes designs. search_images finds stock photos (you SEE thumbnails and pick), search_icons finds 200k+ UI icons as hotlinkable SVGs, search_logos finds real company logos by brand name or domain, upload_asset stores your own file (remote file → source_url; local file → local_file=true, returns a curl command) and returns a permanent URL. Never inline images as data: URIs.
@@ -1002,7 +1002,7 @@ export function buildMcpServer(owner?: string, ownerId?: string): McpServer {
     'append_frame_html',
     {
       description:
-        'Stream a design into a frame chunk by chunk, so viewers watch it build up live — prefer this over set_frame_html when creating or reworking a whole design. Send the HTML in order, in chunks of roughly 200–600 characters (e.g. head/styles first, then section by section). Set start=true on the FIRST chunk (replaces any existing content and shows a live "designing…" badge) and done=true on the LAST chunk. Partial HTML renders progressively, so structure chunks to end at reasonable boundaries when you can.',
+        'Stream a design into a frame section by section — every chunk renders for viewers the moment it arrives, so they watch the design build up live. Prefer this over set_frame_html when creating or reworking a whole design. Send the HTML in document order, ONE complete section per call (head+styles first, then the hero, then each following section), roughly 1–4 KB per chunk. Set start=true on the FIRST chunk (replaces any existing content and shows a live "designing…" badge) and done=true on the LAST chunk. End chunks at element boundaries — partial HTML is healed, but a complete section paints cleanly.',
       inputSchema: {
         frame_id: z.string(),
         html_chunk: z


### PR DESCRIPTION
Streamed chunks used to enter a typewriter reveal that drained at ~500 chars/s with an asymptotic catch-up, so viewers ran tens of seconds behind the agent and the playback kept grinding long after `done=true`. Now every append broadcasts the moment it arrives (healed if it ends mid-element); stream state only carries the designing badge, the escape latch, and the missing-done timeout.

The typewriter survives only for one-shot writes (`set_frame_html`, agent `create_frame` with html), drained against a fixed deadline of 2.5–5s so playback time no longer grows with document size.

Agent guidance changes from ~300–500 char chunks to one complete section per call (~1–4 KB): fewer round trips, and every intermediate render is a sensible visual state.

Ported from the upstream private repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)