### PR TITLE
feat: ban and unban accounts from the admin dashboard

### DIFF
--- a/server/auth.ts
+++ b/server/auth.ts
@@ -200,3 +200,22 @@ export async function getUserName(userId: string): Promise<string | undefined> {
   if (row?.name) userNames.set(userId, { name: row.name, at: Date.now() })
   return row?.name
 }
+
+/* userId -> banned, same short cache: banning revokes browser sessions via
+   better-auth, but MCP OAuth tokens stay valid until expiry — this check is
+   what actually locks a banned user's agent out, so it runs per MCP call */
+const banStates = new Map<string, { banned: boolean; at: number }>()
+
+export async function isBanned(userId: string): Promise<boolean> {
+  const cached = banStates.get(userId)
+  if (cached && Date.now() - cached.at < NAME_TTL_MS) return cached.banned
+  const [row] = await db
+    .select({ banned: authSchema.user.banned })
+    .from(authSchema.user)
+    .where(eq(authSchema.user.id, userId))
+  /* an unknown user is treated as banned: a token whose account is gone
+     should not keep working */
+  const banned = row ? !!row.banned : true
+  banStates.set(userId, { banned, at: Date.now() })
+  return banned
+}

--- a/server/mcp.ts
+++ b/server/mcp.ts
@@ -6,7 +6,7 @@ import { z } from 'zod'
 import { store } from './store.ts'
 import * as actions from './actions.ts'
 import { canAccessCanvas } from './access.ts'
-import { auth, getUserName, PUBLIC_ORIGIN } from './auth.ts'
+import { auth, getUserName, isBanned, PUBLIC_ORIGIN } from './auth.ts'
 import { renderFrame } from './screenshot.ts'
 import { DOOP_GUIDE, GUIDE_TOPICS } from './guide.ts'
 import { ESCAPED_HTML_NOTE, looksEscapedHtml } from './escapedHtml.ts'
@@ -1145,6 +1145,16 @@ export async function handleMcpRequest(req: Request, res: Response) {
         error: { code: -32001, message: 'Unauthorized: this MCP server requires OAuth' },
         id: null,
       })
+    return
+  }
+  /* banning revokes browser sessions, but an already-issued MCP token keeps
+     validating until it expires — refuse it here so a ban is total */
+  if (session.userId && (await isBanned(session.userId))) {
+    res.status(403).json({
+      jsonrpc: '2.0',
+      error: { code: -32003, message: 'This account has been disabled on this server.' },
+      id: null,
+    })
     return
   }
   const owner = session.userId ? await getUserName(session.userId) : undefined

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -266,4 +266,10 @@ export const adminApi = {
   impersonate: (userId: string) =>
     req('/api/auth/admin/impersonate-user', { method: 'POST', body: JSON.stringify({ userId }) }),
   stopImpersonating: () => req('/api/auth/admin/stop-impersonating', { method: 'POST' }),
+
+  /* also better-auth's: banning revokes the user's sessions and blocks
+     sign-in; the server refuses their MCP tokens separately */
+  ban: (userId: string, banReason?: string) =>
+    req('/api/auth/admin/ban-user', { method: 'POST', body: JSON.stringify({ userId, banReason }) }),
+  unban: (userId: string) => req('/api/auth/admin/unban-user', { method: 'POST', body: JSON.stringify({ userId }) }),
 }

--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -42,6 +42,22 @@ export function Admin() {
     location.assign('/')
   }
 
+  async function setBanned(u: AdminUser, banned: boolean) {
+    const ok = window.confirm(
+      banned
+        ? `Ban ${u.name} (${u.email})? They are signed out everywhere and cannot sign in or use MCP until unbanned.`
+        : `Unban ${u.name} (${u.email})?`,
+    )
+    if (!ok) return
+    try {
+      if (banned) await adminApi.ban(u.id)
+      else await adminApi.unban(u.id)
+      setUsers((list) => (list ? list.map((x) => (x.id === u.id ? { ...x, banned } : x)) : list))
+    } catch (e) {
+      console.error(e)
+    }
+  }
+
   if (denied) {
     return (
       <div className="home">
@@ -226,9 +242,19 @@ export function Admin() {
                     </div>
                   </div>
                   {u.role !== 'admin' && (
-                    <button className="btn ghost small" onClick={() => viewAs(u.id)}>
-                      View as
-                    </button>
+                    <div className="admin-user-actions">
+                      {!u.banned && (
+                        <button className="btn ghost small" onClick={() => viewAs(u.id)}>
+                          View as
+                        </button>
+                      )}
+                      <button
+                        className={`btn ghost small${u.banned ? '' : ' danger'}`}
+                        onClick={() => setBanned(u, !u.banned)}
+                      >
+                        {u.banned ? 'Unban' : 'Ban'}
+                      </button>
+                    </div>
                   )}
                 </div>
               ))}

--- a/src/styles.css
+++ b/src/styles.css
@@ -6911,6 +6911,11 @@ textarea {
   font-size: 12.5px;
   color: var(--ink-faint);
 }
+.admin-user-actions {
+  display: flex;
+  gap: 8px;
+  flex-shrink: 0;
+}
 
 /* impersonation: deliberately loud, and it displaces the page rather than
    floating over it — a banner you can scroll past is a banner you forget */


### PR DESCRIPTION
Admins can ban and unban accounts from `/admin`, built on better-auth's admin plugin (the role machinery from the admin surface). A banned account cannot sign in; its sessions are revoked.

Ported from the upstream private repo (upstream #80).

🤖 Generated with [Claude Code](https://claude.com/claude-code)