### PR TITLE
feat(analytics): segment desktop-app sessions in PostHog

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "doop-desktop",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.1.1",
   "scripts": {
     "tauri": "tauri",
     "dev": "tauri dev",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "doop-desktop"
-version = "0.1.0"
+version = "0.1.1"
 description = "Desktop shell for doop — a thin webview over the hosted app"
 edition = "2021"
 

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -38,7 +38,14 @@ fn main() {
                     None => format!("www.{host}"),
                 });
             }
+            // Marks every page loaded in the shell so the app's analytics can
+            // tell desktop sessions from browser ones (src/lib/posthog.ts).
+            let desktop_marker = format!(
+                "window.__DOOP_DESKTOP__ = '{}';",
+                app.package_info().version
+            );
             WebviewWindowBuilder::new(app, "main", WebviewUrl::External(entry.parse()?))
+                .initialization_script(&desktop_marker)
                 .title("doop")
                 .inner_size(1440.0, 900.0)
                 .min_inner_size(900.0, 600.0)

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "doop",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "identifier": "design.doop.desktop",
   "build": {
     "devUrl": "http://localhost:4300",

--- a/src/lib/posthog.ts
+++ b/src/lib/posthog.ts
@@ -60,6 +60,16 @@ if (!key) {
     disable_session_recording: localStorage.getItem(NO_REPLAY_KEY) === '1',
     defaults: '2026-05-30',
   })
+
+  /* The desktop shell injects window.__DOOP_DESKTOP__ = "<shell version>"
+     before any page script runs (desktop/src-tauri/src/main.rs). Register it
+     as super properties so every event and recording from the shell is
+     segmentable in PostHog. The webview's storage is isolated from the
+     user's browsers, so the flag can never leak onto ordinary web sessions. */
+  const desktopVersion = (window as { __DOOP_DESKTOP__?: unknown }).__DOOP_DESKTOP__
+  if (typeof desktopVersion === 'string') {
+    posthog.register({ desktop_app: true, desktop_app_version: desktopVersion })
+  }
 }
 
 /** Call on every identify: stops replay for internal accounts, (re)starts it


### PR DESCRIPTION
Mirror of design-multiplayer#85: the Tauri shell injects `window.__DOOP_DESKTOP__ = "<version>"` via `initialization_script`, and `src/lib/posthog.ts` registers it as super properties (`desktop_app`, `desktop_app_version`) so desktop sessions are segmentable in analytics. Shell version → 0.1.1; a `desktop-v0.1.1` tag after merge ships it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CyTQnktnfHLboMmvBvmauZ