### PR TITLE
feat(analytics): capture custom agent connect and use in PostHog

### DIFF
--- a/server/analytics.ts
+++ b/server/analytics.ts
@@ -1,0 +1,43 @@
+/* Server-side PostHog capture — for events that happen where posthog-js
+ * can't see them (MCP agents, background work). Events use the user's id
+ * as distinct_id, the same id the web client identifies with, so they land
+ * on the same PostHog person as the browser events.
+ *
+ * The key is the same public project token the client bundle ships with;
+ * VITE_POSTHOG_KEY is a Railway service variable, so it is present at
+ * runtime too, not only as a build arg. No key → captures are no-ops
+ * (local dev, self-hosted installs with analytics off). */
+
+const PH_INGEST = process.env.POSTHOG_INGEST_HOST || 'https://us.i.posthog.com'
+const PH_KEY = process.env.POSTHOG_KEY || process.env.VITE_POSTHOG_KEY
+
+export function capture(distinctId: string, event: string, properties: Record<string, unknown> = {}) {
+  if (!PH_KEY) return
+  fetch(`${PH_INGEST}/capture/`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ api_key: PH_KEY, event, distinct_id: distinctId, properties }),
+  }).catch(() => {}) /* analytics must never take a request down with it */
+}
+
+/* Per-(distinct_id, event) rate limit for signals that fire on every request
+ * but only mean something once per session-ish window (an agent streaming a
+ * design makes dozens of tool calls per minute). */
+const lastCapture = new Map<string, number>()
+
+export function captureThrottled(
+  distinctId: string,
+  event: string,
+  properties: Record<string, unknown> = {},
+  windowMs = 30 * 60 * 1000,
+) {
+  const key = `${distinctId}\n${event}`
+  const now = Date.now()
+  const last = lastCapture.get(key)
+  if (last && now - last < windowMs) return
+  lastCapture.set(key, now)
+  if (lastCapture.size > 10_000) {
+    for (const [k, t] of lastCapture) if (now - t >= windowMs) lastCapture.delete(k)
+  }
+  capture(distinctId, event, properties)
+}

--- a/server/mcp.ts
+++ b/server/mcp.ts
@@ -7,6 +7,7 @@ import { store } from './store.ts'
 import * as actions from './actions.ts'
 import { canAccessCanvas } from './access.ts'
 import { auth, getUserName, isBanned, PUBLIC_ORIGIN } from './auth.ts'
+import { capture, captureThrottled } from './analytics.ts'
 import { renderFrame } from './screenshot.ts'
 import { DOOP_GUIDE, GUIDE_TOPICS } from './guide.ts'
 import { ESCAPED_HTML_NOTE, looksEscapedHtml } from './escapedHtml.ts'
@@ -1156,6 +1157,23 @@ export async function handleMcpRequest(req: Request, res: Response) {
       id: null,
     })
     return
+  }
+  /* A custom (bring-your-own) agent talking to us is the behavior we want to
+     grow — instrument it. `initialize` marks a fresh client session (and is
+     the only message carrying the client's name); tool calls mark actual use,
+     throttled because one design task is dozens of calls. */
+  if (session.userId) {
+    const msgs = Array.isArray(req.body) ? req.body : [req.body]
+    for (const msg of msgs) {
+      if (msg?.method === 'initialize') {
+        capture(session.userId, 'custom_agent_connected', {
+          agent_client: msg.params?.clientInfo?.name,
+          agent_client_version: msg.params?.clientInfo?.version,
+        })
+      } else if (msg?.method === 'tools/call') {
+        captureThrottled(session.userId, 'custom_agent_used', { first_tool: msg.params?.name })
+      }
+    }
   }
   const owner = session.userId ? await getUserName(session.userId) : undefined
   const server = buildMcpServer(owner, session.userId ?? undefined)


### PR DESCRIPTION
Captures when a user connects their own MCP agent and when a connected agent is actually used — the activation events the funnel was blind to. As with all analytics, entirely inert unless `VITE_POSTHOG_KEY` is set.

Ported from the upstream private repo (upstream #82).

🤖 Generated with [Claude Code](https://claude.com/claude-code)