### PR TITLE
fix(dashboard): reliable canvas previews — persisted thumbnails, stale-while-revalidate

### DIFF
--- a/server/actions.ts
+++ b/server/actions.ts
@@ -1,6 +1,7 @@
 import { nanoid } from 'nanoid'
 import { store } from './store.ts'
 import * as persist from './db/persist.ts'
+import * as thumbs from './thumbs.ts'
 import { colorFor } from '../shared/types.ts'
 import { DEFAULT_ROLE_ID, mentionedRole, normalizePipeline, roleByAgentName, roleName } from '../shared/agents.ts'
 import { decodeEscapedHtml, looksEscapedHtml, repairEscapedHtml } from './escapedHtml.ts'
@@ -996,6 +997,7 @@ export function deleteFrame(frameId: string, actor: Actor): Frame | undefined {
   finishReveal(frameId)
   const frame = store.deleteFrame(frameId)
   if (!frame) return undefined
+  thumbs.purge(frameId)
   broadcast(frame.canvasId, { type: 'frame:deleted', frameId, actor })
   logActivity(frame.canvasId, actor, `deleted frame “${frame.name}”`, frame.id)
   touch(frame.canvasId, actor, null)
@@ -1006,6 +1008,7 @@ export function deleteFrame(frameId: string, actor: Actor): Frame | undefined {
 export function deleteCanvas(canvasId: string): boolean {
   const c = store.deleteCanvas(canvasId)
   if (!c) return false
+  for (const f of c.frames) thumbs.purge(f.id)
   broadcast(canvasId, { type: 'canvas:deleted' })
   taskLog.delete(canvasId)
   feedbackLog.delete(canvasId)

--- a/server/index.ts
+++ b/server/index.ts
@@ -8,6 +8,7 @@ import { toNodeHandler, fromNodeHeaders } from 'better-auth/node'
 import { oAuthDiscoveryMetadata } from 'better-auth/plugins'
 import { WebSocketServer, WebSocket } from 'ws'
 import { store } from './store.ts'
+import { getImage } from './previews.ts'
 import * as actions from './actions.ts'
 import { canAccessCanvas, hasDurableCanvasAccess, isAdmin } from './access.ts'
 import { auth, initAuth, syncAdmins, getUserName, PUBLIC_ORIGIN } from './auth.ts'
@@ -280,14 +281,9 @@ app.use('/relay', async (req, res) => {
 /* Public frame images: /i/<frameId>.png|jpg — shareable/hotlinkable   */
 /* (og:image etc). Unauthenticated by the same unguessable-id logic as */
 /* canvas share links; renders the CURRENT frame, so embedded images   */
-/* stay up to date as the design iterates. Cached per frame version,   */
-/* rate-limited per IP because each cache miss boots a Chromium page.  */
+/* stay up to date as the design iterates. Caching, rate limiting and  */
+/* render dispatch live in previews.ts — this route is HTTP only.      */
 /* ------------------------------------------------------------------ */
-
-const imgCache = new Map<string, { buf: Buffer; updatedAt: number; at: number }>()
-const IMG_CACHE_MS = 5 * 60_000
-const renderHits = new Map<string, number[]>()
-const RENDERS_PER_MIN = 12
 
 app.get('/i/:id.:ext', async (req, res) => {
   const { id, ext } = req.params as { id: string; ext: string }
@@ -295,34 +291,30 @@ app.get('/i/:id.:ext', async (req, res) => {
   const frame = store.getFrame(id)
   if (!frame) return res.status(404).end()
 
-  const scale = req.query.scale === '2' ? 2 : 1
-  const quality = Math.min(100, Math.max(1, Number(req.query.quality) || 90))
-  const key = `${id}:${ext}:${scale}:${ext === 'jpg' ? quality : ''}`
-  const cached = imgCache.get(key)
-  let buf = cached && cached.updatedAt === frame.updatedAt && Date.now() - cached.at < IMG_CACHE_MS ? cached.buf : null
-
-  if (!buf) {
-    const ip = req.ip ?? 'unknown'
-    const now = Date.now()
-    const hits = (renderHits.get(ip) ?? []).filter((t) => now - t < 60_000)
-    if (hits.length >= RENDERS_PER_MIN) {
-      res.set('Retry-After', '60')
-      return res.status(429).json({ error: 'render rate limit — cached URLs are unaffected' })
-    }
-    hits.push(now)
-    renderHits.set(ip, hits)
-    try {
-      const { renderFrame } = await import('./screenshot.ts')
-      buf = await renderFrame(frame, scale as 1 | 2, { type: ext === 'jpg' ? 'jpeg' : 'png', quality })
-      imgCache.set(key, { buf, updatedAt: frame.updatedAt, at: Date.now() })
-      if (imgCache.size > 200) {
-        const oldest = [...imgCache.entries()].sort((a, b) => a[1].at - b[1].at)[0]
-        if (oldest) imgCache.delete(oldest[0])
-      }
-    } catch (e) {
-      return res.status(500).json({ error: e instanceof Error ? e.message : 'render failed' })
-    }
+  let result: Awaited<ReturnType<typeof getImage>>
+  try {
+    result = await getImage(frame, {
+      ext,
+      scale: req.query.scale === '2' ? 2 : 1,
+      quality: Math.min(100, Math.max(1, Number(req.query.quality) || 90)),
+      /* ?preview — the dashboard-card variant; see previews.ts */
+      preview: req.query.preview !== undefined,
+      ip: req.ip ?? 'unknown',
+      /* the render limit targets anonymous hotlink abuse — a logged-in user
+         loading a dashboard of many canvases shouldn't hit it (and behind
+         the Railway proxy many users can share one req.ip). Only called
+         when the budget is exhausted, so cached serves stay auth-free. */
+      isAuthenticated: async () =>
+        !!(await auth.api.getSession({ headers: fromNodeHeaders(req.headers) }).catch(() => null)),
+    })
+  } catch (e) {
+    return res.status(500).json({ error: e instanceof Error ? e.message : 'render failed' })
   }
+  if (result.status === 'rate-limited') {
+    res.set('Retry-After', '60')
+    return res.status(429).json({ error: 'render rate limit — cached URLs are unaffected' })
+  }
+  const { buf } = result
 
   res.set('Content-Type', ext === 'jpg' ? 'image/jpeg' : 'image/png')
   res.set('Cache-Control', 'public, max-age=60')

--- a/server/previews.ts
+++ b/server/previews.ts
@@ -1,0 +1,106 @@
+import type { Frame } from '../shared/types.ts'
+import * as thumbs from './thumbs.ts'
+
+/**
+ * Everything behind GET /i/<frameId>.<ext> except HTTP: the in-process
+ * image cache, the render rate limit, and the dispatch between the three
+ * ways an image can be produced (persisted thumbnail, preview render,
+ * full-size render). The route stays thin — params, auth callback,
+ * headers — and this module stays testable without a server.
+ *
+ * Freshness model, one layer per lifetime:
+ *  - imgCache: per-process, ~minutes. Holds the render *promise*, not the
+ *    buffer, so concurrent requests for the same key share one render.
+ *    May serve a just-revalidated thumb's previous bytes for up to
+ *    IMG_CACHE_MS — accepted, previews only claim minutes-freshness.
+ *  - thumbs (previews only): persisted across deploys, stale-while-
+ *    revalidate. See thumbs.ts.
+ *  - a full-size render is never persisted; it exists for og:image embeds
+ *    and downloads, and is only ever cached here.
+ */
+
+const imgCache = new Map<string, { buf: Promise<Buffer>; updatedAt: number; at: number }>()
+const IMG_CACHE_MS = 5 * 60_000
+const IMG_CACHE_MAX = 200
+
+/* Renders boot Chromium pages; cached serves and persisted-thumb serves are
+   cheap and never metered. The budget is per IP because its purpose is
+   anonymous hotlink abuse — authenticated users bypass it (verified by the
+   caller, and only checked when the budget is actually exhausted). */
+const renderHits = new Map<string, number[]>()
+const RENDERS_PER_MIN = 12
+
+export interface ImageRequest {
+  ext: 'png' | 'jpg'
+  scale: 1 | 2
+  quality: number
+  /** dashboard-card variant: small, clipped, jpeg, persisted. Only
+   *  meaningful for jpg — a png?preview would serve jpeg bytes under an
+   *  image/png content-type, so the flag is ignored there. */
+  preview: boolean
+  ip: string
+  /** consulted only when the render budget is exhausted */
+  isAuthenticated: () => Promise<boolean>
+}
+
+export type ImageResult = { status: 'ok'; buf: Buffer } | { status: 'rate-limited' }
+
+/** May reject when the render itself fails — the caller owns the 500. */
+export async function getImage(frame: Frame, req: ImageRequest): Promise<ImageResult> {
+  const preview = req.preview && req.ext === 'jpg'
+  const key = `${frame.id}:${req.ext}:${req.scale}:${req.ext === 'jpg' ? req.quality : ''}:${preview ? 'p' : ''}`
+  const cached = imgCache.get(key)
+  let pending =
+    cached && cached.updatedAt === frame.updatedAt && Date.now() - cached.at < IMG_CACHE_MS ? cached.buf : null
+
+  /* previews first try the persisted thumbnail: survives redeploys, serves
+     instantly even when stale (thumbs revalidates in the background), and
+     costs no Chromium boot — so it isn't metered either */
+  if (!pending && preview) {
+    const stored = await thumbs.getStored(frame)
+    if (stored) {
+      pending = Promise.resolve(stored)
+      remember(key, pending, frame.updatedAt)
+    }
+  }
+
+  if (!pending) {
+    if (!(await consumeRenderBudget(req.ip, req.isAuthenticated))) return { status: 'rate-limited' }
+    pending = preview
+      ? /* renders AND persists — the next cold start serves from storage */
+        thumbs.create(frame)
+      : loadScreenshot().then(({ renderFrame }) =>
+          renderFrame(frame, req.scale, { type: req.ext === 'jpg' ? 'jpeg' : 'png', quality: req.quality }),
+        )
+    remember(key, pending, frame.updatedAt)
+  }
+
+  return { status: 'ok', buf: await pending }
+}
+
+function remember(key: string, pending: Promise<Buffer>, updatedAt: number) {
+  imgCache.set(key, { buf: pending, updatedAt, at: Date.now() })
+  /* a failed render must not be served for IMG_CACHE_MS — drop it so the
+     next request retries */
+  pending.catch(() => {
+    if (imgCache.get(key)?.buf === pending) imgCache.delete(key)
+  })
+  if (imgCache.size > IMG_CACHE_MAX) {
+    const oldest = [...imgCache.entries()].sort((a, b) => a[1].at - b[1].at)[0]
+    if (oldest) imgCache.delete(oldest[0])
+  }
+}
+
+async function consumeRenderBudget(ip: string, isAuthenticated: () => Promise<boolean>): Promise<boolean> {
+  const now = Date.now()
+  const hits = (renderHits.get(ip) ?? []).filter((t) => now - t < 60_000)
+  if (hits.length >= RENDERS_PER_MIN) return isAuthenticated()
+  hits.push(now)
+  renderHits.set(ip, hits)
+  return true
+}
+
+/* lazy so dev never pays for puppeteer-core until the first render;
+   single-flight because concurrent import() of one module can serialize */
+let screenshot: Promise<typeof import('./screenshot.ts')> | undefined
+const loadScreenshot = () => (screenshot ??= import('./screenshot.ts'))

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -16,10 +16,13 @@ const DISK_DIR = path.join(process.cwd(), 'data', 'assets')
 
 export const storageMode: 'bucket' | 'disk' = BUCKET ? 'bucket' : 'disk'
 
-/* keys are `<nanoid>.<ext>` — anything else is a bug, and in disk mode the
-   check doubles as the path-traversal guard */
+/* keys are `<nanoid>.<ext>`, optionally under the `thumb/` prefix (derived
+   frame previews — a folder of their own so they can be purged or lifecycle-
+   ruled without touching user uploads). Anything else is a bug, and in disk
+   mode the check doubles as the path-traversal guard: one known literal
+   prefix, no dots or slashes in the name. */
 function assertKey(key: string) {
-  if (!/^[A-Za-z0-9_-]+\.[a-z0-9]+$/.test(key)) throw new Error(`malformed storage key: ${key}`)
+  if (!/^(thumb\/)?[A-Za-z0-9_-]+\.[a-z0-9]+$/.test(key)) throw new Error(`malformed storage key: ${key}`)
 }
 
 let s3: S3Client | undefined
@@ -46,8 +49,18 @@ export async function putObject(key: string, body: Buffer, mime: string): Promis
     await (await client()).send(new PutObjectCommand({ Bucket: BUCKET, Key: key, Body: body, ContentType: mime }))
     return
   }
-  await fs.mkdir(DISK_DIR, { recursive: true })
+  await fs.mkdir(path.dirname(path.join(DISK_DIR, key)), { recursive: true })
   await fs.writeFile(path.join(DISK_DIR, key), body)
+}
+
+export async function deleteObject(key: string): Promise<void> {
+  assertKey(key)
+  if (BUCKET) {
+    const { DeleteObjectCommand } = await import('@aws-sdk/client-s3')
+    await (await client()).send(new DeleteObjectCommand({ Bucket: BUCKET, Key: key }))
+    return
+  }
+  await fs.rm(path.join(DISK_DIR, key), { force: true })
 }
 
 export async function getObject(key: string): Promise<Buffer | null> {

--- a/server/thumbs.ts
+++ b/server/thumbs.ts
@@ -1,0 +1,118 @@
+import type { Frame } from '../shared/types.ts'
+import * as storage from './storage.ts'
+
+/**
+ * Persisted dashboard previews: `thumb/<frameId>.jpg` in byte storage,
+ * stale-while-revalidate on top.
+ *
+ * The stored object survives redeploys — which wipe the in-process image
+ * cache — so a dashboard never shows blank tiles waiting on Chromium: a
+ * possibly-stale thumbnail is served instantly and refreshed in the
+ * background. The key is deliberately unversioned; freshness lives in the
+ * in-memory `written` map (frameId → the frame.updatedAt the stored thumb
+ * was rendered from). After a restart freshness is simply unknown, which
+ * degrades to one background re-render per previewed frame — never to a
+ * blank tile.
+ */
+
+/** frame.updatedAt the stored thumb was rendered from; absent = unknown */
+const written = new Map<string, number>()
+/** in-flight render+persist per frame — concurrent callers share it */
+const pending = new Map<string, Promise<Buffer>>()
+/** background revalidation throttle: an agent saving every few seconds
+ *  must not turn each dashboard poll into a Chromium render */
+const lastAttempt = new Map<string, number>()
+const MIN_REVALIDATE_MS = 30_000
+/** frames purged mid-render — a pending create must not re-persist them */
+const dead = new Set<string>()
+
+const keyFor = (frameId: string) => `thumb/${frameId}.jpg`
+
+/* Global bound on concurrent preview renders. Per-frame dedupe caps repeat
+   requests but not breadth: a post-restart dashboard of 50 stale canvases
+   (or an anonymous crawler walking known frame URLs) would otherwise launch
+   50 Chromium pages at once. Excess renders queue, they are not dropped. */
+const MAX_CONCURRENT_RENDERS = 3
+let active = 0
+const waiting: Array<() => void> = []
+
+/* lazy like every other screenshot.ts consumer (dev never pays for
+   puppeteer-core until the first render), but single-flight */
+let screenshot: Promise<typeof import('./screenshot.ts')> | undefined
+const loadScreenshot = () => (screenshot ??= import('./screenshot.ts'))
+
+/** The preview render: card-sized, clipped, cheap — matches what /i/?preview
+ *  serves, because this IS what /i/?preview serves. */
+async function render(frame: Frame): Promise<Buffer> {
+  if (active >= MAX_CONCURRENT_RENDERS) await new Promise<void>((r) => waiting.push(r))
+  active++
+  try {
+    const { renderFrame } = await loadScreenshot()
+    return await renderFrame(frame, Math.min(1, 640 / frame.width), { type: 'jpeg', quality: 70, maxHeight: 1200 })
+  } finally {
+    active--
+    waiting.shift()?.()
+  }
+}
+
+/** Render now, persist, and return the bytes. Deduped per frame; rejects on
+ *  render failure (the caller decides what a failed render means). */
+export function create(frame: Frame): Promise<Buffer> {
+  const inflight = pending.get(frame.id)
+  if (inflight) return inflight
+  lastAttempt.set(frame.id, Date.now())
+  const p = render(frame).then(async (buf) => {
+    /* persist is best-effort: a bucket hiccup must not fail the response
+       that only needed the bytes */
+    try {
+      if (!dead.has(frame.id)) {
+        await storage.putObject(keyFor(frame.id), buf, 'image/jpeg')
+        written.set(frame.id, frame.updatedAt)
+        /* purge may have run during the put — its delete can land before
+           our write finishes, so re-check and clean up our own orphan */
+        if (dead.has(frame.id)) await storage.deleteObject(keyFor(frame.id))
+      }
+    } catch (e) {
+      console.error(`thumb persist failed for ${frame.id}:`, e)
+    }
+    return buf
+  })
+  pending.set(frame.id, p)
+  p.catch(() => {}).finally(() => pending.delete(frame.id))
+  return p
+}
+
+/** The stored thumbnail, if there is one. When it is stale — or its
+ *  freshness is unknown after a restart — a background re-render is kicked
+ *  off (throttled, deduped, errors logged and swallowed) and the stored
+ *  bytes are returned anyway: stale beats blank. Returns null when nothing
+ *  is stored yet. */
+export async function getStored(frame: Frame): Promise<Buffer | null> {
+  let buf: Buffer | null
+  try {
+    buf = await storage.getObject(keyFor(frame.id))
+  } catch (e) {
+    console.error(`thumb read failed for ${frame.id}:`, e)
+    return null
+  }
+  if (!buf) {
+    /* the map claimed fresh but the object is gone (manual purge, new
+       bucket) — forget, so the caller falls through to a live render */
+    written.delete(frame.id)
+    return null
+  }
+  const fresh = written.get(frame.id) === frame.updatedAt
+  const throttled = Date.now() - (lastAttempt.get(frame.id) ?? 0) < MIN_REVALIDATE_MS
+  if (!fresh && !throttled && !pending.has(frame.id))
+    create(frame).catch((e) => console.error(`thumb revalidate failed for ${frame.id}:`, e))
+  return buf
+}
+
+/** Frame (or its whole canvas) is gone — drop the derived object too, so the
+ *  thumb folder holds only live frames. Best-effort fire-and-forget. */
+export function purge(frameId: string): void {
+  dead.add(frameId)
+  written.delete(frameId)
+  lastAttempt.delete(frameId)
+  storage.deleteObject(keyFor(frameId)).catch(() => {})
+}

--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -228,19 +228,7 @@ export function Admin() {
                 {canvases.map((c) => (
                   <div key={c.id} className={cn(cardShell, 'flex flex-col')}>
                     <div className="relative grid aspect-[4/3] place-items-center overflow-hidden border-b border-line-soft [background:radial-gradient(circle,var(--dot)_1px,transparent_1px)_0_0/18px_18px,var(--paper-deep)]">
-                      {c.previewFrameId ? (
-                        <img
-                          className="h-full w-full object-cover object-top"
-                          src={`/i/${c.previewFrameId}.jpg`}
-                          alt=""
-                          loading="lazy"
-                          onError={(e) => {
-                            e.currentTarget.style.display = 'none'
-                          }}
-                        />
-                      ) : (
-                        <span className="text-[12px] text-ink-faint">empty canvas</span>
-                      )}
+                      <CanvasPreview frameId={c.previewFrameId} />
                     </div>
                     <div className="flex flex-1 flex-col px-3 pt-2.5 pb-3">
                       <div className="truncate font-display text-[13.5px] font-semibold">{c.name}</div>
@@ -325,5 +313,25 @@ export function Admin() {
         </DashContent>
       </DashMain>
     </DashLayout>
+  )
+}
+
+/** Same contract as the Home dashboard's Preview: a failed render must look
+ *  different from an empty canvas, and cards request the cheap ?preview
+ *  render rather than the full-size og:image one. */
+function CanvasPreview({ frameId }: { frameId?: string }) {
+  /* which frame failed, not whether — a new previewFrameId must retry
+     rather than inherit the old frame's failure */
+  const [failedId, setFailedId] = useState<string | null>(null)
+  if (!frameId) return <span className="text-[12px] text-ink-faint">empty canvas</span>
+  if (failedId === frameId) return <span className="text-[12px] text-ink-faint">preview unavailable</span>
+  return (
+    <img
+      className="h-full w-full object-cover object-top"
+      src={`/i/${frameId}.jpg?preview`}
+      alt=""
+      loading="lazy"
+      onError={() => setFailedId(frameId)}
+    />
   )
 }

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -398,16 +398,21 @@ function remove(id: string, done: () => void) {
 }
 
 function Preview({ canvas, blankSize = 'text-[12px]' }: { canvas: CanvasMeta; blankSize?: string }) {
+  /* which frame failed, not whether — a new previewFrameId must retry
+     rather than inherit the old frame's failure */
+  const [failedId, setFailedId] = useState<string | null>(null)
   if (!canvas.previewFrameId) return <span className={cn('text-ink-faint', blankSize)}>empty canvas</span>
+  /* a failed render must look different from an empty canvas — silence here
+     made preview outages undiagnosable */
+  if (failedId === canvas.previewFrameId)
+    return <span className={cn('text-ink-faint', blankSize)}>preview unavailable</span>
   return (
     <img
-      src={`/i/${canvas.previewFrameId}.jpg`}
+      src={`/i/${canvas.previewFrameId}.jpg?preview`}
       alt=""
       loading="lazy"
       className="h-full w-full object-cover object-top"
-      onError={(e) => {
-        e.currentTarget.style.display = 'none'
-      }}
+      onError={() => setFailedId(canvas.previewFrameId ?? null)}
     />
   )
 }

--- a/tests/previews.test.ts
+++ b/tests/previews.test.ts
@@ -1,0 +1,116 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Frame } from '../shared/types'
+
+/* Mock only the leaves (Chromium, byte storage) — previews.ts and thumbs.ts
+ * run for real, so these tests cover the integrated dispatch: cache → stored
+ * thumb → rate limit → render. */
+const mocks = vi.hoisted(() => ({
+  renderFrame: vi.fn(),
+  putObject: vi.fn(),
+  getObject: vi.fn(),
+  deleteObject: vi.fn(),
+}))
+
+vi.mock('../server/screenshot.ts', () => ({ renderFrame: mocks.renderFrame }))
+vi.mock('../server/storage.ts', () => ({
+  putObject: mocks.putObject,
+  getObject: mocks.getObject,
+  deleteObject: mocks.deleteObject,
+}))
+
+import { getImage } from '../server/previews.ts'
+
+let seq = 0
+const frame = (over: Partial<Frame> = {}): Frame =>
+  ({
+    id: `f${seq++}`,
+    canvasId: 'c',
+    name: 'f',
+    x: 0,
+    y: 0,
+    width: 1280,
+    height: 900,
+    html: '',
+    updatedAt: 1,
+    updatedBy: 't',
+    ...over,
+  }) as Frame
+
+const anon = () => Promise.resolve(false)
+const authed = () => Promise.resolve(true)
+const req = (over: Partial<Parameters<typeof getImage>[1]> = {}): Parameters<typeof getImage>[1] => ({
+  ext: 'jpg',
+  scale: 1,
+  quality: 90,
+  preview: false,
+  ip: `ip${seq++}`,
+  isAuthenticated: anon,
+  ...over,
+})
+
+beforeEach(() => {
+  mocks.renderFrame.mockReset().mockResolvedValue(Buffer.from('rendered'))
+  mocks.putObject.mockReset().mockResolvedValue(undefined)
+  mocks.getObject.mockReset().mockResolvedValue(null)
+  mocks.deleteObject.mockReset().mockResolvedValue(undefined)
+})
+
+describe('getImage', () => {
+  it('png?preview does a full png render, never the jpeg thumb path', async () => {
+    const r = await getImage(frame(), req({ ext: 'png', preview: true }))
+    expect(r.status).toBe('ok')
+    expect(mocks.renderFrame).toHaveBeenCalledWith(expect.anything(), 1, expect.objectContaining({ type: 'png' }))
+    expect(mocks.getObject).not.toHaveBeenCalled()
+    expect(mocks.putObject).not.toHaveBeenCalled()
+  })
+
+  it('jpg?preview renders card-size and persists the thumb', async () => {
+    const f = frame()
+    const r = await getImage(f, req({ preview: true }))
+    expect(r.status).toBe('ok')
+    expect(mocks.renderFrame).toHaveBeenCalledWith(
+      expect.anything(),
+      0.5, // 640 / 1280
+      expect.objectContaining({ type: 'jpeg', quality: 70, maxHeight: 1200 }),
+    )
+    await new Promise((r2) => setTimeout(r2, 10))
+    expect(mocks.putObject).toHaveBeenCalledWith(`thumb/${f.id}.jpg`, expect.anything(), 'image/jpeg')
+  })
+
+  it('caches per frame version — one render serves repeat requests, an update re-renders', async () => {
+    const f = frame()
+    const r = req()
+    await getImage(f, r)
+    await getImage(f, r)
+    expect(mocks.renderFrame).toHaveBeenCalledTimes(1)
+    await getImage({ ...f, updatedAt: 2 }, r)
+    expect(mocks.renderFrame).toHaveBeenCalledTimes(2)
+  })
+
+  it('a failed render is not cached — the next request retries', async () => {
+    mocks.renderFrame.mockRejectedValueOnce(new Error('chromium died'))
+    const f = frame()
+    const r = req()
+    await expect(getImage(f, r)).rejects.toThrow('chromium died')
+    await expect(getImage(f, r)).resolves.toMatchObject({ status: 'ok' })
+    expect(mocks.renderFrame).toHaveBeenCalledTimes(2)
+  })
+
+  it('meters anonymous renders per IP but lets authenticated users through', async () => {
+    const ip = 'shared-proxy-ip'
+    for (let i = 0; i < 12; i++) {
+      expect((await getImage(frame(), req({ ip }))).status).toBe('ok')
+    }
+    expect((await getImage(frame(), req({ ip }))).status).toBe('rate-limited')
+    expect((await getImage(frame(), req({ ip, isAuthenticated: authed }))).status).toBe('ok')
+  })
+
+  it('serves a stored thumb without consuming render budget', async () => {
+    const ip = 'exhausted-ip'
+    for (let i = 0; i < 12; i++) await getImage(frame(), req({ ip }))
+    mocks.getObject.mockResolvedValue(Buffer.from('stored'))
+    const r = await getImage(frame(), req({ ip, preview: true }))
+    expect(r.status).toBe('ok')
+    expect(r.status === 'ok' && r.buf.toString()).toBe('stored')
+  })
+})

--- a/tests/storage.test.ts
+++ b/tests/storage.test.ts
@@ -1,0 +1,61 @@
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
+
+/* Disk mode with an isolated data dir: DISK_DIR is computed from
+ * process.cwd() at module load, so pin cwd to a temp dir before importing. */
+let tmp: string
+let storage: typeof import('../server/storage.ts')
+
+beforeAll(async () => {
+  tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'doop-storage-'))
+  vi.spyOn(process, 'cwd').mockReturnValue(tmp)
+  storage = await import('../server/storage.ts')
+})
+
+afterAll(async () => {
+  vi.restoreAllMocks()
+  await fs.rm(tmp, { recursive: true, force: true })
+})
+
+describe('storage keys', () => {
+  it('round-trips a plain asset key and a thumb/ key', async () => {
+    await storage.putObject('abc123.png', Buffer.from('asset'), 'image/png')
+    await storage.putObject('thumb/frame-1.jpg', Buffer.from('thumb'), 'image/jpeg')
+    expect((await storage.getObject('abc123.png'))?.toString()).toBe('asset')
+    expect((await storage.getObject('thumb/frame-1.jpg'))?.toString()).toBe('thumb')
+  })
+
+  it('deletes objects and tolerates deleting what is not there', async () => {
+    await storage.putObject('thumb/gone.jpg', Buffer.from('x'), 'image/jpeg')
+    await storage.deleteObject('thumb/gone.jpg')
+    expect(await storage.getObject('thumb/gone.jpg')).toBeNull()
+    await expect(storage.deleteObject('thumb/gone.jpg')).resolves.toBeUndefined()
+  })
+
+  it('returns null for a missing key', async () => {
+    expect(await storage.getObject('never-written.png')).toBeNull()
+  })
+
+  it.each([
+    '../escape.png',
+    'thumb/../escape.png',
+    'thumb/thumb/nested.jpg',
+    'other/prefix.jpg',
+    'thumb/.jpg',
+    'no-extension',
+    'thumb/dir/',
+    'a b.png',
+  ])('rejects malformed key %s everywhere', async (key) => {
+    await expect(storage.putObject(key, Buffer.from('x'), 'image/png')).rejects.toThrow(/malformed storage key/)
+    await expect(storage.getObject(key)).rejects.toThrow(/malformed storage key/)
+    await expect(storage.deleteObject(key)).rejects.toThrow(/malformed storage key/)
+  })
+
+  it('keeps thumbs in their own folder on disk', async () => {
+    await storage.putObject('thumb/frame-2.jpg', Buffer.from('t'), 'image/jpeg')
+    const stat = await fs.stat(path.join(tmp, 'data', 'assets', 'thumb', 'frame-2.jpg'))
+    expect(stat.isFile()).toBe(true)
+  })
+})

--- a/tests/thumbs.test.ts
+++ b/tests/thumbs.test.ts
@@ -1,0 +1,107 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Frame } from '../shared/types'
+
+/* Deferred renders so tests control when Chromium "finishes" */
+const mocks = vi.hoisted(() => ({
+  renderFrame: vi.fn(),
+  putObject: vi.fn(),
+  getObject: vi.fn(),
+  deleteObject: vi.fn(),
+}))
+
+vi.mock('../server/screenshot.ts', () => ({ renderFrame: mocks.renderFrame }))
+vi.mock('../server/storage.ts', () => ({
+  putObject: mocks.putObject,
+  getObject: mocks.getObject,
+  deleteObject: mocks.deleteObject,
+}))
+
+import * as thumbs from '../server/thumbs.ts'
+
+const frame = (id: string): Frame =>
+  ({
+    id,
+    canvasId: 'c',
+    name: id,
+    x: 0,
+    y: 0,
+    width: 1280,
+    height: 900,
+    html: '',
+    updatedAt: 1,
+    updatedBy: 't',
+  }) as Frame
+
+function deferredRenders() {
+  const resolvers: Array<(b: Buffer) => void> = []
+  mocks.renderFrame.mockImplementation(() => new Promise<Buffer>((r) => resolvers.push(r)))
+  return resolvers
+}
+
+const tick = () => new Promise((r) => setTimeout(r, 25))
+
+beforeEach(() => {
+  mocks.renderFrame.mockReset()
+  mocks.putObject.mockReset().mockResolvedValue(undefined)
+  mocks.getObject.mockReset().mockResolvedValue(null)
+  mocks.deleteObject.mockReset().mockResolvedValue(undefined)
+})
+
+describe('thumbs', () => {
+  it('bounds concurrent renders globally — breadth across frames cannot fan out unbounded', async () => {
+    const resolvers = deferredRenders()
+    const all = Array.from({ length: 10 }, (_, i) => thumbs.create(frame(`cap-${i}`)))
+    await tick()
+    expect(mocks.renderFrame).toHaveBeenCalledTimes(3)
+
+    /* finishing one admits exactly one waiter — never a burst */
+    resolvers[0](Buffer.from('x'))
+    await tick()
+    expect(mocks.renderFrame).toHaveBeenCalledTimes(4)
+
+    for (let i = 1; i < 10; i++) {
+      resolvers[i]?.(Buffer.from('x'))
+      await tick()
+    }
+    await Promise.all(all)
+    expect(mocks.renderFrame).toHaveBeenCalledTimes(10)
+  })
+
+  it('does not persist a thumb for a frame purged mid-render', async () => {
+    const resolvers = deferredRenders()
+    const p = thumbs.create(frame('purged-mid-render'))
+    await tick()
+    thumbs.purge('purged-mid-render')
+    resolvers[0](Buffer.from('late'))
+    await p
+    await tick()
+    expect(mocks.putObject).not.toHaveBeenCalled()
+  })
+
+  it('deletes its own write when purge lands during the put', async () => {
+    const resolvers = deferredRenders()
+    let finishPut!: () => void
+    mocks.putObject.mockImplementation(() => new Promise<void>((r) => (finishPut = r)))
+    const p = thumbs.create(frame('purged-during-put'))
+    await tick()
+    resolvers[0](Buffer.from('x'))
+    await tick() /* now inside putObject */
+    thumbs.purge('purged-during-put')
+    finishPut()
+    await p
+    await tick()
+    expect(mocks.deleteObject).toHaveBeenCalledWith('thumb/purged-during-put.jpg')
+  })
+
+  it('getStored serves stored bytes and refreshes stale ones in the background, deduped', async () => {
+    deferredRenders()
+    mocks.getObject.mockResolvedValue(Buffer.from('stale'))
+    const f = frame('stale-frame')
+    const [a, b] = await Promise.all([thumbs.getStored(f), thumbs.getStored(f)])
+    expect(a?.toString()).toBe('stale')
+    expect(b?.toString()).toBe('stale')
+    await tick()
+    /* one background refresh, not one per request (dedupe + throttle) */
+    expect(mocks.renderFrame).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
Canvas previews on Home used to re-render on every visit and fail invisibly. Previews are now persisted as `thumb/<frameId>.jpg` and served stale-while-revalidate: the dashboard paints instantly from the stored thumbnail while a bounded-concurrency renderer refreshes it, with per-frame retry and a purge-vs-persist race fixed. The `/i/` image pipeline moves into `server/previews.ts`.

Ported from the upstream private repo (upstream #92).

🤖 Generated with [Claude Code](https://claude.com/claude-code)