### PR TITLE
fix(tests): move admin suite to ports 4985-4988, clear of parallel test files

### DIFF
--- a/tests/admin.test.ts
+++ b/tests/admin.test.ts
@@ -11,7 +11,11 @@ import { Client, startServer, type Server } from './harness.ts'
  *     session.impersonatedBy behind, and cannot mint MCP tokens.
  */
 
-const PORT = 4978
+/* Base port for this file. Offsets +1..+3 spawn extra servers, so keep the
+   whole range clear of every other test file's port (they run in parallel —
+   a second server on a taken port passes /healthz against the WRONG instance
+   and the test then reads someone else's database). */
+const PORT = 4985
 
 let server: Server
 let boss: Client


### PR DESCRIPTION
The `admin.test.ts` suite spawns extra servers on `PORT+1..+3` (4979–4981), which collide with `frameHtml.test.ts` (4979) and the new `ingest.test.ts` (4980) — vitest runs files in parallel, and `startServer` polls `/healthz`, which happily answers from whichever server already holds the port. The test then runs its assertions against another suite's database and reads `undefined`. This is why `main` CI went red after #27: the ingest file shifted scheduling enough for the latent collision to bite.

Moves the admin suite to 4985–4988, clear of every other file. Upstream has the same latent collision (identical ports, green CI by timing luck) — worth fixing there too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)