### PR TITLE
feat(agent): run the Doop Agent's server tier on Azure OpenAI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -54,11 +54,25 @@
 #EMAIL_FROM="doop <no-reply@doop.example.com>"
 
 # --------------------------------------------------------- resident agents
-# Anthropic API key for the built-in resident design team (board cards,
-# @mentions, guideline distillation). This is the key the FREE tier runs on.
-# Unset = the team runs only for users who connected an account of their own;
-# external agents connected over MCP work regardless.
+# What the built-in resident design team's FREE tier runs on (board cards,
+# @mentions): anthropic (default) | azure. Each user's own connected account
+# (ChatGPT or OpenAI key) always wins over this, whatever it is set to.
+#DOOP_AGENT_PROVIDER=anthropic
+# Anthropic API key — the free tier's key when DOOP_AGENT_PROVIDER=anthropic,
+# and the guideline distiller's key either way. Unset = the team runs only for
+# users who connected an account of their own; MCP agents work regardless.
 #ANTHROPIC_API_KEY=
+# The free tier's Azure OpenAI resource, used when DOOP_AGENT_PROVIDER=azure:
+# the resource endpoint, one of its keys, and the deployment to run on.
+#AZURE_OPENAI_ENDPOINT=https://my-resource.openai.azure.com
+#AZURE_OPENAI_API_KEY=
+#AZURE_OPENAI_DEPLOYMENT=
+# Only for resources that need a pinned api-version query parameter; the
+# default v1 surface needs none.
+#AZURE_OPENAI_API_VERSION=
+# Reasoning effort for Azure runs. Unset = the parameter is not sent, which
+# non-reasoning deployments require.
+#AZURE_OPENAI_REASONING_EFFORT=
 # Free-tier meter: resident tasks each account may start (default 5). Past it,
 # the team keeps running on whatever model account the user connected (their
 # ChatGPT subscription or OpenAI key). Users who connect their own agent via

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ without a human in the loop. Roles (Doop builds; specialists own one pass each �
 accessibility) are defined in [`shared/agents.ts`](shared/agents.ts), and a card can be routed
 through several in order.
 
-The server's own Anthropic key pays for the free tier:
+The server pays for the free tier, on Anthropic by default:
 
 ```bash
 ANTHROPIC_API_KEY=sk-ant-...   # in .env, or the environment of your deployment
@@ -111,6 +111,18 @@ ANTHROPIC_API_KEY=sk-ant-...   # in .env, or the environment of your deployment
 
 Same key gates the **guideline distiller** ([`server/distill.ts`](server/distill.ts)), which proposes
 durable style rules from your canvas.
+
+The free tier can run on **Azure OpenAI** instead — useful when your organisation's credits or
+compliance rules live there:
+
+```bash
+DOOP_AGENT_PROVIDER=azure
+AZURE_OPENAI_ENDPOINT=https://my-resource.openai.azure.com
+AZURE_OPENAI_API_KEY=...
+AZURE_OPENAI_DEPLOYMENT=my-deployment
+```
+
+The distiller stays on `ANTHROPIC_API_KEY` either way and quietly turns off without it.
 
 ### Past the free tasks: connect your own ChatGPT
 
@@ -126,6 +138,10 @@ kinds of account:
   backend that Plus/Pro/Business plans include. Tokens live in `model_accounts` and never reach a
   browser.
 - **OpenAI API key** — pay-as-you-go on the user's own OpenAI account, no subscription involved.
+
+Azure OpenAI is deliberately _not_ a connectable account kind: a user-supplied endpoint would be a
+URL the server fetches with the run's full context — an SSRF vector — so Azure stays a server-level
+provider only.
 
 Either way the user picks their **model tier** in Settings — `gpt-5.6-sol` (flagship),
 `gpt-5.6-terra` (the default workhorse) or `gpt-5.6-luna` (cheap and fast). They are paying for it,
@@ -167,14 +183,20 @@ authenticate over OAuth and drive the canvas from outside, on your own subscript
 Three paths, same canvas: the Doop Agent on our key (free tier), the Doop Agent on your key, or your
 own agent over MCP.
 
-| Variable                   | Default                     | What it does                                                             |
-| -------------------------- | --------------------------- | ------------------------------------------------------------------------ |
-| `ANTHROPIC_API_KEY`        | _unset_                     | Pays for the free Doop Agent tier and the distiller                      |
-| `RESIDENT_TASK_LIMIT`      | `5`                         | Free Doop Agent tasks per account before a connection is needed          |
-| `DOOP_AGENT_MODEL`         | `claude-opus-5`             | Model for the Doop Agent on the server's key                             |
-| `DOOP_AGENT_OPENAI_MODEL`  | `gpt-5.6-terra`             | Default tier on a user's account; each user can pick another in Settings |
-| `CHATGPT_CONNECT_DISABLED` | _unset_                     | `1` hides the ChatGPT flow, leaving the API-key path                     |
-| `DOOP_DISTILL_MODEL`       | `claude-haiku-4-5-20251001` | Model for the guideline distiller                                        |
+| Variable                        | Default                     | What it does                                                             |
+| ------------------------------- | --------------------------- | ------------------------------------------------------------------------ |
+| `DOOP_AGENT_PROVIDER`           | `anthropic`                 | What the free tier runs on: `anthropic` \| `azure`                       |
+| `ANTHROPIC_API_KEY`             | _unset_                     | Pays for the free Doop Agent tier (default provider) and the distiller   |
+| `AZURE_OPENAI_ENDPOINT`         | _unset_                     | The free tier's Azure OpenAI resource, when `DOOP_AGENT_PROVIDER=azure`  |
+| `AZURE_OPENAI_API_KEY`          | _unset_                     | A key of that resource                                                   |
+| `AZURE_OPENAI_DEPLOYMENT`       | _unset_                     | The deployment the free tier runs on                                     |
+| `AZURE_OPENAI_API_VERSION`      | _unset_                     | Pins an `api-version` query parameter; the v1 surface needs none         |
+| `AZURE_OPENAI_REASONING_EFFORT` | _unset_                     | Reasoning effort on Azure runs; unset sends none (non-reasoning-safe)    |
+| `RESIDENT_TASK_LIMIT`           | `5`                         | Free Doop Agent tasks per account before a connection is needed          |
+| `DOOP_AGENT_MODEL`              | `claude-opus-5`             | Model for the Doop Agent on the server's Anthropic key                   |
+| `DOOP_AGENT_OPENAI_MODEL`       | `gpt-5.6-terra`             | Default tier on a user's account; each user can pick another in Settings |
+| `CHATGPT_CONNECT_DISABLED`      | _unset_                     | `1` hides the ChatGPT flow, leaving the API-key path                     |
+| `DOOP_DISTILL_MODEL`            | `claude-haiku-4-5-20251001` | Model for the guideline distiller                                        |
 
 `RESIDENT_TASK_LIMIT` is the free-tier meter for the hosted version. It counts only tasks a user
 _initiates_ — feedback replies and retries on existing work stay free — and users who have connected

--- a/server/agentModel.ts
+++ b/server/agentModel.ts
@@ -1,16 +1,20 @@
 import Anthropic from '@anthropic-ai/sdk'
 import { getAccount, withFreshToken } from './modelAccounts.ts'
-import type { ModelAccount } from './modelAccounts.ts'
-import { modelFor, ModelAuthError, runOpenAiTurn } from './openaiAgent.ts'
+import type { AccountKind, ModelAccount } from './modelAccounts.ts'
+import { modelFor, ModelAuthError, runAzureTurn, runOpenAiTurn } from './openaiAgent.ts'
 import type { StopReason, TurnBlock } from './openaiAgent.ts'
 
 /**
  * Which model runs a Doop Agent turn, and on whose bill.
  *
- * The server's own ANTHROPIC_API_KEY pays for the free tasks every account
- * starts with. The moment a user connects a model account of their own — their
- * ChatGPT subscription or their own OpenAI key — their runs move onto it, and
- * the free-task meter stops applying to them entirely.
+ * Two layers, resolved in this order:
+ *
+ *  - a user's own model account (their ChatGPT subscription or an OpenAI API
+ *    key) — the moment one is connected, that user's runs move onto it and
+ *    the free-task meter stops applying to them;
+ *  - the server tier, which pays for the free tasks every account starts
+ *    with. DOOP_AGENT_PROVIDER picks what it runs on: 'anthropic' (the
+ *    default, on ANTHROPIC_API_KEY) or 'azure' (the AZURE_OPENAI_* vars).
  *
  * A run bills exactly ONE person: the requester behind the work it claims. The
  * queue is worked one requester at a time rather than sweeping several people's
@@ -18,7 +22,8 @@ import type { StopReason, TurnBlock } from './openaiAgent.ts'
  * else's request.
  */
 
-export type Provider = 'anthropic' | 'chatgpt' | 'openai-key'
+export type ServerProvider = 'anthropic' | 'azure'
+export type Provider = ServerProvider | AccountKind
 
 export interface AgentTurnRequest {
   /** ordered system blocks; `cache` marks an Anthropic cache breakpoint */
@@ -44,26 +49,23 @@ export interface AgentModel {
 
 export { ModelAuthError }
 
+/* ---------------------------------------------------------------- */
+/* the server tier: pays for everyone's free tasks                  */
+/* ---------------------------------------------------------------- */
+
 const ANTHROPIC_MODEL = process.env.DOOP_AGENT_MODEL || 'claude-opus-5'
 
 let anthropic: Anthropic | null = null
-let warned = false
 
-function anthropicClient(): Anthropic | null {
+function anthropicTier(): AgentModel | null {
   if (!process.env.ANTHROPIC_API_KEY) {
-    if (!warned) {
-      warned = true
-      console.log(
-        '[doop-agent] ANTHROPIC_API_KEY not set — the free Doop Agent tier is off. Users who connect their own ChatGPT subscription still get the agent; everyone else sees queued cards and @mentions go unpicked. See README → "The Doop Agent".',
-      )
-    }
+    warnOnce(
+      '[doop-agent] ANTHROPIC_API_KEY not set — the free Doop Agent tier is off. Users who connect a model account of their own still get the agent; everyone else sees queued cards and @mentions go unpicked. See README → "The Doop Agent".',
+    )
     return null
   }
   if (!anthropic) anthropic = new Anthropic()
-  return anthropic
-}
-
-function anthropicModel(client: Anthropic): AgentModel {
+  const client = anthropic
   return {
     provider: 'anthropic',
     label: `Doop (${ANTHROPIC_MODEL})`,
@@ -92,17 +94,97 @@ function anthropicModel(client: Anthropic): AgentModel {
   }
 }
 
-function openaiModel(account: ModelAccount): AgentModel {
+function azureTier(): AgentModel | null {
+  const endpoint = process.env.AZURE_OPENAI_ENDPOINT
+  const deployment = process.env.AZURE_OPENAI_DEPLOYMENT
+  const apiKey = process.env.AZURE_OPENAI_API_KEY
+  if (!endpoint || !deployment || !apiKey) {
+    warnOnce(
+      '[doop-agent] DOOP_AGENT_PROVIDER=azure needs AZURE_OPENAI_ENDPOINT, AZURE_OPENAI_DEPLOYMENT and AZURE_OPENAI_API_KEY — the free Doop Agent tier is off until all three are set.',
+    )
+    return null
+  }
+  const config = { endpoint, deployment, apiKey }
+  return {
+    provider: 'azure',
+    label: `Doop (${deployment})`,
+    async run(req) {
+      try {
+        return await runAzureTurn(config, {
+          system: joinSystem(req),
+          tools: req.tools,
+          messages: req.messages,
+          maxTokens: req.maxTokens,
+        })
+      } catch (err) {
+        /* these are the SERVER's credentials — "reconnect your account" would
+           send users chasing a connection they don't have */
+        if (err instanceof ModelAuthError) {
+          throw new Error(
+            'Azure OpenAI rejected this server’s credentials — check AZURE_OPENAI_API_KEY and AZURE_OPENAI_DEPLOYMENT',
+            { cause: err },
+          )
+        }
+        throw err
+      }
+    },
+  }
+}
+
+const serverTiers: Record<ServerProvider, () => AgentModel | null> = {
+  anthropic: anthropicTier,
+  azure: azureTier,
+}
+
+function serverProvider(): ServerProvider {
+  const chosen = process.env.DOOP_AGENT_PROVIDER || 'anthropic'
+  if (chosen in serverTiers) return chosen as ServerProvider
+  warnOnce(
+    `[doop-agent] DOOP_AGENT_PROVIDER="${chosen}" is not a server provider (anthropic | azure) — using anthropic.`,
+  )
+  return 'anthropic'
+}
+
+/** What the boot banner reports: which provider the free tier would run on,
+ *  and whether it actually can. */
+export function serverTierInfo(): { provider: ServerProvider; ready: boolean } {
+  const provider = serverProvider()
+  return { provider, ready: serverTiers[provider]() !== null }
+}
+
+const warnedAbout = new Set<string>()
+function warnOnce(message: string) {
+  if (warnedAbout.has(message)) return
+  warnedAbout.add(message)
+  console.log(message)
+}
+
+/* ---------------------------------------------------------------- */
+/* a user's own account                                             */
+/* ---------------------------------------------------------------- */
+
+const BYO_LABELS: Record<AccountKind, string> = {
+  chatgpt: 'ChatGPT',
+  'openai-key': 'OpenAI',
+}
+
+/* the OpenAI-shaped transports take one system string; cache breakpoints are
+   an Anthropic concept and simply flatten away */
+function joinSystem(req: AgentTurnRequest): string {
+  return req.system.map((block) => block.text).join('\n\n')
+}
+
+function byoModel(account: ModelAccount): AgentModel {
   return {
     provider: account.kind,
-    label: `${account.kind === 'chatgpt' ? 'ChatGPT' : 'OpenAI'} (${modelFor(account)})`,
+    label: `${BYO_LABELS[account.kind]} (${modelFor(account)})`,
     userId: account.userId,
     async run(req) {
       /* refreshed per turn, not per run: a long design run outlives an
          hour-long access token */
       const live = await withFreshToken(account)
       return runOpenAiTurn(live, {
-        system: req.system.map((block) => block.text).join('\n\n'),
+        system: joinSystem(req),
         tools: req.tools,
         messages: req.messages,
         maxTokens: req.maxTokens,
@@ -114,9 +196,9 @@ function openaiModel(account: ModelAccount): AgentModel {
 /**
  * Pick the model for one run, billed to exactly one person: `payerId` is the
  * human whose work the run is about to claim. Returns null when nothing can
- * run it — they have no account of their own and there is no server key.
+ * run it — they have no account of their own and the server tier is off.
  *
- * A connected account wins outright: someone who has just linked their ChatGPT
+ * A connected account wins outright: someone who has just linked their own
  * subscription expects the very next task to run on it, and the free tier is a
  * trial to get them here, not a balance to spend down first. It also means
  * connecting stops costing us anything from that moment on.
@@ -128,7 +210,6 @@ export async function pickModel(payerId?: string): Promise<AgentModel | null> {
         return null
       })
     : null
-  if (account) return openaiModel(account)
-  const client = anthropicClient()
-  return client ? anthropicModel(client) : null
+  if (account) return byoModel(account)
+  return serverTiers[serverProvider()]()
 }

--- a/server/index.ts
+++ b/server/index.ts
@@ -29,6 +29,7 @@ import * as ingest from './ingest.ts'
 import { seed } from './seed.ts'
 import * as allowance from './allowance.ts'
 import * as modelAccounts from './modelAccounts.ts'
+import { serverTierInfo } from './agentModel.ts'
 import { AGENT_MODELS } from './openaiAgent.ts'
 import { mentionedRole } from '../shared/agents.ts'
 import { colorFor } from '../shared/types.ts'
@@ -1387,9 +1388,10 @@ server.listen(PORT, () => {
   /* The Doop Agent failing silently is the one "why is nothing happening?"
      a self-hoster cannot debug from the UI — board cards and @mentions just
      sit there. Say so at boot, not only when the first card is queued. */
+  const tier = serverTierInfo()
   console.log(
-    process.env.ANTHROPIC_API_KEY
-      ? '⟡ doop agent        on — free tier on this server’s key, then each user’s own ChatGPT/OpenAI account'
-      : '⟡ doop agent        no server key — runs only for users who connect their own ChatGPT subscription or OpenAI key (set ANTHROPIC_API_KEY for a free tier; agents connected over MCP work regardless)',
+    tier.ready
+      ? `⟡ doop agent        on — free tier on this server’s ${tier.provider === 'azure' ? 'Azure OpenAI deployment' : 'Anthropic key'}, then each user’s own model account`
+      : `⟡ doop agent        no server ${tier.provider === 'azure' ? 'Azure config' : 'key'} — runs only for users who connect their own ChatGPT subscription or OpenAI key (${tier.provider === 'azure' ? 'set the AZURE_OPENAI_* vars' : 'set ANTHROPIC_API_KEY'} for a free tier; agents connected over MCP work regardless)`,
   )
 })

--- a/server/modelAccounts.ts
+++ b/server/modelAccounts.ts
@@ -47,6 +47,8 @@ const AUTH_USER_AGENT = process.env.CHATGPT_AUTH_USER_AGENT || 'doop/0.1 (+https
 
 export type AccountKind = 'chatgpt' | 'openai-key'
 
+const ACCOUNT_KINDS: readonly string[] = ['chatgpt', 'openai-key'] satisfies AccountKind[]
+
 export interface ModelAccount {
   userId: string
   kind: AccountKind
@@ -81,10 +83,16 @@ export function chatgptConnectEnabled(): boolean {
 /* storage                                                          */
 /* ---------------------------------------------------------------- */
 
-function toAccount(row: typeof modelAccounts.$inferSelect): ModelAccount {
+function toAccount(row: typeof modelAccounts.$inferSelect): ModelAccount | null {
+  if (!ACCOUNT_KINDS.includes(row.kind)) {
+    /* a kind this build doesn't know (a rollback after an upgrade, say) —
+       treating it as disconnected beats running it as the wrong provider */
+    console.warn(`[doop-agent] ignoring model account with unknown kind "${row.kind}" for user ${row.userId}`)
+    return null
+  }
   return {
     userId: row.userId,
-    kind: row.kind === 'openai-key' ? 'openai-key' : 'chatgpt',
+    kind: row.kind as AccountKind,
     ...(row.accountId ? { accountId: row.accountId } : {}),
     ...(row.email ? { email: row.email } : {}),
     ...(row.plan ? { plan: row.plan } : {}),

--- a/server/openaiAgent.ts
+++ b/server/openaiAgent.ts
@@ -8,10 +8,15 @@ import type { ModelAccount } from './modelAccounts.ts'
  * Responses API item format, tool-call ids, streaming — is contained here, so
  * server/resident.ts stays a single provider-neutral loop.
  *
- * Two transports, one body:
+ * Three transports, one body:
  *  - a connected ChatGPT subscription, through the same Codex backend the
  *    Codex CLI uses (SSE only, no max_output_tokens);
- *  - a plain OpenAI API key against api.openai.com (ordinary JSON).
+ *  - a plain OpenAI API key against api.openai.com (ordinary JSON);
+ *  - an Azure OpenAI deployment (same Responses API, authenticated with
+ *    Azure's api-key header) — SERVER config only, the free tier when
+ *    DOOP_AGENT_PROVIDER=azure. Deliberately not a connectable per-user
+ *    account: a user-supplied endpoint would be a server-side fetch target,
+ *    i.e. an SSRF into whatever network Doop runs on.
  *
  * The one real impedance mismatch is images. Anthropic returns screenshots
  * inside tool results; the Responses API only accepts text in a
@@ -35,6 +40,12 @@ export const AGENT_MODELS = [
 
 export const DEFAULT_OPENAI_MODEL = process.env.DOOP_AGENT_OPENAI_MODEL || 'gpt-5.6-terra'
 const REASONING_EFFORT = process.env.DOOP_AGENT_OPENAI_EFFORT || 'medium'
+/* Azure deployments are named by their owner and can host non-reasoning
+   models, which reject a `reasoning` block outright — so unlike the OpenAI
+   paths there is no default effort: unset means the parameter stays home. */
+const AZURE_REASONING_EFFORT = process.env.AZURE_OPENAI_REASONING_EFFORT || ''
+/* Azure's v1 surface needs no api-version; older resources can pin one. */
+const AZURE_API_VERSION = process.env.AZURE_OPENAI_API_VERSION || ''
 
 export function isKnownModel(id: string): boolean {
   return AGENT_MODELS.some((model) => model.id === id)
@@ -353,8 +364,52 @@ async function runApiKey(account: ModelAccount, req: TurnRequest): Promise<TurnR
   return fromResponse((await res.json()) as ResponseBody)
 }
 
+/** Everything one Azure OpenAI call needs, straight from the AZURE_OPENAI_*
+ *  env vars — server config, never user input. */
+export interface AzureConfig {
+  /** the resource base (https://….openai.azure.com) or a full …/responses URL */
+  endpoint: string
+  deployment: string
+  apiKey: string
+}
+
+/** The Responses URL for an Azure resource. A bare endpoint gets the v1
+ *  path appended; an endpoint that already names …/responses (an APIM
+ *  front door, say) is used as given. */
+export function azureResponsesUrl(endpoint: string): string {
+  const base = endpoint.replace(/\/+$/, '')
+  const url = /\/responses$/.test(new URL(base).pathname) ? base : `${base}/openai/v1/responses`
+  return AZURE_API_VERSION ? `${url}?api-version=${encodeURIComponent(AZURE_API_VERSION)}` : url
+}
+
+/** One turn against an Azure OpenAI deployment. */
+export async function runAzureTurn(config: AzureConfig, req: TurnRequest): Promise<TurnResult> {
+  const res = await fetch(azureResponsesUrl(config.endpoint), {
+    method: 'POST',
+    headers: { 'api-key': config.apiKey, 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      model: config.deployment,
+      instructions: req.system,
+      input: toInput(req.messages),
+      tools: toTools(req.tools),
+      tool_choice: 'auto',
+      parallel_tool_calls: false,
+      ...(AZURE_REASONING_EFFORT ? { reasoning: { effort: AZURE_REASONING_EFFORT } } : {}),
+      max_output_tokens: req.maxTokens,
+      store: false,
+    }),
+  })
+  if (!res.ok) throw await failure(res, 'Azure OpenAI')
+  return fromResponse((await res.json()) as ResponseBody)
+}
+
+const transports: Record<ModelAccount['kind'], (account: ModelAccount, req: TurnRequest) => Promise<TurnResult>> = {
+  chatgpt: runChatgpt,
+  'openai-key': runApiKey,
+}
+
 export function runOpenAiTurn(account: ModelAccount, req: TurnRequest): Promise<TurnResult> {
-  return account.kind === 'chatgpt' ? runChatgpt(account, req) : runApiKey(account, req)
+  return transports[account.kind](account, req)
 }
 
 /* exported for tests */

--- a/server/resident.ts
+++ b/server/resident.ts
@@ -25,11 +25,12 @@ import { executeGuardedBatch } from './guardedBatch.ts'
  * use, so users see the full show: presence, set_status in the working-now
  * strip, a task in the panel, and edits playing back through the reveal.
  *
- * Which model each run uses is server/agentModel.ts's decision: the server's
- * ANTHROPIC_API_KEY covers the free tier, and past that the run moves onto the
- * model account the requesting human connected (their ChatGPT subscription or
- * OpenAI key). With neither, the queue behaves as it always did — the work
- * waits for the next agent to connect over MCP.
+ * Which model each run uses is server/agentModel.ts's decision: the server
+ * tier (Anthropic by default, or an Azure OpenAI deployment via
+ * DOOP_AGENT_PROVIDER) covers the free tasks, and past that the run moves onto
+ * the model account the requesting human connected (their ChatGPT
+ * subscription or OpenAI key). With neither, the queue behaves as it always
+ * did — the work waits for the next agent to connect over MCP.
  */
 
 const MAX_TURNS = 24
@@ -479,8 +480,10 @@ async function runAgent(canvasId: string, agentName: string, stalled: Set<string
       /* An API/tool crash becomes a visible, manually retryable failure. */
       crashed = true
       /* a dead credential is the one crash a human can actually fix, so it
-         gets its own wording all the way through to the card */
-      staleAccount = err instanceof ModelAuthError
+         gets its own wording all the way through to the card — but only when
+         the credential is theirs: a server-tier run has no account to
+         reconnect, whatever error class its transport leaks */
+      staleAccount = err instanceof ModelAuthError && !!model.userId
       console.error('[resident] run errored', err)
       actions.setAgentStatus(
         canvasId,

--- a/tests/openaiAgent.test.ts
+++ b/tests/openaiAgent.test.ts
@@ -1,6 +1,6 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import type Anthropic from '@anthropic-ai/sdk'
-import { _internal } from '../server/openaiAgent.ts'
+import { _internal, azureResponsesUrl, runAzureTurn } from '../server/openaiAgent.ts'
 import { parseAuthCode } from '../server/modelAccounts.ts'
 
 /**
@@ -165,6 +165,62 @@ describe('ChatGPT redirect parsing', () => {
 
   it('rejects a redirect URL with no code', () => {
     expect(() => parseAuthCode('http://localhost:1455/auth/callback')).toThrow(/no \?code=/)
+  })
+})
+
+describe('Azure OpenAI transport', () => {
+  afterEach(() => vi.unstubAllGlobals())
+
+  it('appends the v1 Responses path to a bare resource endpoint', () => {
+    expect(azureResponsesUrl('https://my-res.openai.azure.com')).toBe(
+      'https://my-res.openai.azure.com/openai/v1/responses',
+    )
+    expect(azureResponsesUrl('https://my-res.openai.azure.com/')).toBe(
+      'https://my-res.openai.azure.com/openai/v1/responses',
+    )
+  })
+
+  it('uses an endpoint that already names …/responses as given (APIM front doors)', () => {
+    expect(azureResponsesUrl('https://gateway.example.com/openai/v1/responses')).toBe(
+      'https://gateway.example.com/openai/v1/responses',
+    )
+  })
+
+  it('authenticates with api-key, runs the deployment, and sends no reasoning block by default', async () => {
+    let seen: { url?: string; headers?: Record<string, string>; body?: Record<string, unknown> } = {}
+    vi.stubGlobal('fetch', async (url: string, init: RequestInit) => {
+      seen = { url, headers: init.headers as Record<string, string>, body: JSON.parse(init.body as string) }
+      return new Response(
+        JSON.stringify({
+          status: 'completed',
+          output: [{ type: 'message', content: [{ type: 'output_text', text: 'done' }] }],
+        }),
+        { status: 200 },
+      )
+    })
+    const result = await runAzureTurn(
+      { endpoint: 'https://my-res.openai.azure.com', deployment: 'my-gpt', apiKey: 'azkey' },
+      { system: 'be a designer', tools: [], messages: [{ role: 'user', content: 'hi' }], maxTokens: 4096 },
+    )
+    expect(result.content).toEqual([{ type: 'text', text: 'done' }])
+    expect(seen.url).toBe('https://my-res.openai.azure.com/openai/v1/responses')
+    expect(seen.headers?.['api-key']).toBe('azkey')
+    expect(seen.headers?.Authorization).toBeUndefined()
+    expect(seen.body?.model).toBe('my-gpt')
+    expect(seen.body?.max_output_tokens).toBe(4096)
+    /* a non-reasoning deployment 400s on a reasoning block — absent unless
+       AZURE_OPENAI_REASONING_EFFORT opts in */
+    expect(seen.body).not.toHaveProperty('reasoning')
+  })
+
+  it('surfaces rejected credentials as an auth error', async () => {
+    vi.stubGlobal('fetch', async () => new Response('denied', { status: 401 }))
+    await expect(
+      runAzureTurn(
+        { endpoint: 'https://my-res.openai.azure.com', deployment: 'my-gpt', apiKey: 'stale' },
+        { system: '', tools: [], messages: [], maxTokens: 100 },
+      ),
+    ).rejects.toThrow(/credentials/)
   })
 })
 


### PR DESCRIPTION
The free tier's server-side runs can now use an Azure OpenAI resource instead of Anthropic: `DOOP_AGENT_PROVIDER=azure` with `AZURE_OPENAI_ENDPOINT`/`API_KEY`/`DEPLOYMENT`. Each user's own connected account (ChatGPT or OpenAI key) still always wins over the server tier. The guideline distiller stays on the Anthropic key either way.

Ported from the upstream private repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)