### PR TITLE
feat: design-sync refinements — import-once, pristine first captures, agent flow context

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,8 +305,11 @@ to the user's browser: mint a write-only key in a canvas's Share dialog, drop on
 <script async src="https://your-doop-origin/doop-sync.js?key=dk_…"></script>
 ```
 
-— and every distinct screen people visit lands on that canvas as a frame (one row per app), refreshed
-as the app changes. Routes are normalized (`/orders/8231` → `/orders/:id`) so each screen maps to one
+— and every distinct screen people visit lands on that canvas as a frame (one row per app), imported
+once: a short grace window lets the first capture settle (scroll reveals, late images), then the frame
+freezes so later visits — different viewports, other users' data, open menus — never churn it. Deleting
+a frame re-imports it on the next visit; navigation counts keep accumulating regardless. Routes are
+normalized (`/orders/8231` → `/orders/:id`) so each screen maps to one
 frame; captures are serialized from the CSSOM (so styled-components/emotion output survives), and
 same-origin webfonts and small images are inlined as data: URIs — fonts require CORS inside the
 sandboxed frame, and intranet URLs would never render for viewers outside the network. Scripts are

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -37,7 +37,7 @@ export default tseslint.config(
       globals: Object.fromEntries(
         (
           'window document location history localStorage fetch console setTimeout clearTimeout ' +
-          'matchMedia URL JSON Date Math FileReader Promise'
+          'matchMedia URL JSON Date Math FileReader Promise MutationObserver'
         )
           .split(' ')
           .map((g) => [g, 'readonly']),

--- a/public/doop-sync.js
+++ b/public/doop-sync.js
@@ -5,7 +5,8 @@
  *
  * Runs in the USER'S browser, so it captures apps no crawler can reach
  * (SSO, VPN, localhost) exactly as the signed-in user sees them. Each
- * distinct route becomes one frame, refreshed when the screen changes.
+ * distinct route becomes one frame, imported once — a short grace window
+ * lets the first capture settle, then the screen freezes on the canvas.
  *
  * Options (attributes on the script tag):
  *   data-key   required — a canvas sync key from doop's share dialog
@@ -21,6 +22,10 @@
  * Privacy: input values are always dropped, [data-doop-mask] subtrees are
  * redacted, scripts never leave the page. `window.doopSync.capture()` forces
  * a capture; add data-doop-sync-ignore to elements that should never upload.
+ *
+ * Frames show each screen as it GREETS the user: after the first hover over
+ * a menu, click, or keypress, the poked-at DOM (open dropdowns, modals,
+ * moved focus) never replaces a copy the canvas already has.
  */
 ;(function () {
   'use strict'
@@ -207,7 +212,7 @@
     return Promise.all(jobs)
   }
 
-  function serialize() {
+  function snapshotDom() {
     var root = document.documentElement.cloneNode(true)
 
     /* pair images while both trees are still structurally identical */
@@ -266,19 +271,28 @@
     for (i = 0; i < masked.length; i++) masked[i].textContent = '•••'
 
     var styles = collectCss()
-    var baseSize = root.outerHTML.length + styles.css.length
-    var budget = { left: Math.max(0, MAX_BYTES - baseSize) }
+    /* phase 1 ends here: everything above is cheap DOM work whose serialized
+       form is stable — the content hash is computed on it so unchanged
+       screens skip phase 2 (asset fetches + base64) entirely */
+    return { root: root, css: styles.css, cssLinks: styles.links, imgPairs: imgPairs, pre: root.outerHTML + styles.css }
+  }
 
-    return Promise.all([inlineCssFonts(styles.css, budget), inlineImages(imgPairs, budget)]).then(function (results) {
-      var head = root.querySelector('head')
-      var inject = ''
-      for (var l = 0; l < styles.links.length; l++) {
-        inject += '<link rel="stylesheet" href="' + styles.links[l].replace(/"/g, '&quot;') + '">'
-      }
-      inject += '<style data-doop-sync>\n' + results[0].replace(/<\/style/gi, '<\\/style') + '\n</style>'
-      if (head) head.insertAdjacentHTML('beforeend', inject)
-      return '<!doctype html>\n' + root.outerHTML
-    })
+  /* phase 2: the expensive part — fetch + base64 same-origin fonts/images,
+     then assemble the final document. Runs only for snapshots being sent. */
+  function finalizeSnapshot(snap) {
+    var budget = { left: Math.max(0, MAX_BYTES - snap.pre.length) }
+    return Promise.all([inlineCssFonts(snap.css, budget), inlineImages(snap.imgPairs, budget)]).then(
+      function (results) {
+        var head = snap.root.querySelector('head')
+        var inject = ''
+        for (var l = 0; l < snap.cssLinks.length; l++) {
+          inject += '<link rel="stylesheet" href="' + snap.cssLinks[l].replace(/"/g, '&quot;') + '">'
+        }
+        inject += '<style data-doop-sync>\n' + results[0].replace(/<\/style/gi, '<\\/style') + '\n</style>'
+        if (head) head.insertAdjacentHTML('beforeend', inject)
+        return '<!doctype html>\n' + snap.root.outerHTML
+      },
+    )
   }
 
   /* ---- flow map: which link sits where, and where people actually went */
@@ -322,6 +336,9 @@
     if (now !== lastPage) {
       if (pendingEdges.length < 20) pendingEdges.push({ from: lastPage, to: now })
       lastPage = now
+      /* a new screen opens a fresh untouched window — re-arm and re-stash */
+      armInteractionWatch()
+      scheduleStashes()
     }
   }
 
@@ -333,95 +350,203 @@
 
   /* CAPTURE_VERSION invalidates the dedup when the capture format changes —
      an upgraded snippet must re-upload screens whose HTML alone is unchanged
-     (e.g. to populate the flow map's link hotspots). */
-  var CAPTURE_VERSION = '2'
+     (e.g. to populate the flow map's link hotspots). v3: the hash moved to
+     the pre-asset-inline serialization. */
+  var CAPTURE_VERSION = '3'
   function memoKey(page) {
     return '__doopSync:' + CAPTURE_VERSION + ':' + KEY.slice(-6) + ':' + page
   }
 
-  function shouldSend(page, h) {
+  function readMemo(page) {
     try {
-      var memo = JSON.parse(localStorage.getItem(memoKey(page)) || 'null')
-      if (!memo) return true
-      if (memo.h === h && Date.now() - memo.t < 6 * 3600000) return false // unchanged — server has it
-      return Date.now() - memo.t >= MIN_RESEND_MS
+      return JSON.parse(localStorage.getItem(memoKey(page)) || 'null')
     } catch (e) {
-      return true
+      return null
     }
+  }
+  function writeMemo(page, memo) {
+    try {
+      localStorage.setItem(memoKey(page), JSON.stringify(memo))
+    } catch (e) {
+      /* private mode — fine, we just lose the dedup */
+    }
+  }
+
+  function shouldSend(page, h) {
+    var memo = readMemo(page)
+    if (!memo) return true
+    if (memo.s) return false // frozen server-side — this screen is settled
+    if (memo.h === h && Date.now() - memo.t < 6 * 3600000) return false // unchanged — server has it
+    return Date.now() - memo.t >= MIN_RESEND_MS
+  }
+
+  /* Cheapest skip of all: a global mutation counter. If the DOM hasn't
+     changed since the last confirmed capture of this screen, there is
+     nothing new to serialize — the scroll/nav trigger costs nothing. */
+  var mutationCount = 0
+  var capturedAtMutation = {}
+  try {
+    new MutationObserver(function (list) {
+      mutationCount += list.length
+    }).observe(document.documentElement, { subtree: true, childList: true, attributes: true, characterData: true })
+  } catch (e) {
+    /* no observer — every trigger serializes, as before */
+  }
+
+  /* Flush pending navigations without a snapshot. Requeue unless the
+     server's marker proves the batch was recorded: its rate-limit 429 fires
+     before recording, the page-throttle 429 after. */
+  function sendEdges(page) {
+    if (!pendingEdges.length) return
+    var batch = pendingEdges.splice(0, 20)
+    return fetch(ENDPOINT, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      keepalive: true,
+      body: JSON.stringify({ page: page, edges: batch }),
+    })
+      .then(function (r) {
+        if (r.headers.get('X-Doop-Edges') !== null) batch = []
+        if (!r.ok) throw new Error('sync ' + r.status)
+      })
+      ['catch'](function () {
+        if (batch.length) pendingEdges = batch.concat(pendingEdges).slice(0, 20)
+      })
+  }
+
+  /* Screens should sync as they GREET the user, but hovering a nav opens
+     mega-menus, clicks open modals, keys move focus — and the settle delay
+     gives visitors plenty of time to do all three before the first capture.
+     From the first interaction on, the live DOM is suspect: it never
+     replaces a copy the server already has, and a screen the server lacks
+     ships from the pristine stash below instead. mouseover only counts over
+     interactive elements, so wheel-scrolling past body text stays untouched
+     and the scroll re-capture can still cure reveal animations. */
+  var interacted = false
+  var INTERACT_EVENTS = ['mouseover', 'pointerdown', 'keydown']
+  var HOVER_RISK =
+    'nav,header,a,button,summary,select,[role="button"],[role="menu"],[role="menubar"],' +
+    '[aria-haspopup],[aria-expanded],[tabindex]'
+  function onInteract(e) {
+    if (e.type === 'mouseover' && !(e.target && e.target.closest && e.target.closest(HOVER_RISK))) return
+    /* Last pristine instant: this capture-phase listener runs BEFORE the
+       app's own handler opens a menu or modal, so stashing synchronously
+       here beats any timer race — including the cursor already resting on
+       the nav when the page loads (interaction at ~0ms, both timers late).
+       One-time cost on first interaction, and only if no stash exists yet. */
+    if (!(pristine && pristine.page === routeKey())) stashPristine()
+    interacted = true
+    for (var i = 0; i < INTERACT_EVENTS.length; i++) window.removeEventListener(INTERACT_EVENTS[i], onInteract, true)
+  }
+  function armInteractionWatch() {
+    interacted = false
+    for (var i = 0; i < INTERACT_EVENTS.length; i++) window.addEventListener(INTERACT_EVENTS[i], onInteract, true)
+  }
+  armInteractionWatch()
+
+  /* Snapshotted (phase 1 only — cheap) while the page is still untouched;
+     finalized and uploaded in place of the live DOM when the user started
+     poking before the settle capture fired. Stashed twice: early so fast
+     hoverers don't beat it, late so skeletons have resolved. */
+  var pristine = null
+  var stashTimers = []
+  function stashPristine() {
+    if (interacted) return
+    try {
+      pristine = { page: routeKey(), snap: snapshotDom() }
+    } catch (e) {
+      /* a failed stash just means capture falls back to the live DOM */
+    }
+  }
+  function scheduleStashes() {
+    for (var i = 0; i < stashTimers.length; i++) clearTimeout(stashTimers[i])
+    stashTimers = [setTimeout(stashPristine, 400), setTimeout(stashPristine, 1600)]
   }
 
   var capturing = false
   function capture(force) {
     if (capturing) return
-    capturing = true
     var page = routeKey()
+    var memo = readMemo(page)
+    var poked = !force && interacted
+    if (!force && ((memo && memo.s) || capturedAtMutation[page] === mutationCount || (poked && memo))) {
+      /* frozen screen, untouched DOM, or a poked-at DOM that must not
+         replace a copy the server already has — only navigations flow */
+      sendEdges(page)
+      return
+    }
+    capturing = true
+    var mc = mutationCount // state this capture describes — mutations during the async pipeline stay pending
+    var usedPristine = false
+    var sentSnapshot = false
     var edges = []
-    /* Promise.resolve().then keeps a synchronous throw inside serialize on
+    /* Promise.resolve().then keeps a synchronous throw inside snapshotDom on
        the promise chain — it must hit the catch below, or `capturing` wedges
        shut and every later capture silently no-ops. */
     Promise.resolve()
       .then(function () {
-        return serialize()
-      })
-      .then(function (html) {
-        capturing = false
-        if (html.length > MAX_BYTES) {
-          console.warn('[doop-sync] snapshot too large (' + html.length + ' bytes) — not uploading')
-          return
+        if (poked && pristine && pristine.page === page) {
+          usedPristine = true
+          return pristine.snap
         }
-        var h = hash(html)
-        edges = pendingEdges.splice(0, 20)
+        return snapshotDom()
+      })
+      .then(function (snap) {
+        var h = hash(snap.pre)
         if (!force && !shouldSend(page, h)) {
-          if (!edges.length) return
-          /* screen unchanged — flush just the navigations */
+          /* content unchanged — remember which DOM state we confirmed, so
+             later triggers skip even the serialize (unless the snapshot was
+             the stash: the live DOM was never compared) */
+          capturing = false
+          if (!usedPristine) capturedAtMutation[page] = mc
+          return sendEdges(page)
+        }
+        edges = pendingEdges.splice(0, 20)
+        return finalizeSnapshot(snap).then(function (html) {
+          capturing = false
+          if (html.length > MAX_BYTES) {
+            console.warn('[doop-sync] snapshot too large (' + html.length + ' bytes) — not uploading')
+            return
+          }
+          writeMemo(page, { h: h, t: Date.now() })
+          sentSnapshot = true
           return fetch(ENDPOINT, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            keepalive: true,
-            body: JSON.stringify({ page: page, edges: edges }),
+            keepalive: html.length < 60000, // keepalive caps the body — big snapshots go without it
+            body: JSON.stringify({
+              page: page,
+              title: document.title,
+              url: location.href,
+              width: window.innerWidth,
+              height: Math.min(document.documentElement.scrollHeight, 8000),
+              html: html,
+              links: collectLinks(page),
+              edges: edges,
+            }),
           }).then(function (r) {
-            /* only the server's explicit marker proves the edges were stored:
-               its rate-limit 429 fires before recording (requeue), while the
-               page-throttle 429 fires after (requeue would double-count) */
-            if (r.headers.get('X-Doop-Edges') !== null) edges = []
+            if (r.headers.get('X-Doop-Edges') !== null) edges = [] // recorded server-side — see sendEdges
             if (!r.ok) throw new Error('sync ' + r.status)
+            if (r.headers.get('X-Doop-Synced') !== null) writeMemo(page, { s: 1, t: Date.now() }) // frozen for good
+            if (!usedPristine) capturedAtMutation[page] = mc
           })
-        }
-        try {
-          localStorage.setItem(memoKey(page), JSON.stringify({ h: h, t: Date.now() }))
-        } catch (e) {
-          /* private mode — fine, we just lose the dedup */
-        }
-        return fetch(ENDPOINT, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          keepalive: html.length < 60000, // keepalive caps the body — big snapshots go without it
-          body: JSON.stringify({
-            page: page,
-            title: document.title,
-            url: location.href,
-            width: window.innerWidth,
-            height: Math.min(document.documentElement.scrollHeight, 8000),
-            html: html,
-            links: collectLinks(page),
-            edges: edges,
-          }),
-        }).then(function (r) {
-          if (r.headers.get('X-Doop-Edges') !== null) edges = [] // recorded server-side — see above
-          if (!r.ok) throw new Error('sync ' + r.status)
         })
       })
       ['catch'](function (err) {
-        /* never break the host app over a sync error — but log it, drop the
-           memo so the next scheduled capture retries instead of skipping,
-           and put the drained navigations back so counts don't under-report */
+        /* never break the host app over a sync error — but log it, put the
+           drained navigations back so counts don't under-report, and if a
+           SNAPSHOT upload failed drop its memo so the next capture retries
+           instead of skipping. An edges-only failure keeps the memo — losing
+           it would let a poked-at DOM slip past the gate above. */
         console.warn('[doop-sync] capture failed', err)
         capturing = false
         if (edges.length) pendingEdges = edges.concat(pendingEdges).slice(0, 20)
-        try {
-          localStorage.removeItem(memoKey(page))
-        } catch (e2) {
-          /* private mode */
+        if (sentSnapshot) {
+          try {
+            localStorage.removeItem(memoKey(page))
+          } catch (e2) {
+            /* private mode */
+          }
         }
       })
   }
@@ -436,8 +561,12 @@
   }
 
   /* initial screen + every SPA navigation */
-  if (document.readyState === 'complete') schedule()
-  else window.addEventListener('load', schedule)
+  function onLoad() {
+    scheduleStashes()
+    schedule()
+  }
+  if (document.readyState === 'complete') onLoad()
+  else window.addEventListener('load', onLoad)
   var push = history.pushState
   history.pushState = function () {
     var out = push.apply(this, arguments)

--- a/server/ingest.ts
+++ b/server/ingest.ts
@@ -149,6 +149,13 @@ const INGESTS_PER_MIN = 30
 /** floor between rewrites of the SAME page — a busy app must not churn the
  *  canvas (and its websocket room) with a frame write per user interaction */
 const PAGE_MIN_INTERVAL_MS = Number(process.env.SYNC_PAGE_INTERVAL_MS ?? 30_000)
+/** Import-once: after this age a synced frame freezes — later captures no
+ *  longer rewrite it (traversal edges keep accumulating). The grace window
+ *  exists so the creating visit can still improve its own capture: scroll
+ *  reveals completing, late images, a second look at the same screen.
+ *  Re-import = delete the frame and visit the page again. Continuous
+ *  updating can return later as an opt-in. */
+const FREEZE_AFTER_MS = Number(process.env.SYNC_FREEZE_MS ?? 15 * 60_000)
 
 const ingestHits = new Map<string, number[]>()
 const pageLastWrite = new Map<string, number>()
@@ -168,8 +175,8 @@ export function setIngestCors(res: express.Response) {
   res.set('Access-Control-Allow-Origin', '*')
   res.set('Access-Control-Allow-Methods', 'POST, OPTIONS')
   res.set('Access-Control-Allow-Headers', 'Content-Type')
-  /* the snippet reads this to know its edge batch was recorded (see below) */
-  res.set('Access-Control-Expose-Headers', 'X-Doop-Edges')
+  /* the snippet reads these: edge batch recorded, and screen frozen (see below) */
+  res.set('Access-Control-Expose-Headers', 'X-Doop-Edges, X-Doop-Synced')
   res.set('Access-Control-Max-Age', '86400')
   /* Chrome Private Network Access: a page on a public origin posting to a
      doop on localhost/an intranet host needs this opt-in on the preflight —
@@ -332,6 +339,12 @@ export async function handleIngest(req: express.Request, res: express.Response) 
   const mine = canvas.frames.filter((f) => syncFrameMarker(f.html)?.startsWith(`${key.id}/`))
   const existing = mine.find((f) => syncFrameMarker(f.html) === marker)
   if (existing) {
+    if (Date.now() - existing.createdAt > FREEZE_AFTER_MS) {
+      /* the header tells the snippet this screen is settled — it stops
+         serializing it for good, not just until the content hash drifts */
+      res.set('X-Doop-Synced', '1')
+      return res.json({ ok: true, frameId: existing.id, frozen: true })
+    }
     if (existing.html === wrapped) {
       /* content matches, but this capture may still carry fresher hotspots —
          e.g. the first upload from a snippet version that reports links */
@@ -367,6 +380,31 @@ export async function handleIngest(req: express.Request, res: express.Response) 
   if (!frame) return res.status(410).json({ error: 'canvas vanished mid-sync' })
   await saveLinks(key.id, page, links)
   res.json({ ok: true, frameId: frame.id, created: true })
+}
+
+/** The flow map as plain sentences for agents: which frame links to which
+ *  (deduped by label), and where users actually navigate, most-traveled
+ *  first. One shared formatter so MCP agents and the resident team read the
+ *  same picture. Returns [] when the canvas has no flow data. */
+export function describeSyncFlow(flow: { links: SyncFlowLink[]; edges: SyncFlowEdge[] }, frames: Frame[]): string[] {
+  const nameOf = (id: string) => {
+    const f = frames.find((x) => x.id === id)
+    return f ? `"${f.name}" (${f.id})` : id
+  }
+  const lines: string[] = []
+  for (const e of [...flow.edges].sort((a, b) => b.count - a.count)) {
+    lines.push(
+      `${nameOf(e.fromFrameId)} → ${nameOf(e.toFrameId)}: ${e.count} real user navigation${e.count === 1 ? '' : 's'}`,
+    )
+  }
+  const seen = new Set<string>()
+  for (const l of flow.links) {
+    const key = `${l.fromFrameId}|${l.toFrameId}|${l.label ?? ''}`
+    if (seen.has(key)) continue
+    seen.add(key)
+    lines.push(`${nameOf(l.fromFrameId)} links to ${nameOf(l.toFrameId)}${l.label ? ` via “${l.label}”` : ''}`)
+  }
+  return lines
 }
 
 /** Frames synced by a key, for the share modal's per-key screen count. */

--- a/server/mcp.ts
+++ b/server/mcp.ts
@@ -10,6 +10,7 @@ import { auth, getUserName, PUBLIC_ORIGIN } from './auth.ts'
 import { renderFrame } from './screenshot.ts'
 import { DOOP_GUIDE, GUIDE_TOPICS } from './guide.ts'
 import { ESCAPED_HTML_NOTE, looksEscapedHtml } from './escapedHtml.ts'
+import { describeSyncFlow, getSyncFlow } from './ingest.ts'
 import * as assets from './assets.ts'
 import * as imageSearch from './imageSearch.ts'
 import { viewWebsite } from './website.ts'
@@ -252,7 +253,15 @@ export function buildMcpServer(owner?: string, ownerId?: string): McpServer {
       arrive(canvas_id, agent_name)
       const docs = store.getGuidelines(canvas_id)
       const refs = store.getReferences(canvas_id)
+      /* design-synced canvases carry a flow map: real user navigation between
+         the synced screens — context a redesign must respect */
+      const flow = describeSyncFlow(await getSyncFlow(c), c.frames)
       const notes = [
+        ...(flow.length
+          ? [
+              'This canvas is synced from a live app and `flow` shows how its screens connect — including how often real users take each path. Do not bury or weaken elements that carry heavy navigation.',
+            ]
+          : []),
         ...(docs.length
           ? [
               'This canvas has style guides. Call get_guidelines for each relevant one BEFORE designing — every frame must follow them.',
@@ -285,6 +294,7 @@ export function buildMcpServer(owner?: string, ownerId?: string): McpServer {
             htmlBytes: r.html.length,
             pinnedBy: r.pinnedBy,
           })),
+          ...(flow.length ? { flow } : {}),
           ...(notes.length ? { note: notes.join(' ') } : {}),
         }),
         canvas_id,

--- a/server/resident.ts
+++ b/server/resident.ts
@@ -6,6 +6,7 @@ import { inspectFrame, renderFrame } from './screenshot.ts'
 import { AGENT_ROLES, DEFAULT_ROLE_ID, roleById, roleByAgentName, roleName } from '../shared/agents.ts'
 import type { AgentRole } from '../shared/agents.ts'
 import * as imageSearch from './imageSearch.ts'
+import * as ingest from './ingest.ts'
 import { viewWebsite, referencedUrls } from './website.ts'
 import { createImportedWebpageFrame, findImportedWebpageFrame } from './webpageImport.ts'
 import { DESIGN_QUALITY } from './guide.ts'
@@ -244,6 +245,16 @@ async function runAgent(canvasId: string, agentName: string, stalled: Set<string
       .join('\n')
 
     const sections: string[] = []
+    /* design-synced canvases: real navigation between the synced screens is
+       redesign-critical context — heavy paths must stay prominent */
+    const flowLines = canvas ? ingest.describeSyncFlow(await ingest.getSyncFlow(canvas), visibleFrames) : []
+    if (flowLines.length > 0) {
+      sections.push(
+        `How this app's screens connect (from live design sync — navigation counts are real users):\n` +
+          flowLines.map((line) => `- ${line}`).join('\n') +
+          `\nRespect this when redesigning: do not bury or weaken elements that carry heavy navigation.`,
+      )
+    }
     if (items.length > 0) {
       sections.push(
         `New human feedback on this canvas:\n` +

--- a/src/pages/CanvasPage.tsx
+++ b/src/pages/CanvasPage.tsx
@@ -787,8 +787,9 @@ function SyncKeysSection({ canvasId }: { canvasId: string }) {
     <div className="sync-section">
       <h3>Or sync a live app</h3>
       <p className="share-note">
-        For apps a crawler can't reach — behind a login, a VPN, or on localhost. Paste one script tag and the screens
-        people visit land here as frames, kept current as the app changes. The key only writes to this canvas.
+        For apps a crawler can't reach — behind a login, a VPN, or on localhost. Paste one script tag and each screen
+        people visit lands here as a frame, imported once. Delete a frame to re-import it fresh. The key only writes to
+        this canvas.
       </p>
       {(keys ?? []).map((k) => (
         <div key={k.id} className="sync-key">

--- a/tests/admin.test.ts
+++ b/tests/admin.test.ts
@@ -15,7 +15,7 @@ import { Client, startServer, type Server } from './harness.ts'
    whole range clear of every other test file's port (they run in parallel —
    a second server on a taken port passes /healthz against the WRONG instance
    and the test then reads someone else's database). */
-const PORT = 4985
+const PORT = 4993
 
 let server: Server
 let boss: Client

--- a/tests/ingest.test.ts
+++ b/tests/ingest.test.ts
@@ -1,5 +1,7 @@
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import { Client, startServer, type Server } from './harness.ts'
+import { describeSyncFlow } from '../server/ingest.ts'
+import type { Frame } from '../shared/types.ts'
 
 /**
  * Design-sync ingest: the doop-sync snippet's endpoint and the key-management
@@ -262,5 +264,90 @@ describe('design sync ingest', () => {
       body: JSON.stringify({ page: '/x', html: '<p>x</p>' }),
     })
     expect(res.status).toBe(404)
+  })
+})
+
+/* Pure formatter — what MCP get_canvas and the resident team read as flow
+   context. No server needed. */
+describe('describeSyncFlow', () => {
+  const frame = (id: string, name: string): Frame =>
+    ({
+      id,
+      canvasId: 'c',
+      name,
+      x: 0,
+      y: 0,
+      width: 100,
+      height: 100,
+      html: '',
+      createdAt: 0,
+      updatedAt: 0,
+      updatedBy: 't',
+    }) as Frame
+
+  it('renders edges most-traveled first, dedupes links by label', () => {
+    const frames = [frame('f1', 'Catalog'), frame('f2', 'Checkout'), frame('f3', 'Home')]
+    const lines = describeSyncFlow(
+      {
+        links: [
+          { fromFrameId: 'f1', toFrameId: 'f2', x: 0, y: 0, width: 10, height: 10, label: 'Buy now' },
+          { fromFrameId: 'f1', toFrameId: 'f2', x: 50, y: 9, width: 10, height: 10, label: 'Buy now' },
+          { fromFrameId: 'f3', toFrameId: 'f1', x: 0, y: 0, width: 10, height: 10, label: null },
+        ],
+        edges: [
+          { fromFrameId: 'f3', toFrameId: 'f1', count: 2, lastAt: 1 },
+          { fromFrameId: 'f1', toFrameId: 'f2', count: 9, lastAt: 1 },
+        ],
+      },
+      frames,
+    )
+    expect(lines).toHaveLength(4)
+    expect(lines[0]).toBe('"Catalog" (f1) → "Checkout" (f2): 9 real user navigations')
+    expect(lines[1]).toBe('"Home" (f3) → "Catalog" (f1): 2 real user navigations')
+    expect(lines[2]).toContain('links to "Checkout" (f2) via “Buy now”')
+    expect(lines[3]).toBe('"Home" (f3) links to "Catalog" (f1)')
+  })
+
+  it('returns nothing for canvases without flow data', () => {
+    expect(describeSyncFlow({ links: [], edges: [] }, [])).toEqual([])
+  })
+})
+
+/* Import-once: with the grace window elapsed (SYNC_FREEZE_MS=0), a synced
+   screen freezes — later captures don't rewrite it, edges still count. */
+describe('design sync freeze', () => {
+  let frozenServer: Server
+  let owner: Client
+
+  beforeAll(async () => {
+    frozenServer = await startServer(4985, { SYNC_PAGE_INTERVAL_MS: '0', SYNC_FREEZE_MS: '0' })
+    owner = new Client(frozenServer)
+    await owner.signUp('freeze-owner@test.dev', 'Owner')
+  }, 70_000)
+
+  afterAll(() => frozenServer?.stop())
+
+  it('first capture wins; later captures are told the screen is settled', async () => {
+    const canvas = await (await owner.post('/api/canvases', { name: 'Frozen' })).json()
+    const key = await (await owner.post(`/api/canvases/${canvas.id}/sync-keys`, { name: 'app' })).json()
+    const post = (html: string, edges?: unknown[]) =>
+      fetch(`${frozenServer.base}/ingest/${key.secret}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ page: '/home', html, edges }),
+      })
+
+    const first = await post('<html><body><h1>v1</h1></body></html>')
+    expect((await first.json()).created).toBe(true)
+
+    const second = await post('<html><body><h1>v2</h1></body></html>', [{ from: '/home', to: '/about' }])
+    expect(second.headers.get('x-doop-synced')).toBe('1')
+    expect(second.headers.get('x-doop-edges')).toBe('1') // navigations still count
+    expect((await second.json()).frozen).toBe(true)
+
+    const got = await (await owner.get(`/api/canvases/${canvas.id}`)).json()
+    expect(got.frames).toHaveLength(1)
+    expect(got.frames[0].html).toContain('v1') // the rewrite was refused
+    expect(got.frames[0].html).not.toContain('v2')
   })
 })


### PR DESCRIPTION
Synced screens now freeze after a grace window (`SYNC_FREEZE_MS`): the first capture wins and later captures are told the screen is settled instead of rewriting it, while navigation edges still count. First captures land pristine, and agents get flow context about which synced screen leads where.

Second commit moves the admin test suite to ports 4993–4996: the freeze suite ported here hardcodes 4985, which is where #29 had just moved the admin suite.

Ported from the upstream private repo (upstream #78).

🤖 Generated with [Claude Code](https://claude.com/claude-code)