### PR TITLE
feat: meter feedback and retries — every resident trigger spends a free task

### DIFF
--- a/server/allowance.ts
+++ b/server/allowance.ts
@@ -6,15 +6,15 @@ import { getStatus } from './modelAccounts.ts'
 import type { AccountKind } from './modelAccounts.ts'
 
 /**
- * Free-tier metering for the resident design team. Initiating team work — a
- * board card or an element comment that @mentions a resident — consumes one
- * of RESIDENT_TASK_LIMIT free tasks. Two things lift the meter entirely:
- * connecting your own MCP agent (Claude Code, Codex — your subscription, your
- * model, driving the canvas from outside), or connecting a model account so
- * the Doop Agent itself runs on your ChatGPT subscription or OpenAI key. Both
- * take effect immediately — a connected user is never metered again, and their
- * remaining free tasks simply stop being relevant. Feedback replies and
- * retries on existing work never count either: iteration stays free.
+ * Free-tier metering for the resident design team. Anything that triggers
+ * resident work consumes one of RESIDENT_TASK_LIMIT free tasks: a board card,
+ * an element comment that @mentions a resident, feedback on a task, and every
+ * retry. Two things lift the meter entirely: connecting your own MCP agent
+ * (Claude Code, Codex — your subscription, your model, driving the canvas
+ * from outside), or connecting a model account so the Doop Agent itself runs
+ * on your ChatGPT subscription or OpenAI key. Both take effect immediately —
+ * a connected user is never metered again, and their remaining free tasks
+ * simply stop being relevant.
  */
 
 export const RESIDENT_TASK_LIMIT = Math.max(0, Number(process.env.RESIDENT_TASK_LIMIT ?? 5))

--- a/server/index.ts
+++ b/server/index.ts
@@ -996,10 +996,14 @@ app.post('/api/comments/:id/resolve', (req, res) => {
   res.json(actions.resolveComment(req.params.id, req.user!.name))
 })
 
-app.post('/api/comments/:id/retry', (req, res) => {
+app.post('/api/comments/:id/retry', async (req, res) => {
   const found = actions.findComment(req.params.id)
   if (!found) return res.status(404).json({ error: 'comment not found' })
   if (!requireCanvas(req, res, found.canvasId)) return
+  const gate = await allowance.consumeResidentTask(req.user!.id)
+  if (!gate.ok) {
+    return res.status(403).json({ error: 'resident_limit', used: gate.used, limit: gate.limit })
+  }
   res.json(actions.retryComment(req.params.id, req.user!.name))
 })
 
@@ -1142,26 +1146,40 @@ app.post('/api/canvases/:canvasId/cards/:id/done', (req, res) => {
   res.json(card)
 })
 
-app.post('/api/canvases/:canvasId/cards/:id/retry', (req, res) => {
+app.post('/api/canvases/:canvasId/cards/:id/retry', async (req, res) => {
   if (!requireCanvas(req, res, req.params.canvasId)) return
+  const gate = await allowance.consumeResidentTask(req.user!.id)
+  if (!gate.ok) {
+    return res.status(403).json({ error: 'resident_limit', used: gate.used, limit: gate.limit })
+  }
   const card = actions.retryCard(req.params.canvasId, req.params.id, req.user!.name)
   if (!card) return res.status(404).json({ error: 'card not found' })
   res.json(card)
 })
 
-app.post('/api/tasks/:id/feedback', (req, res) => {
+app.post('/api/tasks/:id/feedback', async (req, res) => {
   const canvasId = actions.taskCanvasId(req.params.id)
   if (!canvasId) return res.status(404).json({ error: 'task not found' })
   if (!requireCanvas(req, res, canvasId)) return
-  const fb = actions.addTaskFeedback(req.params.id, req.user!.name, String(req.body?.text ?? ''), req.user!.id)
+  const text = String(req.body?.text ?? '').trim()
+  if (!text) return res.status(400).json({ error: 'empty text' })
+  const gate = await allowance.consumeResidentTask(req.user!.id)
+  if (!gate.ok) {
+    return res.status(403).json({ error: 'resident_limit', used: gate.used, limit: gate.limit })
+  }
+  const fb = actions.addTaskFeedback(req.params.id, req.user!.name, text, req.user!.id)
   if (!fb) return res.status(404).json({ error: 'task not found or empty text' })
   res.json(fb)
 })
 
-app.post('/api/feedback/:id/retry', (req, res) => {
+app.post('/api/feedback/:id/retry', async (req, res) => {
   const found = actions.findFeedback(req.params.id)
   if (!found) return res.status(404).json({ error: 'feedback not found' })
   if (!requireCanvas(req, res, found.canvasId)) return
+  const gate = await allowance.consumeResidentTask(req.user!.id)
+  if (!gate.ok) {
+    return res.status(403).json({ error: 'resident_limit', used: gate.used, limit: gate.limit })
+  }
   res.json(actions.retryTaskFeedback(req.params.id, req.user!.name))
 })
 

--- a/src/components/ActivityPanel.tsx
+++ b/src/components/ActivityPanel.tsx
@@ -5,6 +5,14 @@ import { api } from '../lib/api'
 import { timeAgo } from '../lib/time'
 import { AgentIcon } from './AgentIcon'
 import { MemoryPanel } from './MemoryPanel'
+import { isResidentLimit } from './TeamAllowance'
+
+/* feedback and retries are metered like any other resident task — a 403
+   here means the free tier ran out, so raise the connect wall */
+function reportLimit(err: unknown) {
+  if (isResidentLimit(err)) useStore.getState().setLimitWall(true)
+  else console.error(err)
+}
 
 function duration(t: AgentTask): string {
   const end = t.endedAt ?? Date.now()
@@ -144,7 +152,7 @@ function TaskRow({ task }: { task: AgentTask }) {
     try {
       await api.sendTaskFeedback(task.id, text)
     } catch (e) {
-      console.error(e)
+      reportLimit(e)
     }
   }
 
@@ -169,10 +177,7 @@ function TaskRow({ task }: { task: AgentTask }) {
               : duration(task)}
         </span>
         {task.failedAt && task.queuedBy && canvasId ? (
-          <button
-            className="retry-action compact"
-            onClick={() => api.retryCard(canvasId, task.id).catch(console.error)}
-          >
+          <button className="retry-action compact" onClick={() => api.retryCard(canvasId, task.id).catch(reportLimit)}>
             ↻ Retry
           </button>
         ) : null}
@@ -195,10 +200,7 @@ function TaskRow({ task }: { task: AgentTask }) {
             {f.failedAt ? (
               <span className="fb-failed">
                 {f.failureReason ?? 'The agent did not finish.'}
-                <button
-                  className="retry-action compact"
-                  onClick={() => api.retryTaskFeedback(f.id).catch(console.error)}
-                >
+                <button className="retry-action compact" onClick={() => api.retryTaskFeedback(f.id).catch(reportLimit)}>
                   ↻ Retry
                 </button>
               </span>

--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -165,7 +165,15 @@ export function Board({ canvasId }: { canvasId: string }) {
                   <span> · {timeAgo(t.failedAt!)}</span>
                 </div>
                 <div className="bfailure">{t.failureReason ?? 'The agent did not finish this task.'}</div>
-                <button className="retry-action" onClick={() => api.retryCard(canvasId, t.id).catch(console.error)}>
+                <button
+                  className="retry-action"
+                  onClick={() =>
+                    api.retryCard(canvasId, t.id).catch((err) => {
+                      if (isResidentLimit(err)) useStore.getState().setLimitWall(true)
+                      else console.error(err)
+                    })
+                  }
+                >
                   ↻ Retry
                 </button>
               </div>

--- a/src/components/FrameView.tsx
+++ b/src/components/FrameView.tsx
@@ -489,7 +489,12 @@ export const FrameView = memo(function FrameView({ frame, raster }: { frame: Fra
                           .catch(console.error)
                         setOpenThread(null)
                       }}
-                      onRetry={() => api.retryComment(c.id).catch(console.error)}
+                      onRetry={() =>
+                        api.retryComment(c.id).catch((err) => {
+                          if (isResidentLimit(err)) useStore.getState().setLimitWall(true)
+                          else console.error(err)
+                        })
+                      }
                     />
                   )}
                 </div>


### PR DESCRIPTION
Feedback replies and retries used to be free, so a handful of free tasks could fan out into unbounded Doop Agent runs. Every resident trigger now spends a free task; users on their own connected model account remain unmetered as before.

Ported from the upstream private repo (upstream #79).

🤖 Generated with [Claude Code](https://claude.com/claude-code)