### PR TITLE
fix: compile the PostHog support widget into the no-external bundle

### DIFF
--- a/src/lib/posthog.ts
+++ b/src/lib/posthog.ts
@@ -14,6 +14,9 @@
 import 'posthog-js/dist/posthog-recorder'
 import 'posthog-js/dist/exception-autocapture'
 import 'posthog-js/dist/web-vitals'
+/* Conversations (customer support widget): also a lazy-loaded extension, so
+   it must be compiled in or the no-external build can never show it. */
+import 'posthog-js/dist/conversations'
 import posthog from 'posthog-js/dist/module.no-external'
 
 const key = import.meta.env.VITE_POSTHOG_KEY


### PR DESCRIPTION
The support widget loaded from PostHog's CDN at runtime, which the strict no-external-hosts posture blocks — so it silently never appeared. It now compiles into the bundle like the rest of the PostHog client.

Ported from the upstream private repo (upstream #81).

🤖 Generated with [Claude Code](https://claude.com/claude-code)