### PR TITLE
feat: design-sync snippet — an app's live screens land on a canvas

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,25 @@ For website viewing/imports, setting `CONTEXT_DEV_API_KEY` makes Context.dev acq
 HTML while Doop still sanitizes it and renders the preview locally; without the key, Doop navigates
 to the public page directly in Chromium.
 
+### Design sync: push an app's live screens onto a canvas
+
+Server-side import can't reach apps behind SSO or a VPN. The **doop-sync snippet** flips the capture
+to the user's browser: mint a write-only key in a canvas's Share dialog, drop one tag into the app —
+
+```html
+<script async src="https://your-doop-origin/doop-sync.js" data-key="dk_…"></script>
+```
+
+— and every distinct screen people visit lands on that canvas as a frame (one row per app), refreshed
+as the app changes. Routes are normalized (`/orders/8231` → `/orders/:id`) so each screen maps to one
+frame; captures are serialized from the CSSOM (so styled-components/emotion output survives), and
+same-origin webfonts and small images are inlined as data: URIs — fonts require CORS inside the
+sandboxed frame, and intranet URLs would never render for viewers outside the network. Scripts are
+stripped client- and server-side, input values are always dropped, and anything marked `data-doop-mask`
+is redacted before upload (`data-doop-sync-ignore` excludes an element entirely). The key is the whole
+credential: it can only write frames to its one canvas, so revoking it in the Share dialog cuts the
+app off instantly. Endpoint: `POST /ingest/<key>` (CORS-open, no cookies).
+
 ### How streaming looks (server-side smoothing)
 
 Agent HTML lands in the store immediately, but viewers see it through a **typewriter reveal**: the server

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -29,6 +29,25 @@ export default tseslint.config(
       '@typescript-eslint/no-namespace': ['error', { allowDeclarations: true }],
     },
   },
+  {
+    /* the embeddable snippet: plain browser JS shipped as-is, no bundling —
+       ES5-flavoured on purpose so it runs wherever the host app does */
+    files: ['public/**/*.js'],
+    languageOptions: {
+      globals: Object.fromEntries(
+        (
+          'window document location history localStorage fetch console setTimeout clearTimeout ' +
+          'matchMedia URL JSON Date Math FileReader Promise'
+        )
+          .split(' ')
+          .map((g) => [g, 'readonly']),
+      ),
+    },
+    rules: {
+      '@typescript-eslint/no-unused-expressions': 'off',
+      '@typescript-eslint/no-unused-vars': ['error', { caughtErrors: 'none' }],
+    },
+  },
   /* must be last: silence stylistic rules that would fight prettier */
   prettier,
 )

--- a/public/doop-sync.js
+++ b/public/doop-sync.js
@@ -1,0 +1,378 @@
+/**
+ * doop design sync — one tag in your app, your live screens on a doop canvas.
+ *
+ *   <script async src="https://yourdoop.example/doop-sync.js" data-key="dk_…"></script>
+ *
+ * Runs in the USER'S browser, so it captures apps no crawler can reach
+ * (SSO, VPN, localhost) exactly as the signed-in user sees them. Each
+ * distinct route becomes one frame, refreshed when the screen changes.
+ *
+ * Options (attributes on the script tag):
+ *   data-key   required — a canvas sync key from doop's share dialog
+ *   data-host  override the doop origin (defaults to where this file loaded from)
+ *   data-mask  extra CSS selector whose text is redacted before upload
+ *
+ * Privacy: input values are always dropped, [data-doop-mask] subtrees are
+ * redacted, scripts never leave the page. `window.doopSync.capture()` forces
+ * a capture; add data-doop-sync-ignore to elements that should never upload.
+ */
+;(function () {
+  'use strict'
+  if (window.doopSync) return
+  var script = document.currentScript
+  var KEY = (script && script.getAttribute('data-key')) || window.doopSyncKey
+  var HOST = (script && script.getAttribute('data-host')) || ''
+  var MASK = (script && script.getAttribute('data-mask')) || ''
+  if (!HOST && script && script.src) {
+    try {
+      HOST = new URL(script.src).origin
+    } catch (e) {
+      /* no src origin — data-host required */
+    }
+  }
+  if (!KEY || !HOST) {
+    console.warn('[doop-sync] missing data-key or data-host — not capturing')
+    return
+  }
+
+  var SETTLE_MS = 2500 // let data land and skeletons resolve before capturing
+  var MIN_RESEND_MS = 30000 // floor between uploads of the same route (matches the server's)
+  var MAX_BYTES = 2400000 // server rejects above 2.5 MB — stay under
+  var MAX_ASSET_BYTES = 200000 // per-file cap for inlined fonts/images
+  var ENDPOINT = HOST.replace(/\/$/, '') + '/ingest/' + KEY
+
+  /* One frame per SCREEN, not per record: normalize id-looking path segments
+     so /orders/8231 and /orders/9007 land on the same frame. */
+  function routeKey() {
+    var segs = location.pathname.split('/').map(function (seg) {
+      if (!seg) return seg
+      if (/^\d+$/.test(seg)) return ':id'
+      if (/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(seg)) return ':id'
+      if (/^[0-9a-f]{16,}$/i.test(seg)) return ':id'
+      if (seg.length >= 20 && /^[\w-]+$/.test(seg) && /\d/.test(seg)) return ':id'
+      return seg
+    })
+    var page = segs.join('/') || '/'
+    return page.length > 280 ? page.slice(0, 280) : page
+  }
+
+  function absUrl(u) {
+    try {
+      return new URL(u, document.baseURI).href
+    } catch (e) {
+      return null
+    }
+  }
+  function isSameOrigin(abs) {
+    try {
+      return new URL(abs).origin === location.origin
+    } catch (e) {
+      return false
+    }
+  }
+
+  /* CSS must come from the CSSOM, not the markup: styled-components/emotion
+     insert rules via insertRule and their <style> tags serialize empty.
+     Same-origin sheets are readable; cross-origin ones are kept as links. */
+  function collectCss() {
+    var css = ''
+    var links = []
+    var sheets = []
+    var i
+    for (i = 0; i < document.styleSheets.length; i++) sheets.push(document.styleSheets[i])
+    if (document.adoptedStyleSheets) {
+      for (i = 0; i < document.adoptedStyleSheets.length; i++) sheets.push(document.adoptedStyleSheets[i])
+    }
+    for (i = 0; i < sheets.length; i++) {
+      var sheet = sheets[i]
+      try {
+        if (sheet.media && sheet.media.mediaText && !matchMedia(sheet.media.mediaText).matches) continue
+        var rules = sheet.cssRules
+        var text = ''
+        for (var r = 0; r < rules.length; r++) text += rules[r].cssText + '\n'
+        css += text
+      } catch (e) {
+        if (sheet.href) links.push(sheet.href)
+      }
+    }
+    return { css: css, links: links }
+  }
+
+  /* Same-origin assets are unreachable for anyone viewing the frame from
+     outside this network (VPN, localhost) — and webfonts additionally demand
+     CORS even when reachable. Inlining as data: URIs is the only rendering
+     that works for every viewer. Cached across captures; a null means
+     skipped/failed so we don't retry every capture. */
+  var assetCache = {}
+
+  function toDataUri(abs, budget) {
+    if (assetCache[abs] !== undefined) return Promise.resolve(assetCache[abs])
+    return fetch(abs)
+      .then(function (r) {
+        if (!r.ok) throw new Error('' + r.status)
+        return r.blob()
+      })
+      .then(function (blob) {
+        if (blob.size > MAX_ASSET_BYTES || blob.size > budget.left) {
+          assetCache[abs] = null
+          return null
+        }
+        return new Promise(function (resolve, reject) {
+          var fr = new FileReader()
+          fr.onload = function () {
+            resolve(fr.result)
+          }
+          fr.onerror = reject
+          fr.readAsDataURL(blob)
+        }).then(function (uri) {
+          budget.left -= blob.size
+          assetCache[abs] = uri
+          return uri
+        })
+      })
+      ['catch'](function () {
+        assetCache[abs] = null
+        return null
+      })
+  }
+
+  var FONT_URL = /url\(\s*(['"]?)([^'")]+)\1\s*\)/g
+
+  /* Fetch every same-origin font the CSS references, then swap the url()s. */
+  function inlineCssFonts(css, budget) {
+    var jobs = []
+    var m
+    FONT_URL.lastIndex = 0
+    while ((m = FONT_URL.exec(css))) {
+      var u = m[2]
+      if (/^data:/.test(u) || !/\.(woff2?|ttf|otf|eot)([?#]|$)/i.test(u)) continue
+      var abs = absUrl(u)
+      if (abs && isSameOrigin(abs) && assetCache[abs] === undefined) jobs.push(toDataUri(abs, budget))
+    }
+    return Promise.all(jobs).then(function () {
+      return css.replace(FONT_URL, function (all, q, u) {
+        var abs = absUrl(u)
+        var data = abs && assetCache[abs]
+        return data ? 'url(' + q + data + q + ')' : all
+      })
+    })
+  }
+
+  /* Inline small same-origin images; absolutize everything else. Pairing is
+     done against the full clone BEFORE nodes are removed, so live and cloned
+     img lists line up index for index. */
+  function inlineImages(imgPairs, budget) {
+    var jobs = []
+    imgPairs.forEach(function (pair) {
+      var src = pair.live.currentSrc || pair.live.src
+      if (!src || /^data:/.test(src)) return
+      var abs = absUrl(src)
+      if (!abs) return
+      pair.clone.setAttribute('src', abs)
+      pair.clone.removeAttribute('srcset')
+      pair.clone.removeAttribute('sizes')
+      if (!isSameOrigin(abs)) return
+      jobs.push(
+        toDataUri(abs, budget).then(function (data) {
+          if (data) pair.clone.setAttribute('src', data)
+        }),
+      )
+    })
+    return Promise.all(jobs)
+  }
+
+  function serialize() {
+    var root = document.documentElement.cloneNode(true)
+
+    /* pair images while both trees are still structurally identical */
+    var liveImgs = document.querySelectorAll('img')
+    var cloneImgs = root.querySelectorAll('img')
+    var imgPairs = []
+    var i
+    for (i = 0; i < cloneImgs.length && i < liveImgs.length; i++) {
+      imgPairs.push({ live: liveImgs[i], clone: cloneImgs[i] })
+    }
+
+    var kill = root.querySelectorAll(
+      'script,noscript,iframe,frame,frameset,object,embed,applet,portal,fencedframe,' +
+        'link[rel="stylesheet"],link[rel="preload"],link[rel="modulepreload"],style,base,meta[http-equiv],' +
+        '[data-doop-sync-ignore]',
+    )
+    for (i = kill.length - 1; i >= 0; i--) kill[i].parentNode && kill[i].parentNode.removeChild(kill[i])
+
+    /* A live DOM can nest <a> inside <a> (React builds via DOM APIs), but
+       serialized HTML cannot: reparsing closes the outer link at the inner
+       one and spills the outer's content out as siblings. Demote inner
+       links/buttons to spans — their classes keep the visual styling. */
+    var nested = root.querySelectorAll('a a, button button')
+    for (i = 0; i < nested.length; i++) {
+      var link = nested[i]
+      var span = document.createElement('span')
+      for (var n = 0; n < link.attributes.length; n++)
+        span.setAttribute(link.attributes[n].name, link.attributes[n].value)
+      if (span.hasAttribute('href')) {
+        span.setAttribute('data-href', span.getAttribute('href'))
+        span.removeAttribute('href')
+      }
+      while (link.firstChild) span.appendChild(link.firstChild)
+      link.parentNode.replaceChild(span, link)
+    }
+
+    var all = root.querySelectorAll('*')
+    for (i = 0; i < all.length; i++) {
+      var el = all[i]
+      for (var a = el.attributes.length - 1; a >= 0; a--) {
+        var attr = el.attributes[a]
+        var name = attr.name.toLowerCase()
+        if (name.indexOf('on') === 0 || name === 'srcdoc' || name === 'ping') el.removeAttribute(attr.name)
+        else if (/^\s*javascript:/i.test(attr.value) && /^(href|src|action|formaction|poster|xlink:href)$/.test(name))
+          el.removeAttribute(attr.name)
+      }
+    }
+
+    /* never ship what people typed — the snapshot is about the design */
+    var inputs = root.querySelectorAll('input,textarea')
+    for (i = 0; i < inputs.length; i++) {
+      inputs[i].removeAttribute('value')
+      if (inputs[i].tagName === 'TEXTAREA') inputs[i].textContent = ''
+    }
+    var masked = MASK ? root.querySelectorAll('[data-doop-mask],' + MASK) : root.querySelectorAll('[data-doop-mask]')
+    for (i = 0; i < masked.length; i++) masked[i].textContent = '•••'
+
+    var styles = collectCss()
+    var baseSize = root.outerHTML.length + styles.css.length
+    var budget = { left: Math.max(0, MAX_BYTES - baseSize) }
+
+    return Promise.all([inlineCssFonts(styles.css, budget), inlineImages(imgPairs, budget)]).then(function (results) {
+      var head = root.querySelector('head')
+      var inject = ''
+      for (var l = 0; l < styles.links.length; l++) {
+        inject += '<link rel="stylesheet" href="' + styles.links[l].replace(/"/g, '&quot;') + '">'
+      }
+      inject += '<style data-doop-sync>\n' + results[0].replace(/<\/style/gi, '<\\/style') + '\n</style>'
+      if (head) head.insertAdjacentHTML('beforeend', inject)
+      return '<!doctype html>\n' + root.outerHTML
+    })
+  }
+
+  function hash(s) {
+    var h = 5381
+    for (var i = 0; i < s.length; i++) h = ((h << 5) + h + s.charCodeAt(i)) | 0
+    return String(h)
+  }
+
+  function memoKey(page) {
+    return '__doopSync:' + KEY.slice(-6) + ':' + page
+  }
+
+  function shouldSend(page, h) {
+    try {
+      var memo = JSON.parse(localStorage.getItem(memoKey(page)) || 'null')
+      if (!memo) return true
+      if (memo.h === h && Date.now() - memo.t < 6 * 3600000) return false // unchanged — server has it
+      return Date.now() - memo.t >= MIN_RESEND_MS
+    } catch (e) {
+      return true
+    }
+  }
+
+  var capturing = false
+  function capture(force) {
+    if (capturing) return
+    capturing = true
+    var page = routeKey()
+    /* Promise.resolve().then keeps a synchronous throw inside serialize on
+       the promise chain — it must hit the catch below, or `capturing` wedges
+       shut and every later capture silently no-ops. */
+    Promise.resolve()
+      .then(function () {
+        return serialize()
+      })
+      .then(function (html) {
+        capturing = false
+        if (html.length > MAX_BYTES) {
+          console.warn('[doop-sync] snapshot too large (' + html.length + ' bytes) — not uploading')
+          return
+        }
+        var h = hash(html)
+        if (!force && !shouldSend(page, h)) return
+        try {
+          localStorage.setItem(memoKey(page), JSON.stringify({ h: h, t: Date.now() }))
+        } catch (e) {
+          /* private mode — fine, we just lose the dedup */
+        }
+        return fetch(ENDPOINT, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          keepalive: html.length < 60000, // keepalive caps the body — big snapshots go without it
+          body: JSON.stringify({
+            page: page,
+            title: document.title,
+            url: location.href,
+            width: window.innerWidth,
+            height: Math.min(document.documentElement.scrollHeight, 8000),
+            html: html,
+          }),
+        }).then(function (r) {
+          if (!r.ok) throw new Error('sync ' + r.status)
+        })
+      })
+      ['catch'](function (err) {
+        /* never break the host app over a sync error — but log it, and drop
+           the memo so the next scheduled capture retries instead of skipping */
+        console.warn('[doop-sync] capture failed', err)
+        capturing = false
+        try {
+          localStorage.removeItem(memoKey(page))
+        } catch (e2) {
+          /* private mode */
+        }
+      })
+  }
+
+  var timer = null
+  function schedule(delay) {
+    if (timer) clearTimeout(timer)
+    timer = setTimeout(function () {
+      timer = null
+      if (document.visibilityState !== 'hidden') capture(false)
+    }, delay || SETTLE_MS)
+  }
+
+  /* initial screen + every SPA navigation */
+  if (document.readyState === 'complete') schedule()
+  else window.addEventListener('load', schedule)
+  var push = history.pushState
+  history.pushState = function () {
+    var out = push.apply(this, arguments)
+    schedule()
+    return out
+  }
+  var replace = history.replaceState
+  history.replaceState = function () {
+    var out = replace.apply(this, arguments)
+    schedule()
+    return out
+  }
+  window.addEventListener('popstate', function () {
+    schedule()
+  })
+
+  /* Scroll-reveal animations leave below-the-fold content at opacity 0 until
+     seen; a capture from the top of the page freezes that. Re-capture after
+     scrolling stops — the hash memo turns fully-revealed pages into a single
+     update and everything else into a no-op. */
+  window.addEventListener(
+    'scroll',
+    function () {
+      schedule(1800)
+    },
+    { passive: true },
+  )
+
+  window.doopSync = {
+    capture: function () {
+      capture(true)
+    },
+  }
+})()

--- a/server/access.ts
+++ b/server/access.ts
@@ -29,3 +29,12 @@ export function canAccessCanvas(userId: string | undefined, canvas: Canvas): boo
   if (canvas.memberIds?.includes(userId)) return true
   return canvas.linkAccess === 'edit'
 }
+
+/** Durable access only: the owner and invited members — NOT link-edit
+ *  visitors. Gates anything that would outlive the visit itself, like
+ *  design-sync keys: a bearer secret minted or read through a share link
+ *  would keep writing frames long after the owner turns the link off. */
+export function hasDurableCanvasAccess(userId: string | undefined, canvas: Canvas): boolean {
+  if (!userId || !canvas.ownerId) return false
+  return canvas.ownerId === userId || !!canvas.memberIds?.includes(userId)
+}

--- a/server/db/migrations/0004_design_sync_keys.sql
+++ b/server/db/migrations/0004_design_sync_keys.sql
@@ -1,0 +1,12 @@
+CREATE TABLE "sync_keys" (
+	"id" text PRIMARY KEY NOT NULL,
+	"secret" text NOT NULL,
+	"canvas_id" text NOT NULL,
+	"name" text NOT NULL,
+	"created_by" text NOT NULL,
+	"created_at" bigint NOT NULL,
+	"last_used_at" bigint
+);
+--> statement-breakpoint
+CREATE INDEX "sync_keys_canvas_idx" ON "sync_keys" USING btree ("canvas_id");--> statement-breakpoint
+CREATE INDEX "sync_keys_secret_idx" ON "sync_keys" USING btree ("secret");

--- a/server/db/migrations/meta/0004_snapshot.json
+++ b/server/db/migrations/meta/0004_snapshot.json
@@ -1,0 +1,1960 @@
+{
+  "id": "7825feca-3f18-4243-baf2-13ffca8b0f0d",
+  "prevId": "361bd1f0-d3ab-4fa8-b485-de6246e61d94",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.activity": {
+      "name": "activity",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "canvas_id": {
+          "name": "canvas_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_kind": {
+          "name": "actor_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_color": {
+          "name": "actor_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frame_id": {
+          "name": "frame_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "at": {
+          "name": "at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "activity_canvas_idx": {
+          "name": "activity_canvas_idx",
+          "columns": [
+            {
+              "expression": "canvas_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.asset_refs": {
+      "name": "asset_refs",
+      "schema": "",
+      "columns": {
+        "asset_id": {
+          "name": "asset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frame_id": {
+          "name": "frame_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "asset_refs_frame_idx": {
+          "name": "asset_refs_frame_idx",
+          "columns": [
+            {
+              "expression": "frame_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "asset_refs_asset_id_frame_id_pk": {
+          "name": "asset_refs_asset_id_frame_id_pk",
+          "columns": ["asset_id", "frame_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.assets": {
+      "name": "assets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "canvas_id": {
+          "name": "canvas_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mime": {
+          "name": "mime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ext": {
+          "name": "ext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "assets_canvas_idx": {
+          "name": "assets_canvas_idx",
+          "columns": [
+            {
+              "expression": "canvas_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.canvas_members": {
+      "name": "canvas_members",
+      "schema": "",
+      "columns": {
+        "canvas_id": {
+          "name": "canvas_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "added_by": {
+          "name": "added_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "canvas_members_canvas_id_user_id_pk": {
+          "name": "canvas_members_canvas_id_user_id_pk",
+          "columns": ["canvas_id", "user_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.canvases": {
+      "name": "canvases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_access": {
+          "name": "link_access",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.comments": {
+      "name": "comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "canvas_id": {
+          "name": "canvas_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frame_id": {
+          "name": "frame_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "selector": {
+          "name": "selector",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snippet": {
+          "name": "snippet",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_name": {
+          "name": "from_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_user_id": {
+          "name": "from_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "at": {
+          "name": "at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "for_agent": {
+          "name": "for_agent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "target_agent": {
+          "name": "target_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_by": {
+          "name": "claimed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failed_at": {
+          "name": "failed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "comments_canvas_idx": {
+          "name": "comments_canvas_idx",
+          "columns": [
+            {
+              "expression": "canvas_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.decisions": {
+      "name": "decisions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "canvas_id": {
+          "name": "canvas_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frame_id": {
+          "name": "frame_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_name": {
+          "name": "from_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "at": {
+          "name": "at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "distilled_at": {
+          "name": "distilled_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "decisions_canvas_idx": {
+          "name": "decisions_canvas_idx",
+          "columns": [
+            {
+              "expression": "canvas_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feedback": {
+      "name": "feedback",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canvas_id": {
+          "name": "canvas_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_agent": {
+          "name": "target_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_name": {
+          "name": "from_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_user_id": {
+          "name": "from_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "at": {
+          "name": "at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_by": {
+          "name": "claimed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failed_at": {
+          "name": "failed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "feedback_canvas_idx": {
+          "name": "feedback_canvas_idx",
+          "columns": [
+            {
+              "expression": "canvas_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.frames": {
+      "name": "frames",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "canvas_id": {
+          "name": "canvas_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "x": {
+          "name": "x",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "y": {
+          "name": "y",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "width": {
+          "name": "width",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "height": {
+          "name": "height",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "html": {
+          "name": "html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "demo": {
+          "name": "demo",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "frames_canvas_idx": {
+          "name": "frames_canvas_idx",
+          "columns": [
+            {
+              "expression": "canvas_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.guideline_versions": {
+      "name": "guideline_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "canvas_id": {
+          "name": "canvas_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "markdown": {
+          "name": "markdown",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "saved_at": {
+          "name": "saved_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "saved_by": {
+          "name": "saved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "guideline_versions_doc_idx": {
+          "name": "guideline_versions_doc_idx",
+          "columns": [
+            {
+              "expression": "canvas_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.guidelines": {
+      "name": "guidelines",
+      "schema": "",
+      "columns": {
+        "canvas_id": {
+          "name": "canvas_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "markdown": {
+          "name": "markdown",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "x": {
+          "name": "x",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "y": {
+          "name": "y",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "guidelines_canvas_id_name_pk": {
+          "name": "guidelines_canvas_id_name_pk",
+          "columns": ["canvas_id", "name"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.memory_proposals": {
+      "name": "memory_proposals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "canvas_id": {
+          "name": "canvas_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guide_name": {
+          "name": "guide_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guide_title": {
+          "name": "guide_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rule": {
+          "name": "rule",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rationale": {
+          "name": "rationale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "based_on": {
+          "name": "based_on",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "at": {
+          "name": "at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "memory_proposals_canvas_idx": {
+          "name": "memory_proposals_canvas_idx",
+          "columns": [
+            {
+              "expression": "canvas_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.memory_references": {
+      "name": "memory_references",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "canvas_id": {
+          "name": "canvas_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frame_id": {
+          "name": "frame_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "html": {
+          "name": "html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "width": {
+          "name": "width",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "height": {
+          "name": "height",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pinned_by": {
+          "name": "pinned_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pinned_at": {
+          "name": "pinned_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "memory_references_canvas_idx": {
+          "name": "memory_references_canvas_idx",
+          "columns": [
+            {
+              "expression": "canvas_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.model_accounts": {
+      "name": "model_accounts",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan": {
+          "name": "plan",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connected_at": {
+          "name": "connected_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.resident_usage": {
+      "name": "resident_usage",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "used": {
+          "name": "used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sync_keys": {
+      "name": "sync_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canvas_id": {
+          "name": "canvas_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "sync_keys_canvas_idx": {
+          "name": "sync_keys_canvas_idx",
+          "columns": [
+            {
+              "expression": "canvas_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sync_keys_secret_idx": {
+          "name": "sync_keys_secret_idx",
+          "columns": [
+            {
+              "expression": "secret",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tasks": {
+      "name": "tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "canvas_id": {
+          "name": "canvas_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto": {
+          "name": "auto",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "queued_by": {
+          "name": "queued_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failed_at": {
+          "name": "failed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pipeline": {
+          "name": "pipeline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stage": {
+          "name": "stage",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attachments": {
+          "name": "attachments",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "queued_by_user_id": {
+          "name": "queued_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "tasks_canvas_idx": {
+          "name": "tasks_canvas_idx",
+          "columns": [
+            {
+              "expression": "canvas_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_access_token": {
+      "name": "oauth_access_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_access_token_access_token_unique": {
+          "name": "oauth_access_token_access_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["access_token"]
+        },
+        "oauth_access_token_refresh_token_unique": {
+          "name": "oauth_access_token_refresh_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["refresh_token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_application": {
+      "name": "oauth_application",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_urls": {
+          "name": "redirect_urls",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_application_client_id_unique": {
+          "name": "oauth_application_client_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["client_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_consent": {
+      "name": "oauth_consent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "consent_given": {
+          "name": "consent_given",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/server/db/migrations/meta/_journal.json
+++ b/server/db/migrations/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1787637526171,
       "tag": "0003_motionless_colossus",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1787764855067,
+      "tag": "0004_design_sync_keys",
+      "breakpoints": true
     }
   ]
 }

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -51,6 +51,28 @@ export const frames = pgTable(
   (t) => [index('frames_canvas_idx').on(t.canvasId)],
 )
 
+/** Design-sync keys: the write-only capability behind the /ingest endpoint.
+ *  An app embeds the doop-sync snippet with a key's secret, and its live
+ *  screens land on ONE canvas as frames — the secret grants no reads and no
+ *  other writes, so shipping it in an internal app's bundle is safe. `id` is
+ *  the public handle (stamped into synced frame HTML to match page → frame);
+ *  the secret never appears in canvas content. Cold path: read per ingest
+ *  request, no in-memory mirror. Revocation = row deletion. */
+export const syncKeys = pgTable(
+  'sync_keys',
+  {
+    id: text('id').primaryKey(),
+    secret: text('secret').notNull(),
+    canvasId: text('canvas_id').notNull(),
+    /** label shown in the share modal and used as the frames' actor name */
+    name: text('name').notNull(),
+    createdBy: text('created_by').notNull(),
+    createdAt: bigint('created_at', { mode: 'number' }).notNull(),
+    lastUsedAt: bigint('last_used_at', { mode: 'number' }),
+  },
+  (t) => [index('sync_keys_canvas_idx').on(t.canvasId), index('sync_keys_secret_idx').on(t.secret)],
+)
+
 export const tasks = pgTable(
   'tasks',
   {

--- a/server/index.ts
+++ b/server/index.ts
@@ -9,7 +9,7 @@ import { oAuthDiscoveryMetadata } from 'better-auth/plugins'
 import { WebSocketServer, WebSocket } from 'ws'
 import { store } from './store.ts'
 import * as actions from './actions.ts'
-import { canAccessCanvas, isAdmin } from './access.ts'
+import { canAccessCanvas, hasDurableCanvasAccess, isAdmin } from './access.ts'
 import { auth, initAuth, syncAdmins, getUserName, PUBLIC_ORIGIN } from './auth.ts'
 import { adminRouter } from './admin.ts'
 import * as demo from './demo.ts'
@@ -25,6 +25,7 @@ import {
   createAsset,
   MAX_ASSET_BYTES,
 } from './assets.ts'
+import * as ingest from './ingest.ts'
 import { seed } from './seed.ts'
 import * as allowance from './allowance.ts'
 import * as modelAccounts from './modelAccounts.ts'
@@ -455,6 +456,27 @@ app.post('/api/account-exists', async (req, res) => {
   res.json({ exists: !!row })
 })
 
+/* ------------------------------------------------------------------ */
+/* Design sync ingest: the doop-sync snippet on a foreign origin posts */
+/* DOM snapshots here. The canvas-scoped write-only secret in the path */
+/* is the whole credential (no cookies), so this stays outside the     */
+/* /api session gate and answers its own CORS preflight. The route-    */
+/* level parser also accepts text/plain — that's what sendBeacon      */
+/* sends when a page unloads mid-capture.                              */
+/* ------------------------------------------------------------------ */
+
+app.options('/ingest/:key', (_req, res) => {
+  ingest.setIngestCors(res)
+  res.status(204).end()
+})
+
+app.post('/ingest/:key', express.json({ limit: '10mb', type: () => true }), (req, res) => {
+  ingest.handleIngest(req, res).catch((err) => {
+    console.error('[ingest] failed', err)
+    if (!res.headersSent) res.status(500).json({ error: 'sync failed' })
+  })
+})
+
 /* everything else under /api requires a logged-in user; the session's user
    is authoritative for names — clients don't get to pick who they are */
 interface SessionUser {
@@ -763,6 +785,43 @@ app.delete('/api/canvases/:id/members/:userId', (req, res) => {
   if (c.ownerId !== req.user!.id && req.params.userId !== req.user!.id)
     return res.status(403).json({ error: 'only the owner can remove collaborators' })
   if (!store.removeMember(c.id, req.params.userId)) return res.status(404).json({ error: 'not a collaborator' })
+  res.json({ ok: true })
+})
+
+/* ---- design-sync keys: mint/list/revoke the write-only snippet creds.
+   Owner and invited members only — NOT link-edit visitors. A key is a
+   durable bearer credential, so someone whose access is only the share
+   link must not be able to mint one (or read an existing secret) and
+   keep writing frames after the owner turns the link off. */
+
+function requireDurableCanvas(req: express.Request, res: express.Response, canvasId: string) {
+  const c = requireCanvas(req, res, canvasId)
+  if (!c) return null
+  if (!hasDurableCanvasAccess(req.user!.id, c)) {
+    res.status(403).json({ error: 'sync keys are managed by the owner and invited members' })
+    return null
+  }
+  return c
+}
+
+app.get('/api/canvases/:id/sync-keys', async (req, res) => {
+  const c = requireDurableCanvas(req, res, req.params.id)
+  if (!c) return
+  const keys = await ingest.listSyncKeys(c.id)
+  res.json(keys.map((k) => ({ ...k, frames: ingest.syncedFrameCount(c, k.id) })))
+})
+
+app.post('/api/canvases/:id/sync-keys', async (req, res) => {
+  const c = requireDurableCanvas(req, res, req.params.id)
+  if (!c) return
+  const key = await ingest.createSyncKey(c.id, String(req.body?.name ?? ''), req.user!.id)
+  res.json({ ...key, frames: 0 })
+})
+
+app.delete('/api/canvases/:id/sync-keys/:keyId', async (req, res) => {
+  if (!requireDurableCanvas(req, res, req.params.id)) return
+  if (!(await ingest.deleteSyncKey(req.params.id, req.params.keyId)))
+    return res.status(404).json({ error: 'sync key not found' })
   res.json({ ok: true })
 })
 

--- a/server/ingest.ts
+++ b/server/ingest.ts
@@ -1,0 +1,255 @@
+import type express from 'express'
+import { nanoid } from 'nanoid'
+import { and, desc, eq } from 'drizzle-orm'
+import { db } from './db/index.ts'
+import { syncKeys } from './db/schema.ts'
+import { store } from './store.ts'
+import * as actions from './actions.ts'
+import type { Frame } from '../shared/types.ts'
+
+/**
+ * Design sync: a PostHog-style snippet (public/doop-sync.js) embedded in an
+ * app posts serialized DOM snapshots of its screens here, and each distinct
+ * screen becomes (or refreshes) a frame on one canvas. The bearer secret in
+ * the URL is the whole credential — write-only, scoped to a single canvas —
+ * so apps behind VPNs/SSO that the server-side importer can never reach can
+ * still push their designs in from the user's own browser.
+ *
+ * Snapshots are scrubbed of scripts like importer snapshots are, but that is
+ * hygiene (the app's JS must not run again inside the canvas), not the
+ * security boundary — frames always render in a sandboxed iframe without
+ * same-origin, exactly like agent-authored HTML that may carry scripts.
+ */
+
+export interface SyncKey {
+  id: string
+  secret: string
+  canvasId: string
+  name: string
+  createdBy: string
+  createdAt: number
+  lastUsedAt: number | null
+}
+
+export async function createSyncKey(canvasId: string, name: string, createdBy: string): Promise<SyncKey> {
+  const row: SyncKey = {
+    id: nanoid(8),
+    secret: 'dk_' + nanoid(24),
+    canvasId,
+    name: name.trim().slice(0, 60) || 'App sync',
+    createdBy,
+    createdAt: Date.now(),
+    lastUsedAt: null,
+  }
+  await db.insert(syncKeys).values(row)
+  return row
+}
+
+export function listSyncKeys(canvasId: string): Promise<SyncKey[]> {
+  return db.select().from(syncKeys).where(eq(syncKeys.canvasId, canvasId)).orderBy(desc(syncKeys.createdAt))
+}
+
+/** Revocation is deletion: the next ingest with the secret gets a 404. */
+export async function deleteSyncKey(canvasId: string, id: string): Promise<boolean> {
+  const gone = await db
+    .delete(syncKeys)
+    .where(and(eq(syncKeys.id, id), eq(syncKeys.canvasId, canvasId)))
+    .returning({ id: syncKeys.id })
+  return gone.length > 0
+}
+
+/* ------------------------------------------------------------------ */
+
+/** Same lockdown the website importer stamps on its captures. Duplicated from
+ *  importer.ts on purpose: this path must not load the Chromium-adjacent
+ *  importer module, and the two snapshots want identical policies. */
+const SNAPSHOT_CSP = [
+  "default-src 'none'",
+  "script-src 'none'",
+  "connect-src 'none'",
+  "object-src 'none'",
+  "frame-src 'none'",
+  "worker-src 'none'",
+  "form-action 'none'",
+  "style-src 'unsafe-inline'",
+  'img-src data: blob: http: https:',
+  'font-src data: http: https:',
+  'media-src data: blob: http: https:',
+].join('; ')
+
+const SYNC_PAGE_META = 'doop-sync-page'
+
+/** Which key/page a synced frame belongs to: `<keyId>/<page>` or undefined.
+ *  The marker carries the key's public id, never its secret — frame HTML is
+ *  readable by everyone on the canvas. */
+export function syncFrameMarker(html: string): string | undefined {
+  const encoded = html.match(
+    new RegExp(`<meta\\s+name=["']${SYNC_PAGE_META}["']\\s+content=["']([^"']+)["']`, 'i'),
+  )?.[1]
+  if (!encoded) return undefined
+  try {
+    return decodeURIComponent(encoded)
+  } catch {
+    return undefined
+  }
+}
+
+const BANNED_TAGS = 'script|noscript|iframe|frame|frameset|object|embed|applet|portal|fencedframe'
+
+/** The snippet already scrubs in the browser with real DOM APIs; this re-scrub
+ *  is belt-and-braces for hand-rolled posters. Regex-based on purpose — see
+ *  the module comment: the sandbox is the boundary, this only keeps snapshots
+ *  passive and editable. */
+export function sanitizeSnapshotHtml(html: string): string {
+  let out = html
+  /* paired blocks first, then any stray open/self-closed tags left behind */
+  out = out.replace(new RegExp(`<(${BANNED_TAGS})\\b[^>]*>[\\s\\S]*?<\\/\\1\\s*>`, 'gi'), '')
+  out = out.replace(new RegExp(`<\\/?(?:${BANNED_TAGS})\\b[^>]*>`, 'gi'), '')
+  out = out.replace(/<meta\b[^>]*http-equiv[^>]*>/gi, '')
+  out = out.replace(/<base\b[^>]*>/gi, '')
+  out = out.replace(/\s(?:on[a-z]+|srcdoc|ping)\s*=\s*("[^"]*"|'[^']*'|[^\s>]+)/gi, '')
+  out = out.replace(
+    /\s(href|src|action|formaction|poster|xlink:href)\s*=\s*("\s*javascript:[^"]*"|'\s*javascript:[^']*'|javascript:[^\s>]+)/gi,
+    '',
+  )
+  return out
+}
+
+function escapeAttr(value: string): string {
+  return value.replace(/&/g, '&amp;').replace(/"/g, '&quot;')
+}
+
+/** Scrub + stamp: marker meta, importer-grade CSP, and a base for the app's
+ *  relative asset URLs. Mirrors the injection the importer performs. */
+export function wrapSnapshotHtml(html: string, marker: string, baseUrl: string | undefined): string {
+  let out = sanitizeSnapshotHtml(html)
+  const inject =
+    `<meta name="${SYNC_PAGE_META}" content="${encodeURIComponent(marker)}">` +
+    `<meta http-equiv="Content-Security-Policy" content="${SNAPSHOT_CSP}">` +
+    (baseUrl ? `<base href="${escapeAttr(baseUrl)}">` : '')
+  const headMatch = out.match(/<head[^>]*>/i)
+  if (headMatch) out = out.replace(headMatch[0], headMatch[0] + inject)
+  else out = inject + out
+  if (!/^\s*<!doctype/i.test(out)) out = '<!doctype html>\n' + out
+  return out
+}
+
+/* ------------------------------------------------------------------ */
+
+export const MAX_SNAPSHOT_BYTES = 2_500_000
+const INGESTS_PER_MIN = 30
+/** floor between rewrites of the SAME page — a busy app must not churn the
+ *  canvas (and its websocket room) with a frame write per user interaction */
+const PAGE_MIN_INTERVAL_MS = Number(process.env.SYNC_PAGE_INTERVAL_MS ?? 30_000)
+
+const ingestHits = new Map<string, number[]>()
+const pageLastWrite = new Map<string, number>()
+
+function takeIngestSlot(keyId: string): boolean {
+  const now = Date.now()
+  const hits = (ingestHits.get(keyId) ?? []).filter((t) => now - t < 60_000)
+  if (hits.length >= INGESTS_PER_MIN) return false
+  hits.push(now)
+  ingestHits.set(keyId, hits)
+  return true
+}
+
+/** The snippet runs on a foreign origin, so every response must carry CORS.
+ *  `*` is safe here: the secret is in the path, no cookies are involved. */
+export function setIngestCors(res: express.Response) {
+  res.set('Access-Control-Allow-Origin', '*')
+  res.set('Access-Control-Allow-Methods', 'POST, OPTIONS')
+  res.set('Access-Control-Allow-Headers', 'Content-Type')
+  res.set('Access-Control-Max-Age', '86400')
+  /* Chrome Private Network Access: a page on a public origin posting to a
+     doop on localhost/an intranet host needs this opt-in on the preflight —
+     the local-testing and self-hosted cases. */
+  res.set('Access-Control-Allow-Private-Network', 'true')
+}
+
+/** Normalize the snippet's page identifier: a rooted path, bounded length. */
+function cleanPage(raw: unknown): string | null {
+  if (typeof raw !== 'string') return null
+  const page = raw.trim()
+  if (!page.startsWith('/') || page.length > 300 || /[\s<>"']/.test(page)) return null
+  return page
+}
+
+export async function handleIngest(req: express.Request, res: express.Response) {
+  setIngestCors(res)
+  const secret = String(req.params.key ?? '')
+  if (!/^dk_[\w-]{20,}$/.test(secret)) return res.status(404).json({ error: 'unknown sync key' })
+  const [key] = await db.select().from(syncKeys).where(eq(syncKeys.secret, secret))
+  if (!key) return res.status(404).json({ error: 'unknown sync key' })
+  const canvas = store.getCanvas(key.canvasId)
+  if (!canvas) return res.status(410).json({ error: 'the canvas this key points at no longer exists' })
+
+  const page = cleanPage(req.body?.page)
+  const html = typeof req.body?.html === 'string' ? req.body.html : ''
+  if (!page || !html.trim()) return res.status(400).json({ error: 'page (a rooted path) and html are required' })
+  if (html.length > MAX_SNAPSHOT_BYTES) {
+    return res.status(413).json({ error: 'snapshot exceeds the 2.5 MB limit — mask or exclude heavy content' })
+  }
+
+  if (!takeIngestSlot(key.id)) {
+    res.set('Retry-After', '60')
+    return res.status(429).json({ error: 'sync rate limit — slow down' })
+  }
+
+  let baseUrl: string | undefined
+  try {
+    const url = new URL(String(req.body?.url ?? ''))
+    if (url.protocol === 'http:' || url.protocol === 'https:') baseUrl = url.href
+  } catch {
+    /* no usable base — same-origin assets just won't resolve */
+  }
+
+  const marker = `${key.id}${page}`
+  const wrapped = wrapSnapshotHtml(html, marker, baseUrl)
+  const title = typeof req.body?.title === 'string' && req.body.title.trim() ? req.body.title.trim() : page
+  const width = Math.min(3840, Math.max(320, Math.round(Number(req.body?.width) || 1280)))
+  const height = Math.min(8000, Math.max(400, Math.round(Number(req.body?.height) || 900)))
+  const actor = actions.resolveActor({ name: key.name, kind: 'user' })
+
+  db.update(syncKeys)
+    .set({ lastUsedAt: Date.now() })
+    .where(eq(syncKeys.id, key.id))
+    .catch((err: unknown) => console.error('[ingest] lastUsedAt write failed', err))
+
+  const mine = canvas.frames.filter((f) => syncFrameMarker(f.html)?.startsWith(`${key.id}/`))
+  const existing = mine.find((f) => syncFrameMarker(f.html) === marker)
+  if (existing) {
+    if (existing.html === wrapped) return res.json({ ok: true, frameId: existing.id, unchanged: true })
+    const last = pageLastWrite.get(marker) ?? 0
+    if (Date.now() - last < PAGE_MIN_INTERVAL_MS) {
+      res.set('Retry-After', String(Math.ceil((PAGE_MIN_INTERVAL_MS - (Date.now() - last)) / 1000)))
+      return res.status(429).json({ error: 'this page was just synced — retry shortly' })
+    }
+    pageLastWrite.set(marker, Date.now())
+    /* geometry the user may have arranged stays; content and height track the app */
+    actions.updateFrame(existing.id, { html: wrapped, name: title.slice(0, 80), height }, actor)
+    return res.json({ ok: true, frameId: existing.id, updated: true })
+  }
+
+  /* New screen: extend this app's frames in one row so a synced app reads
+     left-to-right, starting to the right of everything else on the canvas. */
+  let x: number
+  let y: number
+  if (mine.length) {
+    x = Math.max(...mine.map((f) => f.x + f.width)) + 80
+    y = Math.min(...mine.map((f) => f.y))
+  } else {
+    const rightmost = canvas.frames.reduce((right, f) => Math.max(right, f.x + f.width), 0)
+    x = canvas.frames.length ? rightmost + 80 : 120
+    y = 120
+  }
+  pageLastWrite.set(marker, Date.now())
+  const frame = actions.createFrame(canvas.id, { name: title.slice(0, 80), x, y, width, height, html: wrapped }, actor)
+  if (!frame) return res.status(410).json({ error: 'canvas vanished mid-sync' })
+  res.json({ ok: true, frameId: frame.id, created: true })
+}
+
+/** Frames synced by a key, for the share modal's per-key screen count. */
+export function syncedFrameCount(canvas: { frames: Frame[] }, keyId: string): number {
+  return canvas.frames.filter((f) => syncFrameMarker(f.html)?.startsWith(`${keyId}/`)).length
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -9,6 +9,19 @@ export interface CanvasMember {
   owner: boolean
 }
 
+/** A write-only design-sync key: apps embed its secret in the doop-sync
+ *  snippet to push their live screens onto this canvas. */
+export interface SyncKeyInfo {
+  id: string
+  secret: string
+  canvasId: string
+  name: string
+  createdAt: number
+  lastUsedAt: number | null
+  /** synced frames currently on the canvas */
+  frames: number
+}
+
 export interface DiscoveredPage {
   url: string
   title: string
@@ -116,6 +129,12 @@ export const api = {
     req<CanvasMember>(`/api/canvases/${canvasId}/members`, { method: 'POST', body: JSON.stringify({ email }) }),
   removeMember: (canvasId: string, userId: string) =>
     req(`/api/canvases/${canvasId}/members/${userId}`, { method: 'DELETE' }),
+  /* design-sync keys for the embeddable snippet */
+  listSyncKeys: (canvasId: string) => req<SyncKeyInfo[]>(`/api/canvases/${canvasId}/sync-keys`),
+  createSyncKey: (canvasId: string, name: string) =>
+    req<SyncKeyInfo>(`/api/canvases/${canvasId}/sync-keys`, { method: 'POST', body: JSON.stringify({ name }) }),
+  deleteSyncKey: (canvasId: string, keyId: string) =>
+    req(`/api/canvases/${canvasId}/sync-keys/${keyId}`, { method: 'DELETE' }),
   guidelineHistory: (canvasId: string, name: string) =>
     req<{ markdown: string; savedAt: number; savedBy: string }[]>(
       `/api/canvases/${canvasId}/guidelines/${encodeURIComponent(name)}/history`,

--- a/src/pages/CanvasPage.tsx
+++ b/src/pages/CanvasPage.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useStore } from '../lib/store'
 import { connect, disconnect, sendWs } from '../lib/ws'
-import { api, ApiError, type CanvasMember, type DiscoveredSite } from '../lib/api'
+import { api, ApiError, type CanvasMember, type DiscoveredSite, type SyncKeyInfo } from '../lib/api'
 import { navigate, Logo } from '../App'
 import { Stage } from '../components/Stage'
 import { Board } from '../components/Board'
@@ -508,6 +508,7 @@ function ImportModal({
                       : '⤓ Import page'}
               </button>
             </div>
+            <SyncKeysSection canvasId={canvasId} />
           </>
         ) : (
           <>
@@ -725,6 +726,105 @@ function ShareModal({ canvasId, onClose, onCopied }: { canvasId: string; onClose
             ⧉ Copy link
           </button>
         </div>
+      </div>
+    </div>
+  )
+}
+
+/* Design sync: mint write-only snippet keys so an app pushes its live screens
+   onto this canvas — the import path for products behind SSO/VPN where the
+   server-side importer can't go. */
+function SyncKeysSection({ canvasId }: { canvasId: string }) {
+  const [keys, setKeys] = useState<SyncKeyInfo[] | null>(null)
+  const [name, setAppName] = useState('')
+  const [busy, setBusy] = useState(false)
+  const [copiedId, setCopiedId] = useState<string | null>(null)
+  /* keys are owner/member-only (durable access) — link-edit visitors get a
+     403 and shouldn't see the section at all */
+  const [forbidden, setForbidden] = useState(false)
+
+  useEffect(() => {
+    api
+      .listSyncKeys(canvasId)
+      .then(setKeys)
+      .catch((e) => {
+        if (e instanceof ApiError && e.status === 403) setForbidden(true)
+        setKeys([])
+      })
+  }, [canvasId])
+
+  const snippetFor = (secret: string) =>
+    `<script async src="${location.origin}/doop-sync.js" data-key="${secret}"></` + `script>`
+
+  async function create() {
+    if (busy || !name.trim()) return
+    setBusy(true)
+    try {
+      const key = await api.createSyncKey(canvasId, name.trim())
+      setKeys((k) => [key, ...(k ?? [])])
+      setAppName('')
+      posthog.capture('sync_key_created')
+    } catch (e) {
+      console.error(e)
+    }
+    setBusy(false)
+  }
+
+  function revoke(keyId: string) {
+    api.deleteSyncKey(canvasId, keyId).catch(console.error)
+    setKeys((k) => k?.filter((x) => x.id !== keyId) ?? null)
+  }
+
+  async function copySnippet(key: SyncKeyInfo) {
+    await navigator.clipboard.writeText(snippetFor(key.secret))
+    setCopiedId(key.id)
+    setTimeout(() => setCopiedId(null), 1500)
+  }
+
+  if (forbidden) return null
+  return (
+    <div className="sync-section">
+      <h3>Or sync a live app</h3>
+      <p className="share-note">
+        For apps a crawler can't reach — behind a login, a VPN, or on localhost. Paste one script tag and the screens
+        people visit land here as frames, kept current as the app changes. The key only writes to this canvas.
+      </p>
+      {(keys ?? []).map((k) => (
+        <div key={k.id} className="sync-key">
+          <div className="sync-key-row">
+            <b>{k.name}</b>
+            <span className="share-note">
+              {k.frames ? `${k.frames} screen${k.frames === 1 ? '' : 's'}` : k.lastUsedAt ? 'synced' : 'never synced'}
+            </span>
+            <button className="share-remove" title="Revoke this key" onClick={() => revoke(k.id)}>
+              ✕
+            </button>
+          </div>
+          <div className="sync-snippet-wrap">
+            <textarea
+              className="sync-snippet"
+              readOnly
+              rows={4}
+              value={snippetFor(k.secret)}
+              onFocus={(e) => e.target.select()}
+            />
+            <button className="btn sync-copy" onClick={() => copySnippet(k)}>
+              {copiedId === k.id ? 'Copied!' : '⧉ Copy'}
+            </button>
+          </div>
+        </div>
+      ))}
+      <div className="share-invite-row">
+        <input
+          placeholder="App name (e.g. Admin dashboard)"
+          value={name}
+          disabled={busy}
+          onChange={(e) => setAppName(e.target.value)}
+          onKeyDown={(e) => e.key === 'Enter' && create()}
+        />
+        <button className="btn primary" disabled={busy || !name.trim()} onClick={create}>
+          Create key
+        </button>
       </div>
     </div>
   )

--- a/src/styles.css
+++ b/src/styles.css
@@ -2150,6 +2150,74 @@ textarea {
   color: var(--ink-faint);
   margin: 0;
 }
+.sync-section {
+  border-top: 1px solid var(--line-soft);
+  padding-top: 14px;
+  margin-top: 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.sync-section h3 {
+  margin: 0;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--ink);
+}
+.sync-key {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.sync-key-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+}
+.sync-key-row b {
+  font-weight: 600;
+}
+.sync-key-row .share-note {
+  margin-right: auto;
+}
+/* the ✕ carries 6px of its own padding — pull it back so the glyph's edge
+   lines up with the snippet box's right border */
+.sync-key-row .share-remove {
+  margin-right: -6px;
+}
+.sync-snippet-wrap {
+  position: relative;
+}
+.sync-snippet {
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
+  resize: none;
+  font-size: 11px;
+  line-height: 1.5;
+  font-family: ui-monospace, monospace;
+  color: var(--ink-faint);
+  background: var(--surface-sunken, rgba(0, 0, 0, 0.04));
+  border: 1px solid var(--line-soft);
+  border-radius: 8px;
+  padding: 8px 10px;
+  padding-right: 84px;
+  word-break: break-all;
+}
+.sync-snippet:focus {
+  outline: none;
+  border-color: var(--line);
+  color: var(--ink);
+}
+.sync-copy {
+  position: absolute;
+  top: 12px;
+  right: 14px;
+  font-size: 12px;
+  padding: 4px 10px;
+  background: var(--surface);
+}
 .ctx-menu .ctx-hint {
   margin-left: auto;
   font-size: 11px;

--- a/tests/ingest.test.ts
+++ b/tests/ingest.test.ts
@@ -1,0 +1,177 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { Client, startServer, type Server } from './harness.ts'
+
+/**
+ * Design-sync ingest: the doop-sync snippet's endpoint and the key-management
+ * REST, exercised against the real server. The page-interval throttle is
+ * disabled via env so consecutive writes to the same page can be asserted.
+ */
+
+const PORT = 4980
+
+let server: Server
+let BASE: string
+
+beforeAll(async () => {
+  server = await startServer(PORT, { SYNC_PAGE_INTERVAL_MS: '0' })
+  BASE = server.base
+}, 70_000)
+
+afterAll(() => server?.stop())
+
+const SNAPSHOT = (marker: string) =>
+  `<html><head><title>t</title><meta http-equiv="refresh" content="1"><base href="https://evil.example/"></head>` +
+  `<body onload="alert(1)"><script>alert(1)</script><h1 onclick="x()">${marker}</h1>` +
+  `<a href="javascript:alert(1)">x</a><iframe src="https://x.example"></iframe></body></html>`
+
+describe('design sync ingest', () => {
+  let owner: Client
+  let stranger: Client
+  let canvasId: string
+  let secret: string
+  let keyId: string
+
+  beforeAll(async () => {
+    owner = new Client(server)
+    stranger = new Client(server)
+    await owner.signUp('sync-owner@test.dev', 'Owner')
+    await stranger.signUp('sync-stranger@test.dev', 'Stranger')
+    const canvas = await (await owner.post('/api/canvases', { name: 'Synced' })).json()
+    canvasId = canvas.id
+  })
+
+  it('members can mint keys; strangers cannot', async () => {
+    expect((await stranger.post(`/api/canvases/${canvasId}/sync-keys`, { name: 'nope' })).status).toBe(403)
+    expect((await stranger.get(`/api/canvases/${canvasId}/sync-keys`)).status).toBe(403)
+
+    const res = await owner.post(`/api/canvases/${canvasId}/sync-keys`, { name: 'Admin app' })
+    expect(res.status).toBe(200)
+    const key = await res.json()
+    expect(key.secret).toMatch(/^dk_/)
+    expect(key.name).toBe('Admin app')
+    secret = key.secret
+    keyId = key.id
+
+    const list = await (await owner.get(`/api/canvases/${canvasId}/sync-keys`)).json()
+    expect(list).toHaveLength(1)
+    expect(list[0].frames).toBe(0)
+  })
+
+  it('answers CORS preflight and stamps CORS on responses', async () => {
+    const preflight = await fetch(`${BASE}/ingest/${secret}`, { method: 'OPTIONS' })
+    expect(preflight.status).toBe(204)
+    expect(preflight.headers.get('access-control-allow-origin')).toBe('*')
+    const bad = await fetch(`${BASE}/ingest/dk_00000000000000000000000000`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ page: '/x', html: '<p>x</p>' }),
+    })
+    expect(bad.status).toBe(404)
+    expect(bad.headers.get('access-control-allow-origin')).toBe('*')
+  })
+
+  it('creates a frame from a snapshot and scrubs it', async () => {
+    const res = await fetch(`${BASE}/ingest/${secret}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        page: '/orders/:id',
+        title: 'Orders',
+        url: 'https://intranet.example/orders/1',
+        width: 1440,
+        height: 2000,
+        html: SNAPSHOT('one'),
+      }),
+    })
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.created).toBe(true)
+
+    const canvas = await (await owner.get(`/api/canvases/${canvasId}`)).json()
+    expect(canvas.frames).toHaveLength(1)
+    const frame = canvas.frames[0]
+    expect(frame.name).toBe('Orders')
+    expect(frame.width).toBe(1440)
+    expect(frame.html).toContain('one')
+    expect(frame.html).toContain('doop-sync-page')
+    expect(frame.html).toContain('Content-Security-Policy')
+    /* the app's base is kept, the snapshot's own base and scripts are not */
+    expect(frame.html).toContain('base href="https://intranet.example/orders/1"')
+    expect(frame.html).not.toContain('evil.example')
+    expect(frame.html).not.toContain('<script')
+    expect(frame.html).not.toContain('<iframe')
+    expect(frame.html).not.toContain('onload=')
+    expect(frame.html).not.toContain('onclick=')
+    expect(frame.html).not.toContain('javascript:')
+    expect(frame.html).not.toContain('http-equiv="refresh"')
+  })
+
+  it('updates the same frame on re-sync and reports unchanged replays', async () => {
+    const send = (html: string) =>
+      fetch(`${BASE}/ingest/${secret}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ page: '/orders/:id', title: 'Orders v2', url: 'https://intranet.example/', html }),
+      })
+    const updated = await (await send(SNAPSHOT('two'))).json()
+    expect(updated.updated).toBe(true)
+    const replay = await (await send(SNAPSHOT('two'))).json()
+    expect(replay.unchanged).toBe(true)
+
+    const canvas = await (await owner.get(`/api/canvases/${canvasId}`)).json()
+    expect(canvas.frames).toHaveLength(1)
+    expect(canvas.frames[0].html).toContain('two')
+    expect(canvas.frames[0].name).toBe('Orders v2')
+  })
+
+  it('a new page becomes a second frame in the same row', async () => {
+    const res = await fetch(`${BASE}/ingest/${secret}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'text/plain' }, // sendBeacon's content type
+      body: JSON.stringify({ page: '/settings', html: '<html><body><h2>Settings</h2></body></html>' }),
+    })
+    expect((await res.json()).created).toBe(true)
+    const canvas = await (await owner.get(`/api/canvases/${canvasId}`)).json()
+    expect(canvas.frames).toHaveLength(2)
+    const [a, b] = canvas.frames
+    expect(b.y).toBe(a.y)
+    expect(b.x).toBeGreaterThan(a.x + a.width)
+
+    const list = await (await owner.get(`/api/canvases/${canvasId}/sync-keys`)).json()
+    expect(list[0].frames).toBe(2)
+    expect(list[0].lastUsedAt).toBeGreaterThan(0)
+  })
+
+  it('rejects malformed payloads', async () => {
+    const post = (body: unknown) =>
+      fetch(`${BASE}/ingest/${secret}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      })
+    expect((await post({ page: 'not-rooted', html: '<p>x</p>' })).status).toBe(400)
+    expect((await post({ page: '/x' })).status).toBe(400)
+    expect((await post({ page: '/big', html: '<p>' + 'x'.repeat(2_600_000) + '</p>' })).status).toBe(413)
+  })
+
+  it('link-edit visitors can edit frames but cannot touch sync keys', async () => {
+    /* the P1 from review: a share-link visitor must not be able to read or
+       mint a durable bearer secret that outlives the link being turned off */
+    expect((await owner.patch(`/api/canvases/${canvasId}`, { linkAccess: 'edit' })).status).toBe(200)
+    expect((await stranger.get(`/api/canvases/${canvasId}`)).status).toBe(200) // link access works…
+    expect((await stranger.get(`/api/canvases/${canvasId}/sync-keys`)).status).toBe(403)
+    expect((await stranger.post(`/api/canvases/${canvasId}/sync-keys`, { name: 'sneaky' })).status).toBe(403)
+    expect((await stranger.delete(`/api/canvases/${canvasId}/sync-keys/${keyId}`)).status).toBe(403)
+    expect((await owner.patch(`/api/canvases/${canvasId}`, { linkAccess: 'none' })).status).toBe(200)
+  })
+
+  it('revoked keys stop working immediately', async () => {
+    expect((await owner.delete(`/api/canvases/${canvasId}/sync-keys/${keyId}`)).status).toBe(200)
+    const res = await fetch(`${BASE}/ingest/${secret}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ page: '/x', html: '<p>x</p>' }),
+    })
+    expect(res.status).toBe(404)
+  })
+})

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -13,6 +13,10 @@ export default defineConfig({
   plugins: [react()],
   server: {
     port: webPort,
+    /* the doop-sync snippet posts to /ingest from foreign origins; vite
+       answers CORS preflights itself before the proxy, so its default
+       same-origin policy would block what the express server (prod) allows */
+    cors: true,
     proxy: {
       /* changeOrigin stays OFF so the backend sees the web origin's Host and
          better-auth builds OAuth discovery/authorize URLs on that origin —
@@ -22,6 +26,7 @@ export default defineConfig({
       '/i': { target: api },
       '/a/': { target: api },
       '/u/': { target: api },
+      '/ingest': { target: api },
       '/relay': { target: api },
       '/blog': { target: api },
       '/robots.txt': { target: api },


### PR DESCRIPTION
A one-line snippet in an app sends its rendered screens to a canvas: each distinct screen lands as a frame and stays current as the app changes. Adds per-canvas sync keys (migration `0004_design_sync_keys`), the `/ingest` endpoint, and the snippet itself.

Ported from the upstream private repo (upstream #71). bun.lock changes dropped (OSS is npm-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)