### PR TITLE
feat(auth): restrict signups by email domain

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,9 @@
 # Extra allowed origins for auth requests (comma-separated). Defaults to the
 # localhost dev origins.
 #TRUSTED_ORIGINS=
+# Optional comma-separated domain allowlist for new accounts. Unset means
+# anyone can sign up. Existing users can always continue to sign in.
+#SIGNUP_EMAIL_DOMAINS=jointhetroops.com
 # Instance admins (comma-separated emails). These accounts get the admin role
 # — at signup, and at boot for accounts that already exist — which unlocks
 # /admin: every canvas and account on the instance, plus read-only "view as".

--- a/README.md
+++ b/README.md
@@ -228,6 +228,10 @@ With SMTP configured (`SMTP_HOST` etc. — see [.env.example](.env.example)), si
 verification and "forgot password" sends real reset links. Without it, signup stays open and every
 email is printed to the server log, links included — the flows still work in development.
 
+Set `SIGNUP_EMAIL_DOMAINS=jointhetroops.com` to restrict new accounts to one email domain, or use a
+comma-separated list for several domains. Matching is case-insensitive and exact; existing accounts
+are unaffected. Leave it unset to keep public signup open.
+
 Set `REQUIRE_EMAIL_VERIFICATION=false` to let people in before they verify — the link is still
 emailed, it just stops gating sign-in. Admin promotion is deliberately not part of that trade:
 `ADMIN_EMAILS` only ever promotes a verified address (see below).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       DATABASE_URL: postgres://doop:doop@db:5432/doop
       BETTER_AUTH_SECRET: ${BETTER_AUTH_SECRET:-change-me-please-not-for-production}
       BETTER_AUTH_URL: ${BETTER_AUTH_URL:-http://localhost:4400}
+      SIGNUP_EMAIL_DOMAINS: ${SIGNUP_EMAIL_DOMAINS:-}
       # optional — see .env.example for everything else (SMTP, ANTHROPIC_API_KEY, …)
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
       CONTEXT_DEV_API_KEY: ${CONTEXT_DEV_API_KEY:-}

--- a/server/auth.ts
+++ b/server/auth.ts
@@ -1,4 +1,5 @@
 import { betterAuth } from 'better-auth'
+import { APIError, createAuthMiddleware } from 'better-auth/api'
 import { eq, inArray, or, isNull, ne, and, sql } from 'drizzle-orm'
 import { admin, mcp } from 'better-auth/plugins'
 import { drizzleAdapter } from 'better-auth/adapters/drizzle'
@@ -29,6 +30,12 @@ export const PUBLIC_ORIGIN = process.env.BETTER_AUTH_URL || 'http://localhost:43
 const ADMIN_EMAILS = (process.env.ADMIN_EMAILS || '')
   .split(',')
   .map((s) => s.trim().toLowerCase())
+  .filter(Boolean)
+
+/** Empty means public signup; otherwise only exact email domains may register. */
+const SIGNUP_EMAIL_DOMAINS = (process.env.SIGNUP_EMAIL_DOMAINS || '')
+  .split(',')
+  .map((s) => s.trim().toLowerCase().replace(/^@/, ''))
   .filter(Boolean)
 
 /**
@@ -118,6 +125,18 @@ function buildAuth() {
           return origin ? [origin] : []
         },
     database: drizzleAdapter(db, { provider: 'pg', schema: authSchema }),
+    hooks: {
+      before: createAuthMiddleware(async (ctx) => {
+        if (ctx.path !== '/sign-up/email' || !SIGNUP_EMAIL_DOMAINS.length) return
+        const email = typeof ctx.body?.email === 'string' ? ctx.body.email.toLowerCase() : ''
+        const domain = email.slice(email.lastIndexOf('@') + 1)
+        if (!SIGNUP_EMAIL_DOMAINS.includes(domain)) {
+          throw new APIError('BAD_REQUEST', {
+            message: `Sign up is restricted to ${SIGNUP_EMAIL_DOMAINS.map((d) => `@${d}`).join(', ')} email addresses.`,
+          })
+        }
+      }),
+    },
     /* Verification is enforced only when an SMTP mailer is configured —
        without one (dev, tiny self-hosts) signup stays open and every email
        is printed to the server log instead, links included — and only when

--- a/tests/signupRestrictions.test.ts
+++ b/tests/signupRestrictions.test.ts
@@ -1,0 +1,39 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { Client, startServer, type Server } from './harness.ts'
+
+const PORT = 4980
+
+let server: Server
+let client: Client
+
+beforeAll(async () => {
+  server = await startServer(PORT, { SIGNUP_EMAIL_DOMAINS: 'jointhetroops.com, partner.test' })
+  client = new Client(server)
+}, 70_000)
+
+afterAll(() => server?.stop())
+
+describe('signup domain restrictions', () => {
+  it('allows configured email domains', async () => {
+    const res = await client.post('/api/auth/sign-up/email', {
+      email: 'person@jointhetroops.com',
+      password: 'password12345',
+      name: 'Allowed Person',
+    })
+    expect(res.status, await res.text()).toBe(200)
+  })
+
+  it('rejects other domains without creating an account', async () => {
+    const email = 'outsider@example.com'
+    const res = await client.post('/api/auth/sign-up/email', {
+      email,
+      password: 'password12345',
+      name: 'Outsider',
+    })
+    expect(res.status).toBe(400)
+    expect((await res.json()).message).toContain('@jointhetroops.com')
+
+    const exists = await client.post('/api/account-exists', { email })
+    expect(await exists.json()).toEqual({ exists: false })
+  })
+})

--- a/tests/signupRestrictions.test.ts
+++ b/tests/signupRestrictions.test.ts
@@ -1,7 +1,7 @@
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import { Client, startServer, type Server } from './harness.ts'
 
-const PORT = 4980
+const PORT = 4997
 
 let server: Server
 let client: Client

--- a/tests/signupRestrictions.test.ts
+++ b/tests/signupRestrictions.test.ts
@@ -6,6 +6,14 @@ const PORT = 4980
 let server: Server
 let client: Client
 
+function signUp(email: string, name: string) {
+  return client.req('/api/auth/sign-up/email', {
+    method: 'POST',
+    headers: { Origin: server.base },
+    body: JSON.stringify({ email, password: 'password12345', name }),
+  })
+}
+
 beforeAll(async () => {
   server = await startServer(PORT, { SIGNUP_EMAIL_DOMAINS: 'jointhetroops.com, partner.test' })
   client = new Client(server)
@@ -15,21 +23,13 @@ afterAll(() => server?.stop())
 
 describe('signup domain restrictions', () => {
   it('allows configured email domains', async () => {
-    const res = await client.post('/api/auth/sign-up/email', {
-      email: 'person@jointhetroops.com',
-      password: 'password12345',
-      name: 'Allowed Person',
-    })
+    const res = await signUp('person@jointhetroops.com', 'Allowed Person')
     expect(res.status, await res.text()).toBe(200)
   })
 
   it('rejects other domains without creating an account', async () => {
     const email = 'outsider@example.com'
-    const res = await client.post('/api/auth/sign-up/email', {
-      email,
-      password: 'password12345',
-      name: 'Outsider',
-    })
+    const res = await signUp(email, 'Outsider')
     expect(res.status).toBe(400)
     expect((await res.json()).message).toContain('@jointhetroops.com')
 


### PR DESCRIPTION
## Summary

- add an optional `SIGNUP_EMAIL_DOMAINS` environment variable
- reject new email/password signups outside the configured comma-separated domain allowlist
- keep public signup as the default and leave existing users unaffected
- document the setting and cover allowed and rejected signups with an integration test

Domain matching is case-insensitive and exact. A leading `@` in configured domains is accepted.

## Testing

- `bun run test` (165 tests)
- `bun run typecheck`
- `bun run lint` (8 existing warnings, 0 errors)
- `bun run format:check`
- `bun run build`
