### PR TITLE
feat(guide): taste curriculum — mood method, brief ritual, anchor and hero-review rules

### DIFF
--- a/docs/mcp-roadmap.md
+++ b/docs/mcp-roadmap.md
@@ -1,0 +1,133 @@
+# Doop MCP roadmap
+
+Adjustments derived from the Paper MCP comparison (Aug 2026). Ordered by dependency
+and value: phases 1–3 are the "efficient editing" arc, 4–6 build outward from it.
+
+## Phase 1 — Addressability substrate
+
+Everything else builds on this.
+
+1. **`annotateHtml` module** — server-side pass (Bun `HTMLRewriter`) injecting stable
+   `data-doop-id` attributes on section-level elements. Segment by tree fan-out +
+   subtree weight; semantic tags / headings / meaningful classnames are bonus signals
+   only (div soup must work). Idempotent: never renumber existing ids; per-frame id
+   counter persisted on the frame record.
+2. **Wire into every write path** — `create_frame`, `set_frame_html`,
+   `append_frame_html` (annotate the accumulated document, not fragments),
+   `edit_frame_html` results, `import_webpage`.
+3. **Geometry harvesting** — the screenshot service also collects
+   `getBoundingClientRect()` per `data-doop-id`, cached per frame version. Large
+   rendered regions with no tag get promoted to sections (self-healing pass).
+4. **Strip `data-doop-*` on human-facing HTML export** (copy-code paths); keep in the
+   live DOM (stable ids also improve morph keying).
+
+## Phase 2 — Efficient read/edit tools
+
+5. **`get_frame_outline(frame_id, depth?)`** — indented skeleton: tag, ids/classes,
+   text snippet, child count, byte size, position (from cached boxes).
+6. **`get_frame_html(frame_id, selector)`** — outerHTML of one matched element;
+   error on 0 or >1 matches.
+7. **Selector-based edits** — fold `edit_frame_html` into a single `edit_frame`
+   accepting batched ops `{selector, set_text | set_styles | set_attrs |
+replace_html | remove}` OR the existing `old_str`/`new_str`. One tool, one
+   decision point.
+8. **`duplicate_frame(frame_id)`** — server-side deep clone, auto-placed.
+9. **`get_frame_screenshot` gains `annotate: true`** — section boxes + ids drawn on
+   the image so agents can resolve "the hero" visually.
+
+## Phase 3 — Import quality
+
+10. **Capture-time slimming in `import_webpage`** — Chrome CSS Coverage during
+    render, snapshot DOM, strip all `<script>`, prune CSS via coverage ∪ dropcss
+    selector-matching, minify with Lightning CSS. Target: 400KB captures →
+    30–60KB frames.
+11. **Capture-time annotation** — geometry-based `data-doop-id` sectioning while
+    Puppeteer has the page live (imports get the best segmentation of all).
+
+## Phase 4 — Guide & taste content
+
+Cheap, high leverage, no code risk — can ship anytime. Paper's guide is ~50% taste
+curriculum; that is their real moat and we have evidence (inspo-recipe experiment)
+that injected taste beats model defaults.
+
+12. **Rewrite `get_guide` as a taste + workflow curriculum** — the guide is the
+    STABLE layer: principles only (mood-word palette method, anti-cliché pairing
+    blocklist, anti-first-instinct mood pick, typography doctrine), workflow
+    rituals. Recipes themselves never live in the guide. NOTE: the mandatory
+    retrieval step in the brief ("name a retrieved recipe or state none fits")
+    ships together with the inspo layer (20/12b), not before — until then the
+    brief derives from principles only.
+    - **12a. Inspo research pipeline** — curate gallery exemplars and distill new
+      style recipes (extends the inspo-recipe experiment). Recipes live entirely
+      in the retrieval layer (20); the guide only mandates looking them up.
+      Ongoing content work, not a one-off.
+    - NOTE (from testing): the redesign workflow is a second entry point that
+      bypasses the brief — when the retrieval mandate returns, the redesign
+      section needs its own hook: Direction A stays anchored to the source
+      brand; Direction B must retrieve category inspiration and name its
+      exemplars in the redesign guideline doc.
+    - **12b. Interim bridge** — until `search_inspiration` exists, ship the five
+      existing recipes (CRAV, Oatside, Datacurve, Ponder, Feather) as retrievable
+      guidelines (global tier or per-canvas) so the guide's retrieval mandate has
+      something real to hit. Manual testing of recipes happens here first; the
+      Phase 5 tools later replace the plumbing without changing the workflow.
+13. **Mandatory design brief ritual** — on a fresh canvas, agents post a brief
+    (mood candidates, chosen mood + why not first instinct, palette with roles,
+    type scale, direction) via `set_status` + `save_decision` before the first
+    `create_frame`.
+14. **Named critique rubric** — upgrade REVIEW_NUDGE into a checklist (spacing,
+    typography, contrast, alignment, frame fit, repetition) + one-line verdict.
+15. **Hard rules** — never nuke-and-rewrite a frame for small fixes; no raw frame
+    IDs in user-facing text; placeholder content self-brands as Doop (never Figma/
+    Sketch/Paper); device presets on `create_frame` (`preset: "mobile" | "desktop"`).
+
+## Phase 5 — Assets & generation
+
+One tool per asset class in the product map (fonts, icons, logos, images,
+patterns, videos, inspiration). Conventions: `search_*` returns visible
+thumbnails plus hotlinkable URLs; generation is metered and explicit-request-only.
+
+16. **`search_fonts`** — Google Fonts by name or vibe; rendered specimen previews
+    via the screenshot service so agents SEE fonts before choosing.
+17. **`generate_pattern`** — procedural SVG/CSS backgrounds (mesh gradients, grain,
+    dot grids, waves, blobs, topo lines); seeded/deterministic, token-recolorable,
+    zero AI cost. Differentiator: output is inline SVG/CSS, not raster.
+18. **`doop-gen://` URL scheme** — AI image generation intercepted on any write
+    path (à la Paper's `paper-gen://`): placeholder renders immediately, real
+    asset morphs in when generation completes. Zero new tool surface. Include an
+    SVG model for editable vector output.
+19. **`search_videos`** — Pexels/Coverr stock loops (thumbnail, duration,
+    muted-loop-ready MP4 URL). No video generation.
+20. **`search_inspiration` + `get_style_recipe`** — curated gallery thumbnails +
+    distilled recipes (productizes the inspo experiment; content from 12a).
+    Adopt Mobbin's granularity split (screens / sections / flows); picking a
+    result pins it as a canvas reference. Complementary to Mobbin's MCP, not a
+    catalog competitor — recipes and canvas-memory integration are the moat.
+21. **`get_brand(domain)`** — logo + brand colors + fonts via the existing
+    Brandfetch wiring in `search_logos`.
+
+## Phase 6 — Differentiators (what Paper structurally can't follow)
+
+22. **`get_presence` + element-pinned feedback** — canvas click-to-select resolves
+    to nearest `data-doop-id`; selection rides the feedback channel ("change this
+    ↦ frame + section"). MCP regroup: move `set_status`/`get_feedback` out of
+    "Canvas memory" into a "Presence & collaboration" group.
+23. **Canvas design tokens** — `:root` CSS vars injected into every frame; editing
+    a token restyles the whole canvas live. Tailwind v4 namespaces (`--color-*`,
+    `--text-*`, `--radius-*`, …); `get_tokens(format: css | tailwind)` for export.
+24. **`publish_frame(frame_id, slug?)`** — hosted live URL; the frame IS a real
+    page. Complements `export_frame` image URLs.
+25. **Pixel tools** — `get_frame_analytics` / `get_heatmap` (annotated-screenshot
+    overlay) on published designs. Closes design → publish → measure → optimize.
+26. **Flow graph first-class** — `link_frames` / `get_flow`, generalizing the
+    design-sync flow map so agents design journeys, not screens.
+27. **`list_decisions(canvas_id)`** — read side of `save_decision`.
+28. **PDF/deck export** — canvas → multi-page PDF ordered by frame position.
+
+## Quick wins
+
+- 12–15 (guide content), 8 (`duplicate_frame`), 27 (`list_decisions`).
+
+## Strategic path
+
+- 1 → 2 → 3 in order; the annotation pass is the substrate under 5–9, 11 and 22.

--- a/server/guide.ts
+++ b/server/guide.ts
@@ -16,12 +16,21 @@ export const DESIGN_QUALITY = `- Commit to ONE clear aesthetic direction per fra
 - Typography does the heavy lifting: pair a characterful display face with a quiet body
   face, and use strong size contrast between display and label text. Avoid the default
   faces everyone reaches for (Inter, Roboto, Arial) unless the brief wants a system feel.
-- Color: choose a ground and ONE strong accent, then derive supporting tones from the same
-  world. Avoid the clichés that read as AI output: purple gradients on white, navy with
-  electric teal, gratuitous glassmorphism, shadows on everything.
+- Color: before any hex, commit to a MOOD — a physical scene or register (mineral,
+  bookish, candlelit, maritime, alpine, industrial, phosphor, signage, gallery …) — and
+  derive every color from a specific object in that scene ("bookish" = plaster, oak,
+  ink, candle flame). If you cannot name the object behind a color, the palette is
+  abstract and will feel glued together. List a few plausible moods, then pick one that
+  is NOT your first instinct — first instincts regress to the same predictable answers.
+  One ground, ONE strong accent, supporting tones from the same scene.
+- Avoid the clichés that read as AI output: purple gradients on white, navy or charcoal
+  with electric teal/purple/lime, warm off-white with terracotta or burnt orange, muted
+  earth tones on pure white, neon accents on tinted warm grounds, gratuitous
+  glassmorphism, shadows on everything.
 - White space is a feature. Vary spacing deliberately — tight inside groups, generous
   between them.
-- Realistic content everywhere. No lorem ipsum, no "Your text here".`
+- Realistic content everywhere. No lorem ipsum, no "Your text here". When placeholder
+  content needs a design tool as an example, it is Doop — never a competitor.`
 
 export const DOOP_GUIDE = `# Doop Agent Guide
 
@@ -95,6 +104,22 @@ and fix real issues before moving on:
 Prefer targeted fixes over rewrites. Never delete and restart a mostly-good frame — the
 humans watching lose work they may have been reacting to.
 
+## Design brief — before your first frame
+
+Before creating frames on a canvas whose style is not already established, commit to a
+brief. It is part of the deliverable, not private scratch work:
+
+1. **Write the brief**: mood candidates → the mood chosen (not your first instinct, and
+   say why) → palette with roles (5–6 hexes) → type (faces, weights, scale) → one-line
+   direction, derived from the design-quality principles below.
+2. **Post it.** Summarize in set_status ("Designing grocery landing — candlelit mood")
+   and persist the full brief with save_decision so humans and later agents see what
+   you committed to.
+
+Skip the brief only when the canvas already dictates the style — established frames,
+style guides or pinned references — or when the human handed you a complete design
+system. Then those are the brief; follow them.
+
 ## Streaming — how to write designs
 
 Viewers watch designs assemble live. Stream with append_frame_html:
@@ -103,6 +128,11 @@ Viewers watch designs assemble live. Stream with append_frame_html:
   then each following section — roughly 1–4 KB each. Every chunk renders on the canvas
   the moment it arrives, so each call should leave the frame in a sensible visual state.
 - start=true on the first chunk (clears the frame), done=true on the last.
+- **Review the hero before building on it.** After streaming the first major section
+  (usually nav + hero), call get_frame_screenshot and judge it — the design system
+  (palette, type, spacing) commits there, and humans watching react to the hero first.
+  Fix direction-level problems NOW, before propagating them through the rest of the
+  page. Then continue streaming and do the full review at the end as usual.
 - End chunks at element boundaries. If one lands mid-element anyway, the server heals it
   (closes an open <style>, trims a half-written tag, drops an unfinished <script>), so
   never hold a chunk back to "finish" something.
@@ -152,6 +182,12 @@ any public image URL. Source images in this order:
     commands.
   Either way you get a permanent URL on this origin (/a/<id>.<ext>) to use in <img> or
   CSS.
+- **When to use them.** Enumerated content — feature cards, step lists, capability
+  grids, value rows — needs a visual anchor per item: an icon (search_icons), a big
+  number, or a mono label. Naked text lists read as drafts. Pick ONE anchor style per
+  section and never use emoji as icons. Logos: real marks (search_logos) for real
+  things — integrations, platforms, payment methods; invented customers and
+  testimonials stay text wordmarks, never a real company's mark.
 - **Nothing fits — draw it.** Inline SVG or pure CSS (gradients, patterns, shapes) in
   the frame. Never ship a gray "image goes here" box, and never guess an image URL
   from memory — unverified URLs are usually dead.


### PR DESCRIPTION
The agent guide grows a taste curriculum: a mood method for committing to an aesthetic before designing, a brief ritual (palette, type scale, spacing, direction) ahead of the first write, anchor rules for what stays fixed across frames, and hero-review rules for judging the result.

Ported from the upstream private repo (upstream #88).

🤖 Generated with [Claude Code](https://claude.com/claude-code)