### PR TITLE
feat: flow map — connectors show which button leads to which screen

### DIFF
--- a/public/doop-sync.js
+++ b/public/doop-sync.js
@@ -69,8 +69,8 @@
 
   /* One frame per SCREEN, not per record: normalize id-looking path segments
      so /orders/8231 and /orders/9007 land on the same frame. */
-  function routeKey() {
-    var segs = location.pathname.split('/').map(function (seg) {
+  function routeKey(pathname) {
+    var segs = (pathname === undefined ? location.pathname : pathname).split('/').map(function (seg) {
       if (!seg) return seg
       if (/^\d+$/.test(seg)) return ':id'
       if (/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(seg)) return ':id'
@@ -281,14 +281,62 @@
     })
   }
 
+  /* ---- flow map: which link sits where, and where people actually went */
+
+  /* Same-app link hotspots visible on this screen, in document coordinates —
+     doop draws them as connectors between the synced frames. */
+  function collectLinks(page) {
+    var out = []
+    var anchors = document.querySelectorAll('a[href]')
+    for (var i = 0; i < anchors.length && out.length < 100; i++) {
+      var a = anchors[i]
+      var abs = absUrl(a.getAttribute('href'))
+      if (!abs || !isSameOrigin(abs)) continue
+      var to
+      try {
+        to = routeKey(new URL(abs).pathname)
+      } catch (e) {
+        continue
+      }
+      if (to === page) continue
+      var rect = a.getBoundingClientRect()
+      if (rect.width < 2 || rect.height < 2) continue
+      out.push({
+        to: to,
+        x: rect.left + window.scrollX,
+        y: rect.top + window.scrollY,
+        w: rect.width,
+        h: rect.height,
+        label: (a.getAttribute('aria-label') || a.textContent || '').trim().slice(0, 60),
+      })
+    }
+    return out
+  }
+
+  /* Navigations users make are the traffic weights on the link map. Edges
+     ride along on the next upload; an unchanged screen flushes them alone. */
+  var lastPage = routeKey()
+  var pendingEdges = []
+  function recordNav() {
+    var now = routeKey()
+    if (now !== lastPage) {
+      if (pendingEdges.length < 20) pendingEdges.push({ from: lastPage, to: now })
+      lastPage = now
+    }
+  }
+
   function hash(s) {
     var h = 5381
     for (var i = 0; i < s.length; i++) h = ((h << 5) + h + s.charCodeAt(i)) | 0
     return String(h)
   }
 
+  /* CAPTURE_VERSION invalidates the dedup when the capture format changes —
+     an upgraded snippet must re-upload screens whose HTML alone is unchanged
+     (e.g. to populate the flow map's link hotspots). */
+  var CAPTURE_VERSION = '2'
   function memoKey(page) {
-    return '__doopSync:' + KEY.slice(-6) + ':' + page
+    return '__doopSync:' + CAPTURE_VERSION + ':' + KEY.slice(-6) + ':' + page
   }
 
   function shouldSend(page, h) {
@@ -307,6 +355,7 @@
     if (capturing) return
     capturing = true
     var page = routeKey()
+    var edges = []
     /* Promise.resolve().then keeps a synchronous throw inside serialize on
        the promise chain — it must hit the catch below, or `capturing` wedges
        shut and every later capture silently no-ops. */
@@ -321,7 +370,23 @@
           return
         }
         var h = hash(html)
-        if (!force && !shouldSend(page, h)) return
+        edges = pendingEdges.splice(0, 20)
+        if (!force && !shouldSend(page, h)) {
+          if (!edges.length) return
+          /* screen unchanged — flush just the navigations */
+          return fetch(ENDPOINT, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            keepalive: true,
+            body: JSON.stringify({ page: page, edges: edges }),
+          }).then(function (r) {
+            /* only the server's explicit marker proves the edges were stored:
+               its rate-limit 429 fires before recording (requeue), while the
+               page-throttle 429 fires after (requeue would double-count) */
+            if (r.headers.get('X-Doop-Edges') !== null) edges = []
+            if (!r.ok) throw new Error('sync ' + r.status)
+          })
+        }
         try {
           localStorage.setItem(memoKey(page), JSON.stringify({ h: h, t: Date.now() }))
         } catch (e) {
@@ -338,16 +403,21 @@
             width: window.innerWidth,
             height: Math.min(document.documentElement.scrollHeight, 8000),
             html: html,
+            links: collectLinks(page),
+            edges: edges,
           }),
         }).then(function (r) {
+          if (r.headers.get('X-Doop-Edges') !== null) edges = [] // recorded server-side — see above
           if (!r.ok) throw new Error('sync ' + r.status)
         })
       })
       ['catch'](function (err) {
-        /* never break the host app over a sync error — but log it, and drop
-           the memo so the next scheduled capture retries instead of skipping */
+        /* never break the host app over a sync error — but log it, drop the
+           memo so the next scheduled capture retries instead of skipping,
+           and put the drained navigations back so counts don't under-report */
         console.warn('[doop-sync] capture failed', err)
         capturing = false
+        if (edges.length) pendingEdges = edges.concat(pendingEdges).slice(0, 20)
         try {
           localStorage.removeItem(memoKey(page))
         } catch (e2) {
@@ -371,16 +441,19 @@
   var push = history.pushState
   history.pushState = function () {
     var out = push.apply(this, arguments)
+    recordNav()
     schedule()
     return out
   }
   var replace = history.replaceState
   history.replaceState = function () {
     var out = replace.apply(this, arguments)
+    recordNav()
     schedule()
     return out
   }
   window.addEventListener('popstate', function () {
+    recordNav()
     schedule()
   })
 

--- a/server/db/migrations/0005_sync_flow.sql
+++ b/server/db/migrations/0005_sync_flow.sql
@@ -1,0 +1,21 @@
+CREATE TABLE "sync_edges" (
+	"key_id" text NOT NULL,
+	"from_page" text NOT NULL,
+	"to_page" text NOT NULL,
+	"count" integer DEFAULT 0 NOT NULL,
+	"last_at" bigint NOT NULL,
+	CONSTRAINT "sync_edges_key_id_from_page_to_page_pk" PRIMARY KEY("key_id","from_page","to_page")
+);
+--> statement-breakpoint
+CREATE TABLE "sync_links" (
+	"key_id" text NOT NULL,
+	"page" text NOT NULL,
+	"to_page" text NOT NULL,
+	"x" double precision NOT NULL,
+	"y" double precision NOT NULL,
+	"width" double precision NOT NULL,
+	"height" double precision NOT NULL,
+	"label" text
+);
+--> statement-breakpoint
+CREATE INDEX "sync_links_page_idx" ON "sync_links" USING btree ("key_id","page");

--- a/server/db/migrations/meta/0005_snapshot.json
+++ b/server/db/migrations/meta/0005_snapshot.json
@@ -1,0 +1,2092 @@
+{
+  "id": "6641dc4b-c860-4d3f-9ce0-a5e03db1341f",
+  "prevId": "7825feca-3f18-4243-baf2-13ffca8b0f0d",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.activity": {
+      "name": "activity",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "canvas_id": {
+          "name": "canvas_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_kind": {
+          "name": "actor_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_color": {
+          "name": "actor_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frame_id": {
+          "name": "frame_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "at": {
+          "name": "at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "activity_canvas_idx": {
+          "name": "activity_canvas_idx",
+          "columns": [
+            {
+              "expression": "canvas_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.asset_refs": {
+      "name": "asset_refs",
+      "schema": "",
+      "columns": {
+        "asset_id": {
+          "name": "asset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frame_id": {
+          "name": "frame_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "asset_refs_frame_idx": {
+          "name": "asset_refs_frame_idx",
+          "columns": [
+            {
+              "expression": "frame_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "asset_refs_asset_id_frame_id_pk": {
+          "name": "asset_refs_asset_id_frame_id_pk",
+          "columns": ["asset_id", "frame_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.assets": {
+      "name": "assets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "canvas_id": {
+          "name": "canvas_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mime": {
+          "name": "mime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ext": {
+          "name": "ext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "assets_canvas_idx": {
+          "name": "assets_canvas_idx",
+          "columns": [
+            {
+              "expression": "canvas_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.canvas_members": {
+      "name": "canvas_members",
+      "schema": "",
+      "columns": {
+        "canvas_id": {
+          "name": "canvas_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "added_by": {
+          "name": "added_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "canvas_members_canvas_id_user_id_pk": {
+          "name": "canvas_members_canvas_id_user_id_pk",
+          "columns": ["canvas_id", "user_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.canvases": {
+      "name": "canvases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_access": {
+          "name": "link_access",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.comments": {
+      "name": "comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "canvas_id": {
+          "name": "canvas_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frame_id": {
+          "name": "frame_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "selector": {
+          "name": "selector",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snippet": {
+          "name": "snippet",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_name": {
+          "name": "from_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_user_id": {
+          "name": "from_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "at": {
+          "name": "at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "for_agent": {
+          "name": "for_agent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "target_agent": {
+          "name": "target_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_by": {
+          "name": "claimed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failed_at": {
+          "name": "failed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "comments_canvas_idx": {
+          "name": "comments_canvas_idx",
+          "columns": [
+            {
+              "expression": "canvas_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.decisions": {
+      "name": "decisions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "canvas_id": {
+          "name": "canvas_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frame_id": {
+          "name": "frame_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_name": {
+          "name": "from_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "at": {
+          "name": "at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "distilled_at": {
+          "name": "distilled_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "decisions_canvas_idx": {
+          "name": "decisions_canvas_idx",
+          "columns": [
+            {
+              "expression": "canvas_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feedback": {
+      "name": "feedback",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canvas_id": {
+          "name": "canvas_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_agent": {
+          "name": "target_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_name": {
+          "name": "from_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_user_id": {
+          "name": "from_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "at": {
+          "name": "at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_by": {
+          "name": "claimed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failed_at": {
+          "name": "failed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "feedback_canvas_idx": {
+          "name": "feedback_canvas_idx",
+          "columns": [
+            {
+              "expression": "canvas_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.frames": {
+      "name": "frames",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "canvas_id": {
+          "name": "canvas_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "x": {
+          "name": "x",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "y": {
+          "name": "y",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "width": {
+          "name": "width",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "height": {
+          "name": "height",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "html": {
+          "name": "html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "demo": {
+          "name": "demo",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "frames_canvas_idx": {
+          "name": "frames_canvas_idx",
+          "columns": [
+            {
+              "expression": "canvas_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.guideline_versions": {
+      "name": "guideline_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "canvas_id": {
+          "name": "canvas_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "markdown": {
+          "name": "markdown",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "saved_at": {
+          "name": "saved_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "saved_by": {
+          "name": "saved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "guideline_versions_doc_idx": {
+          "name": "guideline_versions_doc_idx",
+          "columns": [
+            {
+              "expression": "canvas_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.guidelines": {
+      "name": "guidelines",
+      "schema": "",
+      "columns": {
+        "canvas_id": {
+          "name": "canvas_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "markdown": {
+          "name": "markdown",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "x": {
+          "name": "x",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "y": {
+          "name": "y",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "guidelines_canvas_id_name_pk": {
+          "name": "guidelines_canvas_id_name_pk",
+          "columns": ["canvas_id", "name"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.memory_proposals": {
+      "name": "memory_proposals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "canvas_id": {
+          "name": "canvas_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guide_name": {
+          "name": "guide_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guide_title": {
+          "name": "guide_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rule": {
+          "name": "rule",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rationale": {
+          "name": "rationale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "based_on": {
+          "name": "based_on",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "at": {
+          "name": "at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "memory_proposals_canvas_idx": {
+          "name": "memory_proposals_canvas_idx",
+          "columns": [
+            {
+              "expression": "canvas_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.memory_references": {
+      "name": "memory_references",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "canvas_id": {
+          "name": "canvas_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frame_id": {
+          "name": "frame_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "html": {
+          "name": "html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "width": {
+          "name": "width",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "height": {
+          "name": "height",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pinned_by": {
+          "name": "pinned_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pinned_at": {
+          "name": "pinned_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "memory_references_canvas_idx": {
+          "name": "memory_references_canvas_idx",
+          "columns": [
+            {
+              "expression": "canvas_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.model_accounts": {
+      "name": "model_accounts",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan": {
+          "name": "plan",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connected_at": {
+          "name": "connected_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.resident_usage": {
+      "name": "resident_usage",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "used": {
+          "name": "used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sync_edges": {
+      "name": "sync_edges",
+      "schema": "",
+      "columns": {
+        "key_id": {
+          "name": "key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_page": {
+          "name": "from_page",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_page": {
+          "name": "to_page",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_at": {
+          "name": "last_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "sync_edges_key_id_from_page_to_page_pk": {
+          "name": "sync_edges_key_id_from_page_to_page_pk",
+          "columns": ["key_id", "from_page", "to_page"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sync_keys": {
+      "name": "sync_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canvas_id": {
+          "name": "canvas_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "sync_keys_canvas_idx": {
+          "name": "sync_keys_canvas_idx",
+          "columns": [
+            {
+              "expression": "canvas_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sync_keys_secret_idx": {
+          "name": "sync_keys_secret_idx",
+          "columns": [
+            {
+              "expression": "secret",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sync_links": {
+      "name": "sync_links",
+      "schema": "",
+      "columns": {
+        "key_id": {
+          "name": "key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "page": {
+          "name": "page",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_page": {
+          "name": "to_page",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "x": {
+          "name": "x",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "y": {
+          "name": "y",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "width": {
+          "name": "width",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "height": {
+          "name": "height",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "sync_links_page_idx": {
+          "name": "sync_links_page_idx",
+          "columns": [
+            {
+              "expression": "key_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "page",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tasks": {
+      "name": "tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "canvas_id": {
+          "name": "canvas_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto": {
+          "name": "auto",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "queued_by": {
+          "name": "queued_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failed_at": {
+          "name": "failed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pipeline": {
+          "name": "pipeline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stage": {
+          "name": "stage",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attachments": {
+          "name": "attachments",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "queued_by_user_id": {
+          "name": "queued_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "tasks_canvas_idx": {
+          "name": "tasks_canvas_idx",
+          "columns": [
+            {
+              "expression": "canvas_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_access_token": {
+      "name": "oauth_access_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_access_token_access_token_unique": {
+          "name": "oauth_access_token_access_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["access_token"]
+        },
+        "oauth_access_token_refresh_token_unique": {
+          "name": "oauth_access_token_refresh_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["refresh_token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_application": {
+      "name": "oauth_application",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_urls": {
+          "name": "redirect_urls",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_application_client_id_unique": {
+          "name": "oauth_application_client_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["client_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_consent": {
+      "name": "oauth_consent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "consent_given": {
+          "name": "consent_given",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/server/db/migrations/meta/_journal.json
+++ b/server/db/migrations/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1787764855067,
       "tag": "0004_design_sync_keys",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1787770420646,
+      "tag": "0005_sync_flow",
+      "breakpoints": true
     }
   ]
 }

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -73,6 +73,38 @@ export const syncKeys = pgTable(
   (t) => [index('sync_keys_canvas_idx').on(t.canvasId), index('sync_keys_secret_idx').on(t.secret)],
 )
 
+/** Link hotspots a synced page declares: where each same-app link sits in the
+ *  snapshot and which page it leads to. Replaced wholesale on every capture
+ *  of that page — the set mirrors the CURRENT design, it is not history. */
+export const syncLinks = pgTable(
+  'sync_links',
+  {
+    keyId: text('key_id').notNull(),
+    page: text('page').notNull(),
+    toPage: text('to_page').notNull(),
+    x: doublePrecision('x').notNull(),
+    y: doublePrecision('y').notNull(),
+    width: doublePrecision('width').notNull(),
+    height: doublePrecision('height').notNull(),
+    label: text('label'),
+  },
+  (t) => [index('sync_links_page_idx').on(t.keyId, t.page)],
+)
+
+/** Navigations users actually made in the synced app, accumulated per route
+ *  pair — the traffic weights on top of the declared link map. */
+export const syncEdges = pgTable(
+  'sync_edges',
+  {
+    keyId: text('key_id').notNull(),
+    fromPage: text('from_page').notNull(),
+    toPage: text('to_page').notNull(),
+    count: integer('count').notNull().default(0),
+    lastAt: bigint('last_at', { mode: 'number' }).notNull(),
+  },
+  (t) => [primaryKey({ columns: [t.keyId, t.fromPage, t.toPage] })],
+)
+
 export const tasks = pgTable(
   'tasks',
   {

--- a/server/index.ts
+++ b/server/index.ts
@@ -818,6 +818,14 @@ app.post('/api/canvases/:id/sync-keys', async (req, res) => {
   res.json({ ...key, frames: 0 })
 })
 
+/* the flow map is design insight, not a credential — anyone who can see the
+   frames can see how they connect */
+app.get('/api/canvases/:id/sync-flow', async (req, res) => {
+  const c = requireCanvas(req, res, req.params.id)
+  if (!c) return
+  res.json(await ingest.getSyncFlow(c))
+})
+
 app.delete('/api/canvases/:id/sync-keys/:keyId', async (req, res) => {
   if (!requireDurableCanvas(req, res, req.params.id)) return
   if (!(await ingest.deleteSyncKey(req.params.id, req.params.keyId)))

--- a/server/ingest.ts
+++ b/server/ingest.ts
@@ -1,8 +1,8 @@
 import type express from 'express'
 import { nanoid } from 'nanoid'
-import { and, desc, eq } from 'drizzle-orm'
+import { and, desc, eq, inArray, sql } from 'drizzle-orm'
 import { db } from './db/index.ts'
-import { syncKeys } from './db/schema.ts'
+import { syncEdges, syncKeys, syncLinks } from './db/schema.ts'
 import { store } from './store.ts'
 import * as actions from './actions.ts'
 import type { Frame } from '../shared/types.ts'
@@ -55,6 +55,14 @@ export async function deleteSyncKey(canvasId: string, id: string): Promise<boole
     .delete(syncKeys)
     .where(and(eq(syncKeys.id, id), eq(syncKeys.canvasId, canvasId)))
     .returning({ id: syncKeys.id })
+  if (gone.length) {
+    db.delete(syncLinks)
+      .where(eq(syncLinks.keyId, id))
+      .catch((err: unknown) => console.error('[ingest] link cleanup failed', err))
+    db.delete(syncEdges)
+      .where(eq(syncEdges.keyId, id))
+      .catch((err: unknown) => console.error('[ingest] edge cleanup failed', err))
+  }
   return gone.length > 0
 }
 
@@ -160,6 +168,8 @@ export function setIngestCors(res: express.Response) {
   res.set('Access-Control-Allow-Origin', '*')
   res.set('Access-Control-Allow-Methods', 'POST, OPTIONS')
   res.set('Access-Control-Allow-Headers', 'Content-Type')
+  /* the snippet reads this to know its edge batch was recorded (see below) */
+  res.set('Access-Control-Expose-Headers', 'X-Doop-Edges')
   res.set('Access-Control-Max-Age', '86400')
   /* Chrome Private Network Access: a page on a public origin posting to a
      doop on localhost/an intranet host needs this opt-in on the preflight —
@@ -175,6 +185,92 @@ function cleanPage(raw: unknown): string | null {
   return page
 }
 
+/* ---- flow map: which button leads where, and where users actually went.
+   The snippet sends `links` (same-app link hotspots found in the snapshot,
+   replaced per capture) and `edges` (navigations since the last upload,
+   accumulated). Together they draw the app's information architecture as
+   connectors between synced frames. */
+
+interface SyncLinkInput {
+  to: string
+  x: number
+  y: number
+  width: number
+  height: number
+  label?: string
+}
+
+const MAX_LINKS = 120
+const MAX_EDGES = 20
+
+function cleanLinks(raw: unknown, page: string): SyncLinkInput[] {
+  if (!Array.isArray(raw)) return []
+  const links: SyncLinkInput[] = []
+  for (const item of raw.slice(0, MAX_LINKS)) {
+    const to = cleanPage((item as Record<string, unknown>)?.to)
+    const { x, y, w, h, label } = (item ?? {}) as Record<string, unknown>
+    if (!to || to === page) continue
+    const nums = [x, y, w, h].map(Number)
+    if (nums.some((n) => !Number.isFinite(n)) || nums[2]! <= 0 || nums[3]! <= 0) continue
+    links.push({
+      to,
+      x: nums[0]!,
+      y: nums[1]!,
+      width: nums[2]!,
+      height: nums[3]!,
+      label: typeof label === 'string' && label.trim() ? label.trim().slice(0, 60) : undefined,
+    })
+  }
+  return links
+}
+
+/* Both writers are awaited on the ingest path so a flow read right after an
+   upload sees the data — but a storage hiccup must not fail the sync. */
+async function saveLinks(keyId: string, page: string, links: SyncLinkInput[]) {
+  try {
+    await db.delete(syncLinks).where(and(eq(syncLinks.keyId, keyId), eq(syncLinks.page, page)))
+    if (links.length) {
+      await db.insert(syncLinks).values(
+        links.map((l) => ({
+          keyId,
+          page,
+          toPage: l.to,
+          x: l.x,
+          y: l.y,
+          width: l.width,
+          height: l.height,
+          label: l.label ?? null,
+        })),
+      )
+    }
+  } catch (err) {
+    console.error('[ingest] link write failed', err)
+  }
+}
+
+async function recordEdges(keyId: string, raw: unknown): Promise<number> {
+  if (!Array.isArray(raw)) return 0
+  let recorded = 0
+  for (const item of raw.slice(0, MAX_EDGES)) {
+    const from = cleanPage((item as Record<string, unknown>)?.from)
+    const to = cleanPage((item as Record<string, unknown>)?.to)
+    if (!from || !to || from === to) continue
+    recorded++
+    try {
+      await db
+        .insert(syncEdges)
+        .values({ keyId, fromPage: from, toPage: to, count: 1, lastAt: Date.now() })
+        .onConflictDoUpdate({
+          target: [syncEdges.keyId, syncEdges.fromPage, syncEdges.toPage],
+          set: { count: sql`${syncEdges.count} + 1`, lastAt: Date.now() },
+        })
+    } catch (err) {
+      console.error('[ingest] edge write failed', err)
+    }
+  }
+  return recorded
+}
+
 export async function handleIngest(req: express.Request, res: express.Response) {
   setIngestCors(res)
   const secret = String(req.params.key ?? '')
@@ -186,15 +282,32 @@ export async function handleIngest(req: express.Request, res: express.Response) 
 
   const page = cleanPage(req.body?.page)
   const html = typeof req.body?.html === 'string' ? req.body.html : ''
-  if (!page || !html.trim()) return res.status(400).json({ error: 'page (a rooted path) and html are required' })
-  if (html.length > MAX_SNAPSHOT_BYTES) {
-    return res.status(413).json({ error: 'snapshot exceeds the 2.5 MB limit — mask or exclude heavy content' })
-  }
+  if (!page) return res.status(400).json({ error: 'page (a rooted path) is required' })
 
   if (!takeIngestSlot(key.id)) {
     res.set('Retry-After', '60')
     return res.status(429).json({ error: 'sync rate limit — slow down' })
   }
+
+  const edgesRecorded = await recordEdges(key.id, req.body?.edges)
+  /* From here on, edges from this request are in the database — every
+     response (including the page-throttle 429 below) carries this marker so
+     the snippet knows not to requeue them. The rate-limit 429 above returns
+     WITHOUT it: those edges were never recorded and the snippet must retry. */
+  res.set('X-Doop-Edges', String(edgesRecorded))
+
+  /* Edge-only flush: an unchanged screen has nothing to upload, but the
+     navigations that happened on it are still worth keeping. */
+  if (!html.trim()) {
+    if (!edgesRecorded) return res.status(400).json({ error: 'html (or edges) required' })
+    return res.json({ ok: true, edges: edgesRecorded })
+  }
+  if (html.length > MAX_SNAPSHOT_BYTES) {
+    return res.status(413).json({ error: 'snapshot exceeds the 2.5 MB limit — mask or exclude heavy content' })
+  }
+  /* hotspots persist only once the frame write they describe lands (below) —
+     a 429'd snapshot must not leave coordinates for content nobody sees */
+  const links = cleanLinks(req.body?.links, page)
 
   let baseUrl: string | undefined
   try {
@@ -219,7 +332,12 @@ export async function handleIngest(req: express.Request, res: express.Response) 
   const mine = canvas.frames.filter((f) => syncFrameMarker(f.html)?.startsWith(`${key.id}/`))
   const existing = mine.find((f) => syncFrameMarker(f.html) === marker)
   if (existing) {
-    if (existing.html === wrapped) return res.json({ ok: true, frameId: existing.id, unchanged: true })
+    if (existing.html === wrapped) {
+      /* content matches, but this capture may still carry fresher hotspots —
+         e.g. the first upload from a snippet version that reports links */
+      await saveLinks(key.id, page, links)
+      return res.json({ ok: true, frameId: existing.id, unchanged: true })
+    }
     const last = pageLastWrite.get(marker) ?? 0
     if (Date.now() - last < PAGE_MIN_INTERVAL_MS) {
       res.set('Retry-After', String(Math.ceil((PAGE_MIN_INTERVAL_MS - (Date.now() - last)) / 1000)))
@@ -228,6 +346,7 @@ export async function handleIngest(req: express.Request, res: express.Response) 
     pageLastWrite.set(marker, Date.now())
     /* geometry the user may have arranged stays; content and height track the app */
     actions.updateFrame(existing.id, { html: wrapped, name: title.slice(0, 80), height }, actor)
+    await saveLinks(key.id, page, links)
     return res.json({ ok: true, frameId: existing.id, updated: true })
   }
 
@@ -246,10 +365,63 @@ export async function handleIngest(req: express.Request, res: express.Response) 
   pageLastWrite.set(marker, Date.now())
   const frame = actions.createFrame(canvas.id, { name: title.slice(0, 80), x, y, width, height, html: wrapped }, actor)
   if (!frame) return res.status(410).json({ error: 'canvas vanished mid-sync' })
+  await saveLinks(key.id, page, links)
   res.json({ ok: true, frameId: frame.id, created: true })
 }
 
 /** Frames synced by a key, for the share modal's per-key screen count. */
 export function syncedFrameCount(canvas: { frames: Frame[] }, keyId: string): number {
   return canvas.frames.filter((f) => syncFrameMarker(f.html)?.startsWith(`${keyId}/`)).length
+}
+
+export interface SyncFlowLink {
+  fromFrameId: string
+  toFrameId: string
+  x: number
+  y: number
+  width: number
+  height: number
+  label: string | null
+}
+
+export interface SyncFlowEdge {
+  fromFrameId: string
+  toFrameId: string
+  count: number
+  lastAt: number
+}
+
+/** The canvas's flow map: declared link hotspots and traversal counts, with
+ *  pages resolved to the frames that carry their marker. Links to pages no
+ *  one has visited yet have no frame to point at and are dropped. */
+export async function getSyncFlow(canvas: {
+  frames: Frame[]
+}): Promise<{ links: SyncFlowLink[]; edges: SyncFlowEdge[] }> {
+  const frameByMarker = new Map<string, string>()
+  for (const f of canvas.frames) {
+    const marker = syncFrameMarker(f.html)
+    if (marker) frameByMarker.set(marker, f.id)
+  }
+  const keyIds = [...new Set([...frameByMarker.keys()].map((m) => m.slice(0, m.indexOf('/'))))].filter(Boolean)
+  if (!keyIds.length) return { links: [], edges: [] }
+
+  const [linkRows, edgeRows] = await Promise.all([
+    db.select().from(syncLinks).where(inArray(syncLinks.keyId, keyIds)),
+    db.select().from(syncEdges).where(inArray(syncEdges.keyId, keyIds)),
+  ])
+  const links: SyncFlowLink[] = []
+  for (const row of linkRows) {
+    const fromFrameId = frameByMarker.get(`${row.keyId}${row.page}`)
+    const toFrameId = frameByMarker.get(`${row.keyId}${row.toPage}`)
+    if (!fromFrameId || !toFrameId) continue
+    links.push({ fromFrameId, toFrameId, x: row.x, y: row.y, width: row.width, height: row.height, label: row.label })
+  }
+  const edges: SyncFlowEdge[] = []
+  for (const row of edgeRows) {
+    const fromFrameId = frameByMarker.get(`${row.keyId}${row.fromPage}`)
+    const toFrameId = frameByMarker.get(`${row.keyId}${row.toPage}`)
+    if (!fromFrameId || !toFrameId) continue
+    edges.push({ fromFrameId, toFrameId, count: row.count, lastAt: row.lastAt })
+  }
+  return { links, edges }
 }

--- a/src/components/FlowOverlay.tsx
+++ b/src/components/FlowOverlay.tsx
@@ -1,0 +1,123 @@
+import { useEffect, useMemo, useState } from 'react'
+import { useStore } from '../lib/store'
+import { api, type SyncFlow } from '../lib/api'
+
+/**
+ * The information architecture of a synced app, drawn on the canvas: when a
+ * design-synced frame is selected, every same-app link hotspot on it gets a
+ * connector to the frame it navigates to, weighted with how often real users
+ * took that path. Selection-scoped on purpose — always-on connectors would
+ * turn a synced canvas into spaghetti. Purely presentational overlay in world
+ * coordinates; pointer events pass through.
+ */
+
+const SYNC_MARKER = 'name="doop-sync-page"'
+
+interface Connector {
+  /** hotspot outline on the source frame, world coords */
+  box: { x: number; y: number; w: number; h: number }
+  path: string
+  label: string | null
+  count: number
+  /** label anchor */
+  mx: number
+  my: number
+}
+
+export function FlowOverlay() {
+  const canvas = useStore((s) => s.canvas)
+  const selectedId = useStore((s) => s.selectedId)
+  const [flow, setFlow] = useState<SyncFlow | null>(null)
+
+  const selected = canvas?.frames.find((f) => f.id === selectedId)
+  const selectedIsSynced = !!selected && selected.html.includes(SYNC_MARKER)
+
+  /* fetch lazily, on the first selection of a synced frame (and refresh on
+     later selections — sync updates land while the canvas is open) */
+  useEffect(() => {
+    if (!canvas || !selectedIsSynced) return
+    let stale = false
+    api
+      .syncFlow(canvas.id)
+      .then((f) => !stale && setFlow(f))
+      .catch(() => !stale && setFlow(null))
+    return () => {
+      stale = true
+    }
+    /* canvas.frames churn constantly (streams, cursors); refetch only on
+       canvas/selection change */
+  }, [canvas?.id, selectedId, selectedIsSynced]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  const connectors = useMemo<Connector[]>(() => {
+    if (!canvas || !selected || !selectedIsSynced || !flow) return []
+    const frameById = new Map(canvas.frames.map((f) => [f.id, f]))
+    const countFor = new Map(flow.edges.filter((e) => e.fromFrameId === selected.id).map((e) => [e.toFrameId, e.count]))
+    const out: Connector[] = []
+    for (const link of flow.links) {
+      if (link.fromFrameId !== selected.id) continue
+      const target = frameById.get(link.toFrameId)
+      if (!target || target.id === selected.id) continue
+      /* hotspot coordinates are in the snapshot's own pixels; clamp into the
+         frame so a since-resized frame degrades gracefully */
+      const bx = selected.x + Math.min(link.x, selected.width - 8)
+      const by = selected.y + Math.min(link.y, selected.height - 8)
+      const bw = Math.min(link.width, selected.width - (bx - selected.x))
+      const bh = Math.min(link.height, selected.height - (by - selected.y))
+      const targetLeft = target.x + target.width / 2 >= bx
+      const sx = targetLeft ? bx + bw : bx
+      const sy = by + bh / 2
+      const tx = targetLeft ? target.x : target.x + target.width
+      const ty = target.y + Math.min(120, target.height / 2)
+      const bend = Math.max(60, Math.abs(tx - sx) / 3) * (targetLeft ? 1 : -1)
+      out.push({
+        box: { x: bx, y: by, w: bw, h: bh },
+        path: `M ${sx} ${sy} C ${sx + bend} ${sy}, ${tx - bend} ${ty}, ${tx} ${ty}`,
+        label: link.label,
+        count: countFor.get(target.id) ?? 0,
+        mx: (sx + tx) / 2,
+        my: (sy + ty) / 2 - 10,
+      })
+    }
+    return out
+  }, [canvas, selected, selectedIsSynced, flow])
+
+  if (!connectors.length) return null
+
+  /* one SVG spanning everything it draws, placed in world space */
+  const pad = 80
+  const xs = connectors.flatMap((c) => [c.box.x, c.box.x + c.box.w, c.mx])
+  const ys = connectors.flatMap((c) => [c.box.y, c.box.y + c.box.h, c.my])
+  for (const f of canvas!.frames) {
+    xs.push(f.x, f.x + f.width)
+    ys.push(f.y, f.y + f.height)
+  }
+  const minX = Math.min(...xs) - pad
+  const minY = Math.min(...ys) - pad
+  const w = Math.max(...xs) - minX + pad * 2
+  const h = Math.max(...ys) - minY + pad * 2
+
+  return (
+    <svg
+      className="flow-overlay"
+      style={{ left: minX, top: minY, width: w, height: h }}
+      viewBox={`${minX} ${minY} ${w} ${h}`}
+    >
+      <defs>
+        <marker id="flow-arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto">
+          <path d="M 0 1 L 9 5 L 0 9" fill="none" stroke="currentColor" strokeWidth="1.8" />
+        </marker>
+      </defs>
+      {connectors.map((c, i) => (
+        <g key={i}>
+          <rect x={c.box.x} y={c.box.y} width={c.box.w} height={c.box.h} rx={4} className="flow-hotspot" />
+          <path d={c.path} className="flow-line" markerEnd="url(#flow-arrow)" />
+          {c.count > 0 && (
+            <text x={c.mx} y={c.my} className="flow-count" textAnchor="middle">
+              {c.count}×
+            </text>
+          )}
+        </g>
+      ))}
+    </svg>
+  )
+}

--- a/src/components/Stage.tsx
+++ b/src/components/Stage.tsx
@@ -3,6 +3,7 @@ import { useStore } from '../lib/store'
 import { sendWs } from '../lib/ws'
 import { throttle } from '../lib/throttle'
 import { FrameView } from './FrameView'
+import { FlowOverlay } from './FlowOverlay'
 import { GhostFrames } from './GhostFrames'
 import { Cursors } from './Cursors'
 import { SnapGuides } from './SnapGuides'
@@ -274,6 +275,7 @@ export function Stage({ onAddFrame }: { onAddFrame: () => void }) {
             <FrameView key={f.id} frame={f} raster={raster} />
           ))}
           <GhostFrames />
+          <FlowOverlay />
           <SnapGuides />
           <Cursors />
         </div>

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -22,6 +22,21 @@ export interface SyncKeyInfo {
   frames: number
 }
 
+/** The flow map of a canvas's synced app(s): link hotspots between frames
+ *  and how often users actually navigated each pair. */
+export interface SyncFlow {
+  links: {
+    fromFrameId: string
+    toFrameId: string
+    x: number
+    y: number
+    width: number
+    height: number
+    label: string | null
+  }[]
+  edges: { fromFrameId: string; toFrameId: string; count: number; lastAt: number }[]
+}
+
 export interface DiscoveredPage {
   url: string
   title: string
@@ -135,6 +150,7 @@ export const api = {
     req<SyncKeyInfo>(`/api/canvases/${canvasId}/sync-keys`, { method: 'POST', body: JSON.stringify({ name }) }),
   deleteSyncKey: (canvasId: string, keyId: string) =>
     req(`/api/canvases/${canvasId}/sync-keys/${keyId}`, { method: 'DELETE' }),
+  syncFlow: (canvasId: string) => req<SyncFlow>(`/api/canvases/${canvasId}/sync-flow`),
   guidelineHistory: (canvasId: string, name: string) =>
     req<{ markdown: string; savedAt: number; savedBy: string }[]>(
       `/api/canvases/${canvasId}/guidelines/${encodeURIComponent(name)}/history`,

--- a/src/styles.css
+++ b/src/styles.css
@@ -2508,6 +2508,36 @@ textarea {
 
 /* ---------- ghost frames: where a working agent's design will land ---------- */
 
+/* design-sync flow map: connectors from a selected synced frame's link
+   hotspots to the frames those links navigate to */
+.flow-overlay {
+  position: absolute;
+  pointer-events: none;
+  overflow: visible;
+  z-index: 6;
+  color: var(--accent-ink, #e5533c);
+}
+.flow-hotspot {
+  fill: rgba(229, 83, 60, 0.08);
+  stroke: currentColor;
+  stroke-width: 1.5;
+  stroke-dasharray: 4 3;
+}
+.flow-line {
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2;
+  opacity: 0.75;
+}
+.flow-count {
+  font-size: 13px;
+  font-weight: 600;
+  fill: currentColor;
+  paint-order: stroke;
+  stroke: var(--surface, #fff);
+  stroke-width: 4;
+}
+
 .ghost-frame {
   position: absolute;
   pointer-events: none;

--- a/tests/ingest.test.ts
+++ b/tests/ingest.test.ts
@@ -142,6 +142,95 @@ describe('design sync ingest', () => {
     expect(list[0].lastUsedAt).toBeGreaterThan(0)
   })
 
+  it('captures the flow map: link hotspots and traversal counts between frames', async () => {
+    const post = (body: unknown) =>
+      fetch(`${BASE}/ingest/${secret}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      })
+    /* snapshot with links: one to a synced page, one to a page nobody visited */
+    const res = await post({
+      page: '/orders/:id',
+      title: 'Orders',
+      html: SNAPSHOT('three'),
+      links: [
+        { to: '/settings', x: 40, y: 60, w: 120, h: 32, label: 'Settings' },
+        { to: '/nowhere', x: 10, y: 10, w: 50, h: 20 },
+      ],
+      edges: [
+        { from: '/orders/:id', to: '/settings' },
+        { from: '/orders/:id', to: '/settings' },
+      ],
+    })
+    expect(res.status).toBe(200)
+    /* an unchanged screen can still flush navigations on their own */
+    const slim = await (await post({ page: '/settings', edges: [{ from: '/settings', to: '/orders/:id' }] })).json()
+    expect(slim).toEqual({ ok: true, edges: 1 })
+
+    const canvas = await (await owner.get(`/api/canvases/${canvasId}`)).json()
+    const frames = canvas.frames as { name: string; id: string }[]
+    const orders = frames.find((f) => f.name === 'Orders')!.id
+    const settings = frames.find((f) => f.name !== 'Orders')!.id
+
+    const flow = await (await owner.get(`/api/canvases/${canvasId}/sync-flow`)).json()
+    expect(flow.links).toHaveLength(1) // the /nowhere link has no frame to point at
+    expect(flow.links[0]).toMatchObject({
+      fromFrameId: orders,
+      toFrameId: settings,
+      x: 40,
+      y: 60,
+      width: 120,
+      height: 32,
+      label: 'Settings',
+    })
+    expect(flow.edges).toHaveLength(2)
+    const counts = Object.fromEntries(
+      flow.edges.map((e: { fromFrameId: string; count: number }) => [e.fromFrameId, e.count]),
+    )
+    expect(counts[orders]).toBe(2)
+    expect(counts[settings]).toBe(1)
+
+    /* an unchanged snapshot still refreshes hotspots — the first capture from
+       a link-reporting snippet version arrives with identical HTML */
+    const replay = await (
+      await post({
+        page: '/orders/:id',
+        title: 'Orders',
+        html: SNAPSHOT('three'),
+        links: [{ to: '/settings', x: 8, y: 16, w: 90, h: 24, label: 'Go' }],
+      })
+    ).json()
+    expect(replay.unchanged).toBe(true)
+    const flow2 = await (await owner.get(`/api/canvases/${canvasId}/sync-flow`)).json()
+    expect(flow2.links).toHaveLength(1)
+    expect(flow2.links[0]).toMatchObject({ x: 8, y: 16, width: 90, height: 24, label: 'Go' })
+  })
+
+  it('marks recorded edges in a response header; the rate-limit 429 omits it', async () => {
+    /* the snippet requeues its edge batch unless X-Doop-Edges proves the
+       server stored it — the per-key rate limit fires before recording */
+    const canvas = await (await owner.post('/api/canvases', { name: 'Rate limited' })).json()
+    const key = await (await owner.post(`/api/canvases/${canvas.id}/sync-keys`, { name: 'burst' })).json()
+    const post = () =>
+      fetch(`${BASE}/ingest/${key.secret}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ page: '/a', edges: [{ from: '/a', to: '/b' }] }),
+      })
+    const first = await post()
+    expect(first.status).toBe(200)
+    expect(first.headers.get('x-doop-edges')).toBe('1')
+    expect(first.headers.get('access-control-expose-headers')).toContain('X-Doop-Edges')
+    let limited: Response | null = null
+    for (let i = 0; i < 32 && !limited; i++) {
+      const res = await post()
+      if (res.status === 429) limited = res
+    }
+    expect(limited).not.toBeNull()
+    expect(limited!.headers.get('x-doop-edges')).toBeNull() // not recorded — snippet must retry
+  })
+
   it('rejects malformed payloads', async () => {
     const post = (body: unknown) =>
       fetch(`${BASE}/ingest/${secret}`, {


### PR DESCRIPTION
Design-sync captures now record which element navigated where, and the canvas draws connectors between synced frames: click a button in one screen, see the edge to the screen it opens. Carries migration `0005_sync_flow` (chain verified against `0004`).

Ported from the upstream private repo (upstream #73).

🤖 Generated with [Claude Code](https://claude.com/claude-code)