### PR TITLE
feat: add generic OIDC/SSO support

### DIFF
--- a/.context/CODESTYLE.md
+++ b/.context/CODESTYLE.md
@@ -1,0 +1,46 @@
+# CODESTYLE - doop
+
+## Formatting (Prettier, `.prettierrc.json`)
+
+- No semicolons (`semi: false`).
+- Single quotes (`singleQuote: true`).
+- Print width 120.
+- Trailing commas everywhere (`trailingComma: all`).
+- Run `bun run format` to write, `bun run format:check` to verify (CI-gated).
+
+## Linting (ESLint, `eslint.config.js`)
+
+- Base: `@eslint/js` recommended + `typescript-eslint` recommended, with `eslint-config-prettier`
+  applied last so stylistic rules never fight Prettier.
+- `src/**/*.{ts,tsx}` additionally pulls in `eslint-plugin-react-hooks` recommended rules.
+  `react-hooks/set-state-in-effect` is downgraded to `warn` for now (pre-existing patterns; tighten
+  to `error` once those effects are refactored) - do not silently re-tighten it in an unrelated PR.
+- `@typescript-eslint/no-explicit-any` is `warn`, not `error` - the server exchanges broad JSON
+  shapes with itself at its seams, so `any` there is a conscious, allowed choice; still prefer a
+  real type where the shape is actually known.
+- `@typescript-eslint/no-unused-vars` is `error`, with `_`-prefixed args/vars and rest-sibling
+  destructuring exempted.
+- `@typescript-eslint/no-namespace` allows declarations (`declare global { namespace Express }` is
+  how Express request typing is extended in this repo).
+- `public/**/*.js` (the embeddable snippet) is treated as plain, unbundled, ES5-flavoured browser
+  JS on purpose - it ships as-is to run wherever the host page runs. It gets a relaxed rule set
+  (no-unused-expressions off, unused-vars allows caught errors) rather than the TS-project rules.
+- Run `bun run lint` / `bun run lint:fix`.
+
+## Pre-commit (Husky + lint-staged)
+
+- `.husky/pre-commit` runs `bunx lint-staged`.
+- `*.{ts,tsx,js}` -> `eslint --fix` then `prettier --write`.
+- `*.{json,css,md,html}` -> `prettier --write`.
+
+## Commits
+
+- Conventional commits, enforced by commitlint (`commitlint.config.js`,
+  `@commitlint/config-conventional`).
+- PRs land on `main` as a squash merge, so CI lints the **PR title**, not individual commit
+  messages - see `.github/workflows/ci.yml`'s `commit-message` job.
+
+## TypeScript
+
+- `strict: true`, `noEmit: true` (type-check only; Vite/tsx handle actual transpilation).
+- Path alias `@/*` -> `./src/*`.

--- a/.context/DESIGN.md
+++ b/.context/DESIGN.md
@@ -1,0 +1,41 @@
+# DESIGN - doop
+
+Design tokens live in `src/styles.css` as CSS custom properties, mapped into Tailwind 4 via
+`@theme`. shadcn is configured with style `radix-nova`, base color `neutral`, CSS variables on,
+icon library `lucide` (`components.json`). Generate new shadcn components with the shadcn CLI
+rather than hand-rolling primitives; it writes into `src/components/ui` per the aliases below.
+
+## Palette
+
+- `--paper` `#f7f7f9` / `--paper-deep` `#eeeef2` - page background layers.
+- `--surface` `#ffffff` - card/panel surfaces.
+- `--ink` `#17171b`, `--ink-soft`, `--ink-faint` - text, in descending emphasis.
+- `--line`, `--line-soft` - borders/dividers.
+- `--brand` `#e5533c` / `--accent-ink` `#c23a25` - the doop orange-red brand color and its ink
+  variant.
+- Full shadcn semantic set also present: `--primary`, `--secondary`, `--muted`, `--accent`,
+  `--destructive`, `--border`, `--input`, `--ring`, `--card`, `--popover`, `--sidebar-*`,
+  `--chart-1` through `--chart-5`.
+
+## Typography
+
+- `--font-ui`: `'Archivo', sans-serif` - UI text (`--font-sans` alias).
+- `--font-display`: `'Bricolage Grotesque', sans-serif` - headings (`--font-heading` alias).
+- `--font-mono`: `'Spline Sans Mono', ui-monospace, monospace`.
+
+## Shape and depth
+
+- `--radius`: `0.625rem`, with `--radius-sm` through `--radius-4xl` derived from it
+  (`calc(var(--radius) * N)`) - use the scale, not one-off radius values.
+- `--shadow-card` / `--shadow-pop` - two-layer soft shadows (ambient + key) for cards and popped
+  elements respectively.
+
+## Aliases (`components.json`)
+
+- `@/components` -> `src/components`, `@/components/ui` -> `src/components/ui`,
+  `@/lib` -> `src/lib`, `@/hooks` -> `src/hooks`, `@/lib/utils` -> `src/lib/utils`.
+
+## Breakpoints
+
+- `--breakpoint-xs`: `30rem`, `--breakpoint-md`: `56.25rem` - custom additions on top of
+  Tailwind's defaults.

--- a/.context/INDEX.md
+++ b/.context/INDEX.md
@@ -1,0 +1,22 @@
+# doop - Context Index
+
+## Root Files
+
+- [@TECHSTACK.md](TECHSTACK.md) - Tech stack reference (auto-imported).
+- [@DESIGN.md](DESIGN.md) - Design tokens (palette, type, radius/shadow scale) and shadcn config
+  (auto-imported).
+- [@RELEASE.md](RELEASE.md) - Docker self-host path and the Tauri desktop DMG release pipeline
+  (auto-imported).
+- [@CODESTYLE.md](CODESTYLE.md) - ESLint/Prettier/commitlint crib sheet (auto-imported).
+
+## Subfolders
+
+### `specs/`
+
+- [specs/INDEX.md](specs/INDEX.md) - Complete record of design specs. Feature and API designs for
+  doop (canvas, MCP server, auth, realtime).
+
+### `plans/`
+
+- [plans/INDEX.md](plans/INDEX.md) - Complete record of implementation plans. Test-first task
+  breakdowns derived from the specs.

--- a/.context/RELEASE.md
+++ b/.context/RELEASE.md
@@ -1,0 +1,31 @@
+# RELEASE - doop
+
+## Self-hosted server (Docker)
+
+No versioned release/tag pipeline for the server app itself. Self-hosting is
+`docker compose up` (`docker-compose.yml` + `Dockerfile`) - builds the app image locally, runs it
+on port 4400 alongside a `postgres:16-alpine` container, and applies DB migrations at boot
+(`server/db/index.ts`). CI (`ci.yml`) validates every push/PR to `main` (typecheck, lint,
+format:check, build, test) but does not build or push a container image.
+
+## Desktop app (Tauri, macOS DMG)
+
+Driven by `.github/workflows/desktop-release.yml`:
+
+- Push a tag matching `desktop-v*` -> builds a universal (Apple Silicon + Intel) DMG with
+  `bunx tauri build --target universal-apple-darwin --bundles dmg` and attaches it to a GitHub
+  Release.
+- `workflow_dispatch` or a PR touching the workflow file itself -> same build, uploaded as a
+  workflow artifact instead (keeps the pipeline validated without cutting a release).
+- Signing/notarization: automatic once the `APPLE_CERTIFICATE`, `APPLE_CERTIFICATE_PASSWORD`,
+  `APPLE_SIGNING_IDENTITY`, `APPLE_ID`, `APPLE_PASSWORD`, `APPLE_TEAM_ID` repo secrets exist (see
+  `desktop/README.md`). Without them the DMG is unsigned - it still works, but downloaders must
+  approve it via System Settings -> Privacy & Security.
+- Desktop app version is tracked separately in `desktop/package.json` (currently ahead of the root
+  `package.json` version) - bump both when cutting a desktop release, and tag as `desktop-vX.Y.Z`.
+
+## Other workflows
+
+- `.github/workflows/desktop.yml` - desktop app CI (build/check) outside of the release path.
+- `.github/workflows/cla.yml` - CLA sign-off check on PRs (AGPL-3.0 project, CLA-based
+  contribution per `CLA.md` / `CONTRIBUTING.md`).

--- a/.context/TECHSTACK.md
+++ b/.context/TECHSTACK.md
@@ -1,0 +1,82 @@
+# TECHSTACK - doop
+
+## 1. Language and Runtime
+
+- TypeScript 5.5.3 (strict mode) - primary language across `server/`, `src/`, and `shared/`.
+- Node.js - runtime; `tsx` 4.23.9 runs server TypeScript directly with no build step, both in dev
+  (`tsx watch`) and prod (`NODE_ENV=production tsx server/index.ts`).
+- Bun 1.3.10 - pinned via `packageManager` in `package.json`; used as the package manager and
+  script runner, not as the server runtime.
+- Rust (stable) - `desktop/src-tauri`, the Tauri desktop shell.
+
+## 2. Core Frameworks and Libraries
+
+- Express 4.19.2 - HTTP server framework in `server/`.
+- React 18.3.1 - UI framework in `src/`.
+- Zustand 4.5.4 - client-side state management.
+- Radix UI primitives (`@radix-ui/react-*`, ^1.x-2.x) + shadcn 4.19.0 - accessible UI primitives
+  generated into `src/components/ui`.
+- `@anthropic-ai/sdk` 0.115.0 and `@modelcontextprotocol/sdk` 1.12.0 - power the built-in Doop
+  Agent and the MCP server that lets external agents (e.g. Claude Code) design on a canvas.
+- `ws` 8.18.0 - WebSocket server for realtime multiplayer (cursors, presence, frame edits,
+  activity feed) over one room per canvas.
+
+## 3. Data and Persistence
+
+- PostgreSQL 16 (`postgres:16-alpine` in `docker-compose.yml`) - primary database.
+- drizzle-orm 0.45.2 + drizzle-kit - schema in `server/db/schema.ts` and
+  `server/db/auth-schema.ts`; migrations generated via `npx drizzle-kit generate` into
+  `server/db/migrations`, applied at boot by `server/db/index.ts` (never by drizzle-kit itself).
+- `@electric-sql/pglite` 0.5.4 - embedded Postgres so `bun run dev` works with zero external
+  services.
+- `pg` 8.22.0 - Postgres driver for the real-database path.
+
+## 5. Security and Secrets
+
+- better-auth 1.6.26 - authentication: email/password plus generic OIDC/SSO. Configuration and
+  secrets (`BETTER_AUTH_SECRET`, `BETTER_AUTH_URL`, provider client IDs/secrets) come from the
+  environment (`.env`, documented in `.env.example`); never committed.
+
+## 6. Build and Dependency Management
+
+- Bun 1.3.10 - package manager; lockfile at `bun.lock`, installed with `bun install
+--frozen-lockfile` in CI.
+- Vite 5.3.3 - frontend build tool (`vite build`).
+
+## 7. Testing Stack
+
+- Vitest 4.1.11 - unit/integration tests across `server/` and `src/`; run via `bun run test`
+  (`vitest run`). Tests live in `tests/`.
+
+## 8. CI/CD and Delivery
+
+- GitHub Actions:
+  - `.github/workflows/ci.yml` - gates `typecheck`, `lint`, `format:check`, `build`, `test` on
+    push to `main` and on PRs; a separate job lints the PR title with commitlint (PRs land on
+    `main` as a squash, so the PR title becomes the commit subject).
+  - `.github/workflows/cla.yml` - CLA check (this is an AGPL-3.0 project with CLA-based
+    contribution).
+  - `.github/workflows/desktop.yml` / `desktop-release.yml` - Tauri desktop app CI and DMG
+    release (tag `desktop-v*`, universal macOS build, optional Apple signing/notarization).
+
+## 9. Infrastructure and Deployment
+
+- Docker - `Dockerfile` + `docker-compose.yml`; `docker compose up` runs the app container
+  (port 4400) and a `postgres:16-alpine` db container for self-hosting.
+
+## 10. Frontend Stack
+
+- React 18.3.1 + Vite 5.3.3 - SPA, entry at `index.html`.
+- Tailwind CSS 4.3.3 (`@tailwindcss/vite` 4.3.3) - styling; `tw-animate-css` 1.4.0 for animation
+  utilities. Design tokens in `src/styles.css` (see `.context/DESIGN.md`).
+- Tauri 2.9.0 (`@tauri-apps/cli`, `desktop/src-tauri`) - desktop app wrapper around the web build.
+
+## 11. Developer Experience Tooling
+
+- ESLint 10.8.1 + typescript-eslint 8.67.0 + eslint-plugin-react-hooks 7.1.1 - lint, config in
+  `eslint.config.js`.
+- Prettier 3.9.6 - formatting (no semicolons, single quotes, printWidth 120), config in
+  `.prettierrc.json`.
+- Husky 9.1.7 + lint-staged 17.3.0 - pre-commit hook runs `lint-staged` (`.husky/pre-commit`).
+- commitlint 21.2.2 (`@commitlint/config-conventional`) - conventional commit / PR title linting,
+  config in `commitlint.config.js`.

--- a/.context/plans/INDEX.md
+++ b/.context/plans/INDEX.md
@@ -1,0 +1,9 @@
+# doop - plans Index
+
+Complete record of `.context/plans/`. This file is NOT @-imported by CLAUDE.md; it is reached by
+link from [../INDEX.md](../INDEX.md), so it costs nothing until someone opens it, which is why it
+lists every file in this folder.
+
+## Active
+
+(none yet)

--- a/.context/specs/INDEX.md
+++ b/.context/specs/INDEX.md
@@ -1,0 +1,9 @@
+# doop - specs Index
+
+Complete record of `.context/specs/`. This file is NOT @-imported by CLAUDE.md; it is reached by
+link from [../INDEX.md](../INDEX.md), so it costs nothing until someone opens it, which is why it
+lists every file in this folder.
+
+## Active
+
+(none yet)

--- a/.env.example
+++ b/.env.example
@@ -28,6 +28,20 @@
 # nobody and says so at boot; local development promotes without verifying.
 #ADMIN_EMAILS=you@example.com
 
+# Optional SSO against an external OIDC provider (Zitadel, Okta, Authentik,
+# Keycloak, etc.), alongside email/password — not a replacement for it.
+# Set all three of ISSUER/CLIENT_ID/CLIENT_SECRET together to enable; the
+# server refuses to boot if only some are set (almost certainly a mistake).
+# ISSUER is the provider's base URL — .well-known/openid-configuration is
+# resolved from it lazily, at sign-in time, not at boot.
+#OIDC_ISSUER=https://idp.example.com
+#OIDC_CLIENT_ID=
+#OIDC_CLIENT_SECRET=
+# Space- or comma-separated. Default: openid email profile
+#OIDC_SCOPES=
+# Shown on the login button ("Sign in with Zitadel"). Default: SSO
+#OIDC_PROVIDER_NAME=Zitadel
+
 # ------------------------------------------------------------------- email
 # SMTP for verification and password-reset emails (works with any provider:
 # Resend, Postmark, SES, a local relay). With SMTP_HOST set, new signups must

--- a/.env.example
+++ b/.env.example
@@ -33,7 +33,8 @@
 # Set all three of ISSUER/CLIENT_ID/CLIENT_SECRET together to enable; the
 # server refuses to boot if only some are set (almost certainly a mistake).
 # ISSUER is the provider's base URL — .well-known/openid-configuration is
-# resolved from it lazily, at sign-in time, not at boot.
+# resolved from it. As of better-auth 1.6.26 this happens at sign-in time
+# rather than at boot, but that's this version's behavior, not a guarantee.
 #OIDC_ISSUER=https://idp.example.com
 #OIDC_CLIENT_ID=
 #OIDC_CLIENT_SECRET=

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
       - run: bun run typecheck
       - run: bun run lint
       - run: bun run format:check
+      - run: bun run doc-lint
       - run: bun run build
       # `bun run test`, not `bun test`: the suite is vitest, and `bun test`
       # would run Bun's own runner against the same files

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,9 @@ desktop/src-tauri/gen
 .DS_Store
 .env*
 !.env.example
+
+# .claude/ is committed (skills, slash commands, settings.json define the
+# agent contract for this repo). Only the per-contributor and per-session
+# files are ignored.
+.claude/settings.local.json
+.claude/.current-tool

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,52 @@
+@.context/INDEX.md
+
+This is a placeholder. Will need to be updated.
+https://github.com/kgoedecke/doop
+
+# doop
+
+Doop is the open-source alternative to Paper.design: a multiplayer design canvas for humans and AI
+agents. Every design lives on a shareable Canvas (`/c/<id>`) holding Frames - artboards that
+render real HTML in sandboxed iframes. People edit in the browser; AI agents edit through the
+built-in MCP server, streaming designs in live. Everyone sees cursors, presence, frame edits, agent
+status, and an activity feed in realtime over one WebSocket room per canvas.
+
+## Tech stack
+
+TypeScript/React/Express/Postgres (drizzle), realtime over `ws`, MCP server for agent access, Tauri
+desktop shell. Full details in `.context/TECHSTACK.md`, which `.context/INDEX.md` links.
+
+Always use the `clean-code:typescript` skill when writing or reviewing TypeScript code in this
+repo.
+
+## First-time setup after clone
+
+```bash
+bun install
+bun run dev   # zero-config: embedded Postgres (pglite), server + web concurrently
+```
+
+Or self-host via Docker: `docker compose up` (real Postgres, port 4400).
+
+## Project layout
+
+```
+src/               - React frontend (Vite entry: index.html)
+src/components/ui/ - shadcn-generated UI primitives
+src/pages/         - route-level pages
+src/hooks/         - React hooks
+src/lib/           - client-side utilities
+server/            - Express backend, WebSocket room, MCP server, better-auth
+server/db/         - drizzle-orm schema (schema.ts, auth-schema.ts) and migrations
+shared/            - types/utilities shared between server and client
+desktop/           - Tauri desktop app wrapper
+desktop/src-tauri/ - Rust side of the desktop app
+scripts/           - repo maintenance scripts
+tests/             - vitest test suite
+```
+
+## Language
+
+TypeScript. Always use the `clean-code:typescript` skill when writing or reviewing TypeScript
+code. Formatter and lint rules are captured in `.context/CODESTYLE.md`, which `.context/INDEX.md`
+links.

--- a/README.md
+++ b/README.md
@@ -264,9 +264,12 @@ to boot rather than run with SSO half-configured. `OIDC_SCOPES` (default
 `openid email profile`) and `OIDC_PROVIDER_NAME` (default `SSO`, shown on the login
 button — e.g. `Zitadel`) are optional. Signing in via SSO links to an existing
 email/password account when the emails match and the provider marks the email
-verified — same trust model `ADMIN_EMAILS` already uses, and this works even
-on an instance with no SMTP configured, where a local account could otherwise
-never verify on its own.
+verified, and this works even on an instance with no SMTP configured, where a
+local account could otherwise never verify on its own. SSO alone never grants
+the admin role, even for an address listed in `ADMIN_EMAILS` — an IdP is not
+trusted as an admin-promotion source, only as an email-ownership check;
+promotion still requires the normal `ADMIN_EMAILS` path (verified signup, or
+`syncAdmins` at boot for an account SSO has since verified).
 
 Env: see the OIDC block in [.env.example](.env.example).
 

--- a/README.md
+++ b/README.md
@@ -255,6 +255,21 @@ so a privileged read there would give every agent holding an admin's token the r
 instance. View-as sessions cannot write, cannot connect agents, and record who is behind
 them in `session.impersonated_by`.
 
+### SSO (OIDC)
+
+Optional login against an external OIDC provider (Zitadel, Okta, Authentik, Keycloak,
+etc.), alongside email/password — not a replacement for it. Set `OIDC_ISSUER`,
+`OIDC_CLIENT_ID`, and `OIDC_CLIENT_SECRET` together to enable it; a partial set refuses
+to boot rather than run with SSO half-configured. `OIDC_SCOPES` (default
+`openid email profile`) and `OIDC_PROVIDER_NAME` (default `SSO`, shown on the login
+button — e.g. `Zitadel`) are optional. Signing in via SSO links to an existing
+email/password account when the emails match and the provider marks the email
+verified — same trust model `ADMIN_EMAILS` already uses, and this works even
+on an instance with no SMTP configured, where a local account could otherwise
+never verify on its own.
+
+Env: see the OIDC block in [.env.example](.env.example).
+
 ## Agent auth (MCP OAuth)
 
 The `/mcp` endpoint requires OAuth. Adding the server in Claude Code / Codex triggers

--- a/docs/superpowers/specs/2026-08-31-oidc-sso-design.md
+++ b/docs/superpowers/specs/2026-08-31-oidc-sso-design.md
@@ -32,17 +32,17 @@ Use `genericOAuth`, single provider entry (`id: 'oidc'`).
 
 ## Configuration
 
-| Env var | Required | Purpose |
-|---|---|---|
-| `OIDC_ISSUER` | yes (as a set) | Base issuer URL; `${OIDC_ISSUER}/.well-known/openid-configuration` is used for discovery |
-| `OIDC_CLIENT_ID` | yes (as a set) | OAuth client id registered with the IdP |
-| `OIDC_CLIENT_SECRET` | yes (as a set) | OAuth client secret |
-| `OIDC_SCOPES` | no | Space- or comma-separated scopes; default `openid email profile` |
-| `OIDC_PROVIDER_NAME` | no | Display name for the login button, e.g. `Zitadel`; default `SSO` |
+| Env var              | Required       | Purpose                                                                                  |
+| -------------------- | -------------- | ---------------------------------------------------------------------------------------- |
+| `OIDC_ISSUER`        | yes (as a set) | Base issuer URL; `${OIDC_ISSUER}/.well-known/openid-configuration` is used for discovery |
+| `OIDC_CLIENT_ID`     | yes (as a set) | OAuth client id registered with the IdP                                                  |
+| `OIDC_CLIENT_SECRET` | yes (as a set) | OAuth client secret                                                                      |
+| `OIDC_SCOPES`        | no             | Space- or comma-separated scopes; default `openid email profile`                         |
+| `OIDC_PROVIDER_NAME` | no             | Display name for the login button, e.g. `Zitadel`; default `SSO`                         |
 
 "Required as a set": if none of `OIDC_ISSUER` / `OIDC_CLIENT_ID` /
 `OIDC_CLIENT_SECRET` are set, SSO is simply absent - zero behavior change
-for existing installs. If *some but not all three* are set, that's a
+for existing installs. If _some but not all three_ are set, that's a
 misconfiguration and the server throws at boot, same severity as the
 existing `BETTER_AUTH_SECRET` production check in `server/auth.ts`.
 
@@ -67,7 +67,7 @@ trust model `ADMIN_EMAILS`/`mayPromote()` already uses for
    is constructed.
 
 3. **New public endpoint**, `GET /api/oidc-config` -> `{ enabled: boolean,
-   displayName?: string }`. Needed because the client is a static bundle
+displayName?: string }`. Needed because the client is a static bundle
    shared across self-hosted deployments - it cannot know at build time
    whether SSO is configured for a given deploy, so it asks at runtime.
    Same fetch-based pattern as the existing `accountExists()` check in

--- a/docs/superpowers/specs/2026-08-31-oidc-sso-design.md
+++ b/docs/superpowers/specs/2026-08-31-oidc-sso-design.md
@@ -1,0 +1,124 @@
+# Generic OIDC/SSO support
+
+- Issue: https://github.com/kgoedecke/doop/issues/46
+- Status: approved by maintainer (kgoedecke), ready for implementation
+
+## Purpose
+
+Let self-hosted doop instances delegate login to an external OIDC identity
+provider (Zitadel, Okta, Authentik, Keycloak, etc.) instead of, or alongside,
+doop's built-in email/password auth. Proposed and approved as a generic,
+env-var-gated feature - not specific to any one IdP or deployment.
+
+## Scope
+
+Single OIDC provider per doop instance, entirely configured by environment
+variables. No UI-based provider management, no multi-IdP support - out of
+scope, and not what was proposed in issue #46.
+
+Additive: existing email/password login is untouched and stays available.
+SSO is an extra option that appears only when configured.
+
+## Approach
+
+better-auth (already in use, v1.6.26) ships two relevant plugins:
+
+- `genericOAuth` (client role) - doop delegates login to an external
+  OAuth2/OIDC provider. Supports OIDC discovery via `discoveryUrl`.
+- `oidcProvider` - makes doop itself an OIDC issuer. Already used via the
+  `mcp()` plugin for agent auth. Wrong direction for this feature.
+
+Use `genericOAuth`, single provider entry (`id: 'oidc'`).
+
+## Configuration
+
+| Env var | Required | Purpose |
+|---|---|---|
+| `OIDC_ISSUER` | yes (as a set) | Base issuer URL; `${OIDC_ISSUER}/.well-known/openid-configuration` is used for discovery |
+| `OIDC_CLIENT_ID` | yes (as a set) | OAuth client id registered with the IdP |
+| `OIDC_CLIENT_SECRET` | yes (as a set) | OAuth client secret |
+| `OIDC_SCOPES` | no | Space- or comma-separated scopes; default `openid email profile` |
+| `OIDC_PROVIDER_NAME` | no | Display name for the login button, e.g. `Zitadel`; default `SSO` |
+
+"Required as a set": if none of `OIDC_ISSUER` / `OIDC_CLIENT_ID` /
+`OIDC_CLIENT_SECRET` are set, SSO is simply absent - zero behavior change
+for existing installs. If *some but not all three* are set, that's a
+misconfiguration and the server throws at boot, same severity as the
+existing `BETTER_AUTH_SECRET` production check in `server/auth.ts`.
+
+## Account linking
+
+Confirmed with user: auto-link on matching verified email. If an OIDC
+sign-in's email matches an existing password account, and the IdP marks
+the email verified, they resolve to the same doop user. This mirrors the
+trust model `ADMIN_EMAILS`/`mayPromote()` already uses for
+`emailVerified`. No separate "please link your account" flow.
+
+## Components
+
+1. **`server/auth.ts`** - add the `genericOAuth` plugin to `buildAuth()`,
+   gated on all three required env vars being set. Provider id `'oidc'`.
+   `discoveryUrl` built from `OIDC_ISSUER`. Scopes parsed from
+   `OIDC_SCOPES` (space/comma separated), default `openid email profile`.
+   Account linking configured to trust the IdP's `email_verified` claim.
+
+2. **`server/auth.ts`** - boot-time validation: partial OIDC config (1 or 2
+   of the 3 required vars set) throws a clear error before `betterAuth()`
+   is constructed.
+
+3. **New public endpoint**, `GET /api/oidc-config` -> `{ enabled: boolean,
+   displayName?: string }`. Needed because the client is a static bundle
+   shared across self-hosted deployments - it cannot know at build time
+   whether SSO is configured for a given deploy, so it asks at runtime.
+   Same fetch-based pattern as the existing `accountExists()` check in
+   `AuthPage.tsx`. No secrets in the response.
+
+4. **`src/lib/auth.ts`** - add `genericOAuthClient()` to
+   `createAuthClient({ plugins: [...] })`, enabling
+   `authClient.signIn.oauth2({ providerId: 'oidc' })`.
+
+5. **`src/pages/AuthPage.tsx`** - on mount, fetch `/api/oidc-config`. If
+   enabled, render a "Sign in with {displayName}" button (falls back to
+   "Sign in with SSO") above the existing email/password form, with a
+   divider. Email/password form remains untouched below it.
+
+6. **`.env.example`** and **`README.md`** - document the five env vars
+   above.
+
+## Error handling
+
+- No OIDC env vars set: SSO absent, no behavior change.
+- Partial config (1-2 of the 3 required vars): throw at boot.
+- Bad `OIDC_ISSUER` (discovery fails): better-auth fetches discovery
+  lazily, not at boot, so this surfaces as a sign-in-time error rather than
+  a boot crash. Exact behavior to be confirmed against better-auth's
+  `genericOAuth` docs during implementation; if boot-time validation is in
+  fact possible cheaply, prefer it, but do not block the feature on this -
+  document the current behavior either way.
+
+## Testing
+
+TDD, server-only, following the existing convention (`tests/harness.ts`,
+real server + real DB, no mocking of better-auth or the IdP). No
+client-side test infrastructure exists in this repo yet, so `AuthPage.tsx`
+changes are covered by manual smoke test, not automated tests - consistent
+with current coverage.
+
+1. `buildAuth()` excludes the OIDC plugin when unset - no regression to
+   existing email/password-only behavior.
+2. Server throws on boot with partial OIDC config (e.g. `OIDC_ISSUER` set,
+   `OIDC_CLIENT_ID`/`OIDC_CLIENT_SECRET` unset).
+3. `GET /api/oidc-config` returns `{ enabled: false }` when unset.
+4. `GET /api/oidc-config` returns `{ enabled: true, displayName: ... }`
+   when fully configured, respecting `OIDC_PROVIDER_NAME` fallback to
+   `"SSO"`.
+5. `OIDC_SCOPES` parsing: default value, custom comma-separated value,
+   custom space-separated value.
+
+## Out of scope
+
+- Multi-IdP support (would need a config format beyond flat env vars).
+- UI-based provider management/admin config.
+- Automated client-side (React component) tests - no existing
+  infrastructure for this in the repo; would be a separate, unrelated
+  addition.

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "lint:fix": "eslint . --fix",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
+    "doc-lint": "node scripts/doc-lint.mjs",
     "prepare": "husky || true"
   },
   "lint-staged": {

--- a/scripts/doc-lint.mjs
+++ b/scripts/doc-lint.mjs
@@ -1,0 +1,472 @@
+#!/usr/bin/env node
+// scripts/doc-lint.mjs
+//
+// Enforces the CLAUDE.md + .context/ convention in CI so the project's context
+// docs cannot silently rot. Zero dependencies; Node 18+.
+//
+// Installed by the `context-pattern` skill. ADAPT THE CONFIG BLOCK BELOW to the
+// repo -- at minimum SOURCE_DIRS and REQUIRED_CONTEXT_DOCS. Everything under
+// "Rules" is generic and should not need editing.
+//
+// Errors fail the build (exit 1). Warnings are printed and pass.
+//
+// Escape hatches, for when the guard is in the way but you do not want to
+// unwire it:
+//   DOCLINT_SKIP=1                 exit 0 immediately, check nothing
+//   --warn-only | DOCLINT_WARN_ONLY=1
+//                                  run every rule, print errors, still exit 0
+// Prefer --warn-only while a repo is being brought up to the convention: it
+// keeps the findings visible. DOCLINT_SKIP hides them, so treat it as
+// temporary. To remove the guard for good, unwire it (drop the npm script, CI
+// step, or hook) and delete this file.
+//
+// Design note on index symmetry -- the invariant is narrow, not absolute. In
+// EVERY index, an entry pointing at a missing file is an ERROR. The reverse
+// direction depends on what reading the index costs:
+//
+//   .context/INDEX.md      @-imported by CLAUDE.md, so it loads on every agent
+//   (Rule 4, WARNING)      session. A repo with years of accumulated specs/ and
+//                          plans/ is right to let finished work age out of it.
+//                          Erroring here fails healthy repos and "fixes" them
+//                          by bloating the one file the convention exists to
+//                          keep small.
+//   .context/<dir>/INDEX.md  reached only by a link, so it costs nothing until
+//   (Rule 9, ERROR)          something reads it. Completeness is free, and
+//                            therefore enforceable: these files are the full
+//                            record of their folder.
+//
+// The repo that motivated the original one-way rule -- 161 files under
+// .context/ behind a 72-line INDEX.md, where a symmetric root rule produced 122
+// false findings -- becomes conformant under this split by gaining a complete
+// specs/INDEX.md, not by growing its root index. Rule 4 therefore skips
+// anything inside a CHILD_INDEX_DIRS folder: Rule 9 owns those entries, and
+// double-reporting them would re-create the noise.
+
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs'
+import { join, resolve, dirname, relative, extname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __filename = fileURLToPath(import.meta.url)
+const ROOT = resolve(dirname(__filename), '..')
+const CONTEXT_DIR = join(ROOT, '.context')
+
+// Checked before any rule runs, so a skipped run costs nothing.
+if (process.env.DOCLINT_SKIP) {
+  console.log('doc-lint skipped (DOCLINT_SKIP is set)')
+  process.exit(0)
+}
+
+// Downgrades errors to a non-fatal report. Every rule still runs and every
+// finding is still printed -- only the exit code changes.
+const WARN_ONLY = process.argv.includes('--warn-only') || !!process.env.DOCLINT_WARN_ONLY
+
+// ============================ CONFIG - ADAPT ME ============================
+
+// Root-level files that must exist.
+const REQUIRED_ROOT_FILES = ['CLAUDE.md', 'README.md']
+
+// Standing docs under .context/ that must exist. Add CODESTYLE.md, DESIGN.md,
+// RELEASE.md, ARCHITECTURE.md etc. only if this repo actually has them -- the
+// convention says never require a doc the repo cannot fill with real content.
+const REQUIRED_CONTEXT_DOCS = ['INDEX.md', 'TECHSTACK.md', 'DESIGN.md', 'CODESTYLE.md', 'RELEASE.md']
+
+// Subfolders of .context/ that own their own complete INDEX.md. These grow one
+// file per unit of work forever, so their index is a link (never @-imported)
+// and completeness in it is free -- which is why symmetry is an ERROR here but
+// only a warning for the root index. Folders NOT listed here (e.g. reference/)
+// keep their entries inline in the root index.
+const CHILD_INDEX_DIRS = ['specs', 'plans']
+
+// Directories holding source the docs describe, for the freshness check.
+// Non-existent entries are skipped, so listing extras is harmless.
+const SOURCE_DIRS = ['src', 'server', 'shared', 'desktop', 'tests']
+
+// File extensions counted as source for the freshness check.
+const SOURCE_EXT_RE = /\.(go|java|kt|rs|py|ts|tsx|js|jsx|mjs|cjs|vue|svelte)$/
+
+// Path fragments excluded from the freshness check (generated or vendored).
+const GENERATED_MARKERS = [
+  'node_modules',
+  'dist',
+  'build',
+  'target',
+  'vendor',
+  '.generated',
+  'wailsjs',
+  'src-tauri/gen',
+]
+
+// Max lines for CLAUDE.md before warning. The convention's guidance is 200.
+const CLAUDE_MD_MAX_LINES = 200
+
+// Strings that mark a doc as still-unfilled scaffolding.
+const PLACEHOLDER_MARKERS = ['_(populate)_', '<!-- SCAFFOLD:', '[Placeholder]']
+
+// ========================== END CONFIG - ADAPT ME ==========================
+
+const errors = []
+const warnings = []
+
+const err = (msg) => errors.push(msg)
+const warn = (msg) => warnings.push(msg)
+
+function readIfExists(path) {
+  try {
+    return readFileSync(path, 'utf8')
+  } catch {
+    return null
+  }
+}
+
+// Every markdown link target in `src`, normalized: fragments stripped, external
+// URLs dropped, blanks dropped. Paths stay relative to the linking file.
+function markdownLinkTargets(src) {
+  const targets = new Set()
+  const linkRe = /]\(([^)]+)\)/g
+  let match
+  while ((match = linkRe.exec(src))) {
+    const target = match[1].trim().split('#')[0]
+    if (!target) continue
+    if (/^[a-z][a-z0-9+.-]*:\/\//i.test(target)) continue // external URL
+    targets.add(target)
+  }
+  return targets
+}
+
+// Recursively collect files under `dir`, optionally filtered by `filterFn`.
+function walk(dir, filterFn) {
+  const out = []
+  if (!existsSync(dir)) return out
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const p = join(dir, entry.name)
+    if (entry.isDirectory()) {
+      out.push(...walk(p, filterFn))
+    } else if (!filterFn || filterFn(p, entry)) {
+      out.push(p)
+    }
+  }
+  return out
+}
+
+// ---------------- Rule 1: CLAUDE.md exists and wires in INDEX.md ----------------
+
+const claudeMdPath = join(ROOT, 'CLAUDE.md')
+const claudeMd = readIfExists(claudeMdPath)
+
+if (claudeMd === null) {
+  err('CLAUDE.md is missing')
+} else {
+  if (!/^@\.context\/INDEX\.md\s*$/m.test(claudeMd)) {
+    err(
+      'CLAUDE.md must @-import .context/INDEX.md (add "@.context/INDEX.md" as its own line, near the top)',
+    )
+  }
+
+  const lineCount = claudeMd.split('\n').length
+  if (lineCount > CLAUDE_MD_MAX_LINES) {
+    warn(
+      `CLAUDE.md is ${lineCount} lines (guidance: under ${CLAUDE_MD_MAX_LINES}); move detail into .context/ and link it from INDEX.md`,
+    )
+  }
+
+  // Over-importing: specs/plans/reference should be INDEX links, not @-imports,
+  // because every @-import is paid for on every session.
+  const overImports = [...claudeMd.matchAll(/^@(\.context\/(?:specs|plans|reference)\/\S+)/gm)]
+  for (const m of overImports) {
+    warn(
+      `CLAUDE.md @-imports "${m[1]}"; specs/plans/reference belong in INDEX.md as links, not as always-loaded imports`,
+    )
+  }
+}
+
+// ---------------- Rule 2: required files exist ----------------
+
+for (const f of REQUIRED_ROOT_FILES) {
+  if (!existsSync(join(ROOT, f))) {
+    err(`Missing required root file: ${f}`)
+  }
+}
+
+for (const f of REQUIRED_CONTEXT_DOCS) {
+  if (!existsSync(join(CONTEXT_DIR, f))) {
+    err(`Missing required context doc: .context/${f}`)
+  }
+}
+
+// ---------------- Rules 3 & 4: INDEX.md <-> .context/ consistency ----------------
+
+const indexPath = join(CONTEXT_DIR, 'INDEX.md')
+const indexSrc = readIfExists(indexPath)
+const rootLinkedPaths = new Set()
+
+if (indexSrc === null) {
+  // Already reported by Rule 2 if it was in REQUIRED_CONTEXT_DOCS.
+  if (!REQUIRED_CONTEXT_DOCS.includes('INDEX.md')) {
+    err('.context/INDEX.md is missing')
+  }
+} else {
+  for (const target of markdownLinkTargets(indexSrc)) rootLinkedPaths.add(target)
+
+  // Rule 3 (ERROR): every INDEX entry must resolve. A stale entry is always a
+  // defect -- it points an agent at a file that is not there.
+  for (const link of rootLinkedPaths) {
+    if (!existsSync(join(CONTEXT_DIR, link))) {
+      err(`.context/INDEX.md links to "${link}", which does not exist`)
+    }
+  }
+
+  // Rule 4 (WARNING): unlisted docs. See the design note at the top of this
+  // file for why this is deliberately not an error.
+  const docsOnDisk = walk(CONTEXT_DIR, (p) => extname(p) === '.md').filter(
+    (p) => resolve(p) !== resolve(indexPath),
+  )
+  const unlisted = docsOnDisk
+    .map((doc) => relative(CONTEXT_DIR, doc).split('\\').join('/'))
+    .filter((rel) => !rootLinkedPaths.has(rel))
+
+  // A missing STANDING doc is a stronger signal than an old spec aging out, so
+  // call those out individually and summarize the rest.
+  //
+  // A DIRECT child of a child-index folder is Rule 9's business, not this
+  // warning's. Anything nested DEEPER than that is nobody's otherwise -- Rule 9
+  // only reads the folder's top level -- so it stays here rather than falling
+  // through both rules unchecked. It is also off-convention: specs/ and plans/
+  // are flat, and only reference/ nests by topic.
+  const isDirectChildOf = (rel, dir) => {
+    const prefix = `${dir}/`
+    return rel.startsWith(prefix) && !rel.slice(prefix.length).includes('/')
+  }
+  const isDirectChildOfChildIndexDir = (rel) =>
+    CHILD_INDEX_DIRS.some((dir) => isDirectChildOf(rel, dir))
+
+  const standingUnlisted = unlisted.filter((rel) => !rel.includes('/'))
+  const nestedUnlisted = unlisted.filter(
+    (rel) => rel.includes('/') && !isDirectChildOfChildIndexDir(rel),
+  )
+
+  for (const rel of standingUnlisted) {
+    warn(`.context/${rel} is a standing doc but is not linked from .context/INDEX.md`)
+  }
+  if (nestedUnlisted.length > 0) {
+    warn(
+      `${nestedUnlisted.length} file(s) under .context/ are not linked from INDEX.md (expected as finished work ages out; add an entry only if still current)`,
+    )
+  }
+}
+
+// ---------------- Rule 5: no placeholder-only standing docs ----------------
+
+for (const f of REQUIRED_CONTEXT_DOCS) {
+  const content = readIfExists(join(CONTEXT_DIR, f))
+  if (content === null) continue
+  const hit = PLACEHOLDER_MARKERS.find((marker) => content.includes(marker))
+  if (hit) {
+    warn(`.context/${f} still contains the placeholder marker "${hit}"; fill it in or delete it`)
+  }
+}
+
+// ---------------- Rule 6: freshness (warning only) ----------------
+// If source has changed more recently than every doc describing it, nudge.
+// Mtimes are meaningless right after a fresh checkout (everything lands at
+// once), so this only bites in a real working tree -- which is when it helps.
+
+const sourceFiles = SOURCE_DIRS.flatMap((d) =>
+  walk(join(ROOT, d), (p) => {
+    if (!SOURCE_EXT_RE.test(p)) return false
+    return !GENERATED_MARKERS.some((marker) => p.includes(marker))
+  }),
+)
+
+const docFiles = [claudeMdPath, ...walk(CONTEXT_DIR, (p) => extname(p) === '.md')].filter(existsSync)
+
+if (sourceFiles.length > 0 && docFiles.length > 0) {
+  const newestDocMtime = Math.max(...docFiles.map((p) => statSync(p).mtimeMs))
+
+  let newestSourceMtime = 0
+  let newestSourcePath = null
+  for (const s of sourceFiles) {
+    const mtime = statSync(s).mtimeMs
+    if (mtime > newestSourceMtime) {
+      newestSourceMtime = mtime
+      newestSourcePath = s
+    }
+  }
+
+  if (newestSourcePath && newestSourceMtime > newestDocMtime) {
+    warn(
+      `Stale docs: ${relative(ROOT, newestSourcePath)} is newer than every file in CLAUDE.md / .context/ - consider updating the docs`,
+    )
+  }
+}
+
+// ------- Rules 7-12: hierarchical child indexes (.context/<dir>/INDEX.md) -------
+// Each folder in CHILD_INDEX_DIRS is the complete record of itself. Its index is
+// reached by a link rather than @-imported, so nothing is paid for until
+// something reads it. That is what makes it fair to demand completeness here --
+// and to demand that an entry marked archived really is gone from the tree.
+
+const HEADING_RE = /^(#{1,6})\s+/
+const ARCHIVED_HEADING_RE = /^(#{1,6})\s+Archived\b/i
+
+// Where the "Archived" heading is and how deep, or null if there is none.
+function findArchivedHeading(lines) {
+  for (const [index, line] of lines.entries()) {
+    const heading = ARCHIVED_HEADING_RE.exec(line)
+    if (heading) return { index, level: heading[1].length }
+  }
+  return null
+}
+
+// The lines under the first "Archived" heading, running to the next heading of
+// the same or a higher level, or to EOF.
+function archivedSectionLines(src) {
+  const lines = src.split('\n')
+  const heading = findArchivedHeading(lines)
+  if (heading === null) return []
+
+  const body = []
+  for (const line of lines.slice(heading.index + 1)) {
+    const nextHeading = HEADING_RE.exec(line)
+    if (nextHeading && nextHeading[1].length <= heading.level) break
+    body.push(line)
+  }
+  return body
+}
+
+// Group lines into top-level "- " list items, folding wrapped continuation
+// lines into the item they belong to. Indented sub-bullets fold in too, since
+// only the top-level item counts as one entry.
+function topLevelListItems(lines) {
+  const items = []
+  let current = null
+  for (const line of lines) {
+    if (/^[-*]\s+/.test(line)) {
+      if (current !== null) items.push(current)
+      current = line
+    } else if (current !== null) {
+      if (line.trim() === '') {
+        items.push(current)
+        current = null
+      } else {
+        current += `\n${line}`
+      }
+    }
+  }
+  if (current !== null) items.push(current)
+  return items
+}
+
+// An archived entry names its file in backticks, never as a link: a link to a
+// removed file would be a stale entry, which Rule 8 rejects outright.
+const BACKTICKED_MD_RE = /`([^`]+\.md)`/g
+
+// A recovery SHA, in either form the convention accepts. Backticked is what the
+// template writes and is taken as-is. A bare token must contain a digit, because
+// an all-[a-f] run is far more likely to be an English word ("defaced") than a
+// commit: the cost of that guess is a spurious "add a SHA" nudge on the rare
+// digitless bare SHA, versus silently vouching for recoverability that does not
+// exist.
+const BACKTICKED_SHA_RE = /`[0-9a-fA-F]{7,40}`/
+const BARE_SHA_RE = /\b(?=[0-9a-fA-F]{7,40}\b)[a-fA-F]*[0-9][0-9a-fA-F]*\b/
+
+function hasRecoverySha(entry) {
+  if (BACKTICKED_SHA_RE.test(entry)) return true
+  return BARE_SHA_RE.test(entry.replace(BACKTICKED_MD_RE, ' '))
+}
+
+for (const dir of CHILD_INDEX_DIRS) {
+  const childDir = join(CONTEXT_DIR, dir)
+  if (!existsSync(childDir)) continue // a folder that does not exist owes nothing
+
+  const childIndexPath = join(childDir, 'INDEX.md')
+  const childIndexSrc = readIfExists(childIndexPath)
+
+  // Rule 7 (ERROR): the folder must have an index at all.
+  if (childIndexSrc === null) {
+    err(`.context/${dir}/ exists but has no INDEX.md`)
+    continue
+  }
+
+  const childLinks = markdownLinkTargets(childIndexSrc)
+
+  // Rule 8 (ERROR): every entry resolves, relative to the child folder. Links
+  // may escape it (../INDEX.md) and must still land on a real file.
+  for (const link of childLinks) {
+    if (!existsSync(join(childDir, link))) {
+      err(`.context/${dir}/INDEX.md links to "${link}", which does not exist`)
+    }
+  }
+
+  // Rule 9 (ERROR): the symmetry flip -- every .md in the folder is listed.
+  // Non-markdown siblings (fixtures, feature files) are not index material.
+  const childDocs = readdirSync(childDir, { withFileTypes: true })
+    .filter((entry) => entry.isFile() && extname(entry.name) === '.md' && entry.name !== 'INDEX.md')
+    .map((entry) => entry.name)
+
+  for (const name of childDocs) {
+    if (!childLinks.has(name) && !childLinks.has(`./${name}`)) {
+      err(`.context/${dir}/${name} is not listed in .context/${dir}/INDEX.md`)
+    }
+  }
+
+  for (const item of topLevelListItems(archivedSectionLines(childIndexSrc))) {
+    const archivedNames = [...item.matchAll(BACKTICKED_MD_RE)].map((m) => m[1])
+    if (archivedNames.length === 0) continue // prose or a non-file entry
+
+    // Rule 10 (ERROR): "archived" means summarized AND removed. A file that is
+    // still on disk is either not archived or was listed by mistake, and either
+    // way the index is now lying about the working tree.
+    for (const name of archivedNames) {
+      // Resolve against every base the convention plausibly means, because a
+      // form that silently matches nothing would turn this error into a
+      // guarantee it is not making. Bare name -> this folder; a path -> either
+      // repo-root-relative (.context/specs/x.md) or .context-relative
+      // (specs/x.md), both of which people write.
+      const bases = name.includes('/') ? [ROOT, CONTEXT_DIR] : [childDir]
+      if (bases.some((base) => existsSync(join(base, name)))) {
+        err(`.context/${dir}/INDEX.md lists "${name}" as archived, but the file still exists`)
+      }
+    }
+
+    // Rule 11 (WARNING): the SHA is the only handle left on the removed file, so
+    // an entry without one is a summary of something nobody can get back.
+    if (!hasRecoverySha(item)) {
+      warn(
+        `.context/${dir}/INDEX.md archived entry "${archivedNames[0]}" has no recovery SHA; recoverability cannot be verified`,
+      )
+    }
+  }
+
+  // Rule 12 (ERROR): a child index is not @-imported, so a root-index link is
+  // the only thing that makes it reachable.
+  if (
+    indexSrc !== null &&
+    !rootLinkedPaths.has(`${dir}/INDEX.md`) &&
+    !rootLinkedPaths.has(`./${dir}/INDEX.md`)
+  ) {
+    err(
+      `.context/INDEX.md does not link to .context/${dir}/INDEX.md, so the ${dir} index is unreachable`,
+    )
+  }
+}
+
+// ---------------- Report ----------------
+
+if (warnings.length > 0) {
+  console.log('doc-lint warnings:')
+  for (const w of warnings) console.log(`  ! ${w}`)
+  console.log('')
+}
+
+if (errors.length > 0) {
+  console.log('doc-lint errors:')
+  for (const e of errors) console.log(`  x ${e}`)
+  if (WARN_ONLY) {
+    console.log(`\ndoc-lint: ${errors.length} error(s), not failing (--warn-only)`)
+    process.exit(0)
+  }
+  console.log(`\ndoc-lint failed: ${errors.length} error(s)`)
+  process.exit(1)
+}
+
+console.log(`doc-lint passed (${warnings.length} warning(s))`)

--- a/server/auth.ts
+++ b/server/auth.ts
@@ -148,9 +148,18 @@ export function oidcPublicConfig(): { enabled: boolean; displayName?: string } {
  * if the IdP marks this email verified and a local, still-unverified account
  * already holds it, the IdP has already proven ownership — mark the local
  * account verified too, so the gate's own default (matching, verified email)
- * decides the outcome. Also runs the same admin-promotion check syncAdmins
- * and afterEmailVerification already run at the moment a user verifies,
- * since this is exactly that moment for anyone in ADMIN_EMAILS.
+ * decides the outcome.
+ *
+ * Deliberately does NOT run the ADMIN_EMAILS promotion check here, unlike
+ * syncAdmins and afterEmailVerification: any configured IdP would otherwise
+ * become a trust root for the admin role, which is exactly what mayPromote
+ * exists to prevent (a public/open-registration IdP can assert
+ * email_verified for an address it never confirmed ownership of just as
+ * cheaply as a stranger typing it into a password signup). It also runs
+ * before better-auth's own linking gate, so a grant here would persist even
+ * if the sign-in then fails to link. Promotion for an SSO-linked ADMIN_EMAILS
+ * account still happens — once, safely — the next time syncAdmins runs at
+ * boot, since this handler leaves emailVerified true.
  */
 async function linkVerifiedOidcEmail(profile: {
   email?: unknown
@@ -159,12 +168,11 @@ async function linkVerifiedOidcEmail(profile: {
   const email = typeof profile.email === 'string' ? profile.email.toLowerCase() : undefined
   if (email && profile.email_verified === true) {
     const [existing] = await db
-      .select({ id: authSchema.user.id, email: authSchema.user.email })
+      .select({ id: authSchema.user.id })
       .from(authSchema.user)
       .where(and(eq(sql`lower(${authSchema.user.email})`, email), eq(authSchema.user.emailVerified, false)))
     if (existing) {
       await db.update(authSchema.user).set({ emailVerified: true }).where(eq(authSchema.user.id, existing.id))
-      if (mayPromote({ email: existing.email, emailVerified: true })) await promote(existing.id, existing.email)
     }
   }
   return {}
@@ -250,9 +258,12 @@ function buildAuth() {
        an expired impersonation session doesn't revert to the admin, it signs
        them out entirely, so the window should be short and re-entered. */
     /* genericOAuth: SSO against an external OIDC provider, absent unless
-       loadOidcConfig() finds a full config. discoveryUrl resolves the
-       authorize/token endpoints lazily at sign-in time, so an unreachable
-       issuer surfaces there rather than at boot.
+       loadOidcConfig() finds a full config. As of better-auth 1.6.26,
+       discoveryUrl resolves the authorize/token endpoints at sign-in time
+       rather than at plugin registration, so an unreachable issuer tends to
+       surface there rather than at boot — an implementation detail of this
+       version, not a documented contract, so don't rely on it.
+       pkce: true because some IdPs reject a non-PKCE authorization code flow.
        Account linking (see linkVerifiedOidcEmail below): better-auth's own
        default linking gate requires BOTH the IdP's email_verified claim AND
        the local user row already being emailVerified — the second half is
@@ -273,6 +284,7 @@ function buildAuth() {
                   clientSecret: oidc.clientSecret,
                   discoveryUrl: `${oidc.issuer.replace(/\/$/, '')}/.well-known/openid-configuration`,
                   scopes: oidc.scopes,
+                  pkce: true,
                   mapProfileToUser: linkVerifiedOidcEmail,
                 },
               ],

--- a/server/auth.ts
+++ b/server/auth.ts
@@ -1,6 +1,6 @@
 import { betterAuth } from 'better-auth'
 import { eq, inArray, or, isNull, ne, and, sql } from 'drizzle-orm'
-import { admin, mcp } from 'better-auth/plugins'
+import { admin, mcp, genericOAuth } from 'better-auth/plugins'
 import { drizzleAdapter } from 'better-auth/adapters/drizzle'
 import { db } from './db/index.ts'
 import * as authSchema from './db/auth-schema.ts'
@@ -96,7 +96,82 @@ export async function syncAdmins(): Promise<void> {
   }
 }
 
+interface OidcConfig {
+  issuer: string
+  clientId: string
+  clientSecret: string
+  scopes: string[]
+  providerName: string
+}
+
+/**
+ * Env-gated SSO against an external OIDC provider (Zitadel, Okta, Authentik,
+ * Keycloak, ...). All three of OIDC_ISSUER/OIDC_CLIENT_ID/OIDC_CLIENT_SECRET
+ * must be set together to enable it — a partial set is almost certainly a
+ * misconfiguration, not a valid state, so it throws rather than silently
+ * running with SSO half-on.
+ */
+export function loadOidcConfig(): OidcConfig | null {
+  const { OIDC_ISSUER, OIDC_CLIENT_ID, OIDC_CLIENT_SECRET, OIDC_SCOPES, OIDC_PROVIDER_NAME } = process.env
+  const setCount = [OIDC_ISSUER, OIDC_CLIENT_ID, OIDC_CLIENT_SECRET].filter(Boolean).length
+  if (setCount === 0) return null
+  if (setCount < 3) {
+    throw new Error('OIDC_ISSUER, OIDC_CLIENT_ID, and OIDC_CLIENT_SECRET must all be set together to enable SSO')
+  }
+  return {
+    issuer: OIDC_ISSUER!,
+    clientId: OIDC_CLIENT_ID!,
+    clientSecret: OIDC_CLIENT_SECRET!,
+    scopes: (OIDC_SCOPES || 'openid email profile').split(/[,\s]+/).filter(Boolean),
+    providerName: OIDC_PROVIDER_NAME || 'SSO',
+  }
+}
+
+/** What the login page is allowed to know: whether SSO exists and what to call it. Never the secret. */
+export function oidcPublicConfig(): { enabled: boolean; displayName?: string } {
+  const config = loadOidcConfig()
+  return config ? { enabled: true, displayName: config.providerName } : { enabled: false }
+}
+
+/**
+ * better-auth's account-linking gate requires the LOCAL user row to already
+ * be emailVerified before it will link an incoming OAuth sign-in to it —
+ * the IdP's own emailVerified claim alone is not enough (see
+ * link-account.mjs's requireLocalEmailVerified, which defaults true and, per
+ * its own deprecation note, is headed toward becoming unconditional). On an
+ * instance with no SMTP configured, no local account can ever verify on its
+ * own (see mailerConfigured in mailer.ts), so without this, an existing
+ * password user could never link their account to SSO — exactly the
+ * migration this feature exists to support.
+ *
+ * Used as the OIDC provider's mapProfileToUser, which runs before that gate:
+ * if the IdP marks this email verified and a local, still-unverified account
+ * already holds it, the IdP has already proven ownership — mark the local
+ * account verified too, so the gate's own default (matching, verified email)
+ * decides the outcome. Also runs the same admin-promotion check syncAdmins
+ * and afterEmailVerification already run at the moment a user verifies,
+ * since this is exactly that moment for anyone in ADMIN_EMAILS.
+ */
+async function linkVerifiedOidcEmail(profile: {
+  email?: unknown
+  email_verified?: unknown
+}): Promise<Record<string, never>> {
+  const email = typeof profile.email === 'string' ? profile.email.toLowerCase() : undefined
+  if (email && profile.email_verified === true) {
+    const [existing] = await db
+      .select({ id: authSchema.user.id, email: authSchema.user.email })
+      .from(authSchema.user)
+      .where(and(eq(sql`lower(${authSchema.user.email})`, email), eq(authSchema.user.emailVerified, false)))
+    if (existing) {
+      await db.update(authSchema.user).set({ emailVerified: true }).where(eq(authSchema.user.id, existing.id))
+      if (mayPromote({ email: existing.email, emailVerified: true })) await promote(existing.id, existing.email)
+    }
+  }
+  return {}
+}
+
 function buildAuth() {
+  const oidc = loadOidcConfig()
   if (!process.env.BETTER_AUTH_SECRET && process.env.NODE_ENV === 'production') {
     throw new Error('BETTER_AUTH_SECRET must be set in production')
   }
@@ -174,7 +249,37 @@ function buildAuth() {
     /* admin: role/ban/impersonate. 15 minutes rather than the default hour —
        an expired impersonation session doesn't revert to the admin, it signs
        them out entirely, so the window should be short and re-entered. */
-    plugins: [mcp({ loginPage: '/' }), admin({ impersonationSessionDuration: 15 * 60 })],
+    /* genericOAuth: SSO against an external OIDC provider, absent unless
+       loadOidcConfig() finds a full config. discoveryUrl resolves the
+       authorize/token endpoints lazily at sign-in time, so an unreachable
+       issuer surfaces there rather than at boot.
+       Account linking (see linkVerifiedOidcEmail below): better-auth's own
+       default linking gate requires BOTH the IdP's email_verified claim AND
+       the local user row already being emailVerified — the second half is
+       unreachable on an SMTP-less instance, where no local account ever
+       verifies on its own. mapProfileToUser flips that local flag first,
+       so the gate's own default (matching, IdP-verified email) is what
+       actually decides linking, as intended. */
+    plugins: [
+      mcp({ loginPage: '/' }),
+      admin({ impersonationSessionDuration: 15 * 60 }),
+      ...(oidc
+        ? [
+            genericOAuth({
+              config: [
+                {
+                  providerId: 'oidc',
+                  clientId: oidc.clientId,
+                  clientSecret: oidc.clientSecret,
+                  discoveryUrl: `${oidc.issuer.replace(/\/$/, '')}/.well-known/openid-configuration`,
+                  scopes: oidc.scopes,
+                  mapProfileToUser: linkVerifiedOidcEmail,
+                },
+              ],
+            }),
+          ]
+        : []),
+    ],
   })
 }
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -11,7 +11,7 @@ import { store } from './store.ts'
 import { getImage } from './previews.ts'
 import * as actions from './actions.ts'
 import { canAccessCanvas, hasDurableCanvasAccess, isAdmin } from './access.ts'
-import { auth, initAuth, syncAdmins, getUserName, PUBLIC_ORIGIN } from './auth.ts'
+import { auth, initAuth, syncAdmins, getUserName, PUBLIC_ORIGIN, oidcPublicConfig } from './auth.ts'
 import { adminRouter } from './admin.ts'
 import * as demo from './demo.ts'
 import { db, initDb } from './db/index.ts'
@@ -447,6 +447,13 @@ app.post('/api/account-exists', async (req, res) => {
     .from(authSchema.user)
     .where(eq(authSchema.user.email, email))
   res.json({ exists: !!row })
+})
+
+/* Public: is SSO configured, and what should the login button say? Static
+   build shared across self-hosted deploys can't know this at build time —
+   see server/auth.ts oidcPublicConfig for what's safe to expose here. */
+app.get('/api/oidc-config', (req, res) => {
+  res.json(oidcPublicConfig())
 })
 
 /* ------------------------------------------------------------------ */

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,4 +1,7 @@
 import { createAuthClient } from 'better-auth/react'
+import { genericOAuthClient } from 'better-auth/client/plugins'
 
 /** Same-origin better-auth client — cookies do the rest. */
-export const authClient = createAuthClient()
+export const authClient = createAuthClient({
+  plugins: [genericOAuthClient()],
+})

--- a/src/pages/AuthPage.tsx
+++ b/src/pages/AuthPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { authClient } from '../lib/auth'
 import { setName } from '../lib/identity'
 import { posthog } from '../lib/posthog'
@@ -31,11 +31,26 @@ async function accountExists(email: string): Promise<boolean> {
   }
 }
 
+/* Only ever follow a same-origin relative path from a query param. A naive
+   startsWith('/') check passes both "//evil.com" (protocol-relative — the
+   browser resolves it against the current protocol, landing on a different
+   origin) and "/\evil.com" (browsers normalize the backslash to a second
+   slash for http(s) URLs, same bypass) — resolving against location.origin
+   and comparing origins catches both. */
+function safeRelativeTarget(raw: string | null): string | null {
+  if (!raw || !raw.startsWith('/')) return null
+  try {
+    return new URL(raw, location.origin).origin === location.origin ? raw : null
+  } catch {
+    return null
+  }
+}
+
 function resumeOAuthFlow(): boolean {
   const params = new URLSearchParams(location.search)
-  const target = params.get('redirect_to') || params.get('redirect_uri')
-  if (target?.startsWith('/')) {
-    location.href = target // relative only — never follow an absolute URL from a query param
+  const target = safeRelativeTarget(params.get('redirect_to') || params.get('redirect_uri'))
+  if (target) {
+    location.href = target
     return true
   }
   if (params.has('client_id') && params.has('response_type')) {
@@ -47,7 +62,56 @@ function resumeOAuthFlow(): boolean {
 
 type AuthMode = 'signin' | 'signup' | 'forgot' | 'reset'
 
+/* Human copy for the OAuth error codes better-auth's callback can redirect
+   back with (see redirectOnError in its oauth2 package) — everything else
+   falls back to a generic message. account_not_linked is the one an
+   operator is most likely to actually hit: an existing local account whose
+   email the IdP claims, but that better-auth's own gate refused to link
+   (see linkVerifiedOidcEmail in server/auth.ts for why that should now be
+   rare, not why it can still happen — a provider that never sends
+   email_verified, for instance). */
+const SSO_ERROR_MESSAGES: Record<string, string> = {
+  account_not_linked:
+    'That email already has a doop account that could not be linked automatically — sign in with email/password instead.',
+  "email_doesn't_match": "The signed-in email doesn't match the account you started from — try again.",
+  email_is_missing: "Your identity provider didn't share an email address — doop needs one to sign you in.",
+}
+
+/* Where the SSO redirect should land, mirroring resumeOAuthFlow() below —
+   but handed to the server as callbackURL rather than navigated to
+   directly. The browser leaves for the IdP and returns already carrying a
+   session, so this component's own resumeOAuthFlow() never gets to run for
+   this path; the equivalent logic has to travel with the request instead. */
+function ssoCallbackURL(): string {
+  const params = new URLSearchParams(location.search)
+  const target = safeRelativeTarget(params.get('redirect_to') || params.get('redirect_uri'))
+  if (target) return target
+  if (params.has('client_id') && params.has('response_type')) return `/api/auth/mcp/authorize${location.search}`
+  return location.pathname + location.search
+}
+
+/** Matches server/auth.ts oidcPublicConfig's response shape. */
+interface OidcClientConfig {
+  enabled: boolean
+  displayName?: string
+}
+
+/* The client bundle is static and shared across self-hosted deploys — it
+   can't know at build time whether the operator configured SSO, so it asks
+   the server. See server/auth.ts oidcPublicConfig. */
+function useOidcConfig(): OidcClientConfig {
+  const [config, setConfig] = useState<OidcClientConfig>({ enabled: false })
+  useEffect(() => {
+    fetch('/api/oidc-config')
+      .then((res) => (res.ok ? res.json() : { enabled: false }))
+      .then(setConfig)
+      .catch(() => {}) // SSO button just doesn't appear — email/password still works
+  }, [])
+  return config
+}
+
 export function AuthPage() {
+  const oidc = useOidcConfig()
   /* better-auth lands password-reset links on /auth/reset?token=… */
   const resetToken = location.pathname === '/auth/reset' ? new URLSearchParams(location.search).get('token') : null
   const [mode, setMode] = useState<AuthMode>(resetToken ? 'reset' : 'signin')
@@ -70,6 +134,34 @@ export function AuthPage() {
     setNotice(null)
     setSuggestMode(null)
     setUnverified(false)
+  }
+
+  /* A failure inside the IdP round trip (the browser has already left and
+     come back) redirects here with ?error=<code> rather than throwing where
+     ssoSignIn's own res.error check could see it — that check only ever
+     catches failures of the *initiating* request (e.g. unknown providerId). */
+  useEffect(() => {
+    const ssoError = new URLSearchParams(location.search).get('error')
+    if (!ssoError) return
+    setError(SSO_ERROR_MESSAGES[ssoError] ?? 'SSO sign-in failed — try again or use email/password.')
+    history.replaceState(null, '', location.pathname)
+  }, [])
+
+  async function ssoSignIn() {
+    setError(null)
+    setBusy(true)
+    try {
+      const res = await authClient.signIn.oauth2({
+        providerId: 'oidc',
+        callbackURL: ssoCallbackURL(),
+        errorCallbackURL: '/auth',
+      })
+      /* success redirects the browser away immediately; only the failure
+         case leaves us here to show something */
+      if (res.error) setError(res.error.message ?? 'Could not start SSO sign-in — try again or use email/password.')
+    } finally {
+      setBusy(false)
+    }
   }
 
   async function resendVerification() {
@@ -179,6 +271,18 @@ export function AuthPage() {
             </>
           )}
         </p>
+        {oidc.enabled && (mode === 'signin' || mode === 'signup') && (
+          <>
+            <Button variant="default" size="lg" block type="button" onClick={ssoSignIn} disabled={busy}>
+              {mode === 'signup' ? 'Sign up' : 'Sign in'} with {oidc.displayName}
+            </Button>
+            <div className="flex items-center gap-3 text-[11px] uppercase tracking-wide text-ink-faint">
+              <span className="h-px flex-1 bg-line" />
+              or
+              <span className="h-px flex-1 bg-line" />
+            </div>
+          </>
+        )}
         {mode === 'signup' && (
           <Field label="Name" labelVariant="form">
             <Input

--- a/tests/oidc.test.ts
+++ b/tests/oidc.test.ts
@@ -1,0 +1,93 @@
+import { spawn } from 'node:child_process'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { Client, startServer, type Server } from './harness.ts'
+
+/**
+ * The /api/oidc-config surface and the guarantee that configuring SSO
+ * doesn't disturb the existing email/password flow. discoveryUrl is fetched
+ * lazily at sign-in time (confirmed against better-auth's source), so a
+ * fake, unreachable OIDC_ISSUER is fine here - only the config-gating
+ * behavior is under test, not a real IdP round trip.
+ */
+
+const ROOT = process.cwd()
+
+/* 4970-4972: test files run in parallel, each claiming its own port range
+   (see admin.test.ts's PORT comment) - this file's is clear of every other
+   test file's (checked: 4977, 4979, 4980, 4985, 4993-4996 for admin.test.ts's
+   PORT/+1/+2/+3, and 4973 for oidcAccountLinking.test.ts). */
+const PORT_UNCONFIGURED = 4970
+const PORT_CONFIGURED = 4971
+const PORT_BOOT_REFUSAL = 4972
+
+let unconfigured: Server
+let configured: Server
+
+beforeAll(async () => {
+  unconfigured = await startServer(PORT_UNCONFIGURED)
+  configured = await startServer(PORT_CONFIGURED, {
+    OIDC_ISSUER: 'https://idp.invalid',
+    OIDC_CLIENT_ID: 'test-client',
+    OIDC_CLIENT_SECRET: 'test-secret',
+    OIDC_PROVIDER_NAME: 'Zitadel',
+  })
+}, 70_000)
+
+afterAll(() => {
+  unconfigured?.stop()
+  configured?.stop()
+})
+
+describe('GET /api/oidc-config', () => {
+  it('reports disabled when no OIDC env vars are set', async () => {
+    const client = new Client(unconfigured)
+    expect(await (await client.get('/api/oidc-config')).json()).toEqual({ enabled: false })
+  })
+
+  it('reports enabled with the configured display name, and never the secret', async () => {
+    const client = new Client(configured)
+    const res = await client.get('/api/oidc-config')
+    const body = await res.text()
+    expect(JSON.parse(body)).toEqual({ enabled: true, displayName: 'Zitadel' })
+    expect(body).not.toContain('test-secret')
+  })
+})
+
+describe('email/password login, unaffected by SSO configuration', () => {
+  it('still works on a server with OIDC fully configured', async () => {
+    const client = new Client(configured)
+    await client.signUp('alice@test.dev', 'Alice')
+    expect((await (await client.get('/api/me')).json()).email).toBe('alice@test.dev')
+  })
+})
+
+describe('boot-time refusal on partial OIDC config', () => {
+  /* Not startServer(): its /healthz poll waits up to 60s before giving up,
+     which is the right patience for a server that might just be slow to
+     boot, but wrong for asserting one that should never come up at all -
+     this spawns directly and asserts the process exits on its own. */
+  it('exits rather than boot when only some of the three required vars are set', async () => {
+    const dataDir = mkdtempSync(path.join(tmpdir(), 'doop-test-'))
+    const proc = spawn(path.join(ROOT, 'node_modules', '.bin', 'tsx'), [path.join(ROOT, 'server', 'index.ts')], {
+      cwd: dataDir,
+      env: {
+        ...process.env,
+        PORT: String(PORT_BOOT_REFUSAL),
+        NODE_ENV: undefined as unknown as string,
+        OIDC_ISSUER: 'https://idp.invalid',
+        // OIDC_CLIENT_ID / OIDC_CLIENT_SECRET deliberately left unset
+      },
+      stdio: 'ignore',
+    })
+    try {
+      const exitCode = await new Promise<number | null>((resolve) => proc.on('exit', resolve))
+      expect(exitCode).not.toBe(0)
+    } finally {
+      proc.kill()
+      rmSync(dataDir, { recursive: true, force: true })
+    }
+  }, 15_000)
+})

--- a/tests/oidcAccountLinking.test.ts
+++ b/tests/oidcAccountLinking.test.ts
@@ -1,0 +1,136 @@
+import { createServer, type Server as HttpServer } from 'node:http'
+import type { AddressInfo } from 'node:net'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { Client, startServer, type Server } from './harness.ts'
+
+/**
+ * Drives the real callback leg of an OIDC sign-in against better-auth's
+ * actual code (no mocking of doop or better-auth) - only the third-party
+ * IdP is faked, which is unavoidable without a real Zitadel/Okta/etc to
+ * point at. better-auth's default getUserInfo decodes the id_token JWT via
+ * jose's decodeJwt (confirmed in node_modules/better-auth/dist/plugins/
+ * generic-oauth/routes.mjs) without verifying its signature, so an
+ * unsigned, self-issued token is sufficient here - this is testing doop's
+ * account-linking logic, not JWT cryptography.
+ *
+ * This exists to prove server/auth.ts's linkVerifiedOidcEmail: better-auth's
+ * own account-linking gate requires the LOCAL user to already be
+ * emailVerified before it will link an incoming OAuth sign-in to them, which
+ * an SMTP-less instance (the default in this test harness, and a supported
+ * self-host mode) can never satisfy on its own. Without the fix, the second
+ * test below fails with an "account_not_linked" redirect.
+ */
+
+function fakeIdToken(claims: Record<string, unknown>): string {
+  const segment = (obj: unknown) => Buffer.from(JSON.stringify(obj)).toString('base64url')
+  return `${segment({ alg: 'none', typ: 'JWT' })}.${segment(claims)}.`
+}
+
+function startFakeIdp(codeToClaims: Map<string, Record<string, unknown>>): Promise<HttpServer> {
+  return new Promise((resolve) => {
+    const server = createServer((req, res) => {
+      const url = new URL(req.url ?? '/', 'http://localhost')
+      const port = (server.address() as AddressInfo).port
+      if (url.pathname === '/.well-known/openid-configuration') {
+        res.writeHead(200, { 'Content-Type': 'application/json' })
+        res.end(
+          JSON.stringify({
+            issuer: `http://localhost:${port}`,
+            authorization_endpoint: `http://localhost:${port}/authorize`,
+            token_endpoint: `http://localhost:${port}/token`,
+          }),
+        )
+        return
+      }
+      if (url.pathname === '/token' && req.method === 'POST') {
+        let body = ''
+        req.on('data', (chunk) => (body += chunk))
+        req.on('end', () => {
+          const code = new URLSearchParams(body).get('code') ?? ''
+          const claims = codeToClaims.get(code) ?? {}
+          res.writeHead(200, { 'Content-Type': 'application/json' })
+          res.end(
+            JSON.stringify({
+              access_token: 'fake-access-token',
+              token_type: 'Bearer',
+              expires_in: 3600,
+              id_token: fakeIdToken(claims),
+            }),
+          )
+        })
+        return
+      }
+      res.writeHead(404)
+      res.end()
+    })
+    server.listen(0, () => resolve(server))
+  })
+}
+
+/* code -> the ID token claims the fake IdP hands back for it, set by each
+   test right before it drives the flow */
+const codeToClaims = new Map<string, Record<string, unknown>>()
+let idp: HttpServer
+let server: Server
+
+/* 4973: clear of every other test file's port range (see tests/oidc.test.ts
+   for the full accounting) - the fake IdP itself binds an OS-assigned port. */
+const PORT = 4973
+
+beforeAll(async () => {
+  idp = await startFakeIdp(codeToClaims)
+  const idpPort = (idp.address() as AddressInfo).port
+  server = await startServer(PORT, {
+    OIDC_ISSUER: `http://localhost:${idpPort}`,
+    OIDC_CLIENT_ID: 'test-client',
+    OIDC_CLIENT_SECRET: 'test-secret',
+  })
+}, 70_000)
+
+afterAll(() => {
+  idp?.close()
+  server?.stop()
+})
+
+async function driveSsoCallback(client: Client, code: string): Promise<Response> {
+  const initiate = await (
+    await client.post('/api/auth/sign-in/oauth2', { providerId: 'oidc', callbackURL: '/' })
+  ).json()
+  const state = new URL(initiate.url).searchParams.get('state')
+  return client.get(`/api/auth/oauth2/callback/oidc?code=${code}&state=${state}`)
+}
+
+describe('OIDC account linking against a real (faked-IdP) callback', () => {
+  it('links to an existing password account, even though it was never SMTP-verified, when the IdP marks the email verified', async () => {
+    const client = new Client(server)
+    await client.signUp('carol@test.dev', 'Carol')
+    const before = await (await client.get('/api/me')).json()
+
+    const code = 'code-carol'
+    codeToClaims.set(code, { sub: 'oidc-sub-carol', email: 'carol@test.dev', email_verified: true, name: 'Carol' })
+    const callback = await driveSsoCallback(client, code)
+
+    expect(callback.status).toBe(302)
+    const location = new URL(callback.headers.get('location') ?? '', 'http://x')
+    expect(location.searchParams.get('error')).toBeNull() // not an account_not_linked (or any other) error redirect
+
+    const after = await (await client.get('/api/me')).json()
+    expect(after.id).toBe(before.id) // same account, not a second one
+    expect(after.email).toBe('carol@test.dev')
+  })
+
+  it('creates a new account via SSO when no local account exists for the email', async () => {
+    const client = new Client(server)
+    const code = 'code-dave'
+    codeToClaims.set(code, { sub: 'oidc-sub-dave', email: 'dave@test.dev', email_verified: true, name: 'Dave' })
+
+    const callback = await driveSsoCallback(client, code)
+
+    expect(callback.status).toBe(302)
+    const location = new URL(callback.headers.get('location') ?? '', 'http://x')
+    expect(location.searchParams.get('error')).toBeNull()
+
+    const me = await (await client.get('/api/me')).json()
+    expect(me.email).toBe('dave@test.dev')
+  })
+})

--- a/tests/oidcAccountLinking.test.ts
+++ b/tests/oidcAccountLinking.test.ts
@@ -1,5 +1,6 @@
 import { createServer, type Server as HttpServer } from 'node:http'
 import type { AddressInfo } from 'node:net'
+import { generateKeyPairSync, sign as cryptoSign, type KeyObject } from 'node:crypto'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import { Client, startServer, type Server } from './harness.ts'
 
@@ -7,11 +8,12 @@ import { Client, startServer, type Server } from './harness.ts'
  * Drives the real callback leg of an OIDC sign-in against better-auth's
  * actual code (no mocking of doop or better-auth) - only the third-party
  * IdP is faked, which is unavoidable without a real Zitadel/Okta/etc to
- * point at. better-auth's default getUserInfo decodes the id_token JWT via
- * jose's decodeJwt (confirmed in node_modules/better-auth/dist/plugins/
- * generic-oauth/routes.mjs) without verifying its signature, so an
- * unsigned, self-issued token is sufficient here - this is testing doop's
- * account-linking logic, not JWT cryptography.
+ * point at. The fake IdP signs its ID tokens (RS256) and publishes a
+ * jwks_uri, matching what a spec-compliant OIDC discovery document always
+ * includes - so this exercises the same shape of token a real IdP produces,
+ * rather than the unsigned `alg: none` case that better-auth's own
+ * decodeJwt-based getUserInfo (see node_modules/better-auth/dist/plugins/
+ * generic-oauth/routes.mjs) currently accepts either way.
  *
  * This exists to prove server/auth.ts's linkVerifiedOidcEmail: better-auth's
  * own account-linking gate requires the LOCAL user to already be
@@ -21,9 +23,18 @@ import { Client, startServer, type Server } from './harness.ts'
  * test below fails with an "account_not_linked" redirect.
  */
 
-function fakeIdToken(claims: Record<string, unknown>): string {
-  const segment = (obj: unknown) => Buffer.from(JSON.stringify(obj)).toString('base64url')
-  return `${segment({ alg: 'none', typ: 'JWT' })}.${segment(claims)}.`
+const { privateKey, publicKey } = generateKeyPairSync('rsa', { modulusLength: 2048 })
+const jwk = publicKey.export({ format: 'jwk' }) as Record<string, unknown>
+const KID = 'test-key-1'
+
+function base64url(input: Buffer | string): string {
+  return Buffer.from(input).toString('base64url')
+}
+
+function fakeIdToken(claims: Record<string, unknown>, key: KeyObject): string {
+  const headerAndPayload = `${base64url(JSON.stringify({ alg: 'RS256', typ: 'JWT', kid: KID }))}.${base64url(JSON.stringify(claims))}`
+  const signature = cryptoSign('RSA-SHA256', Buffer.from(headerAndPayload), key)
+  return `${headerAndPayload}.${base64url(signature)}`
 }
 
 function startFakeIdp(codeToClaims: Map<string, Record<string, unknown>>): Promise<HttpServer> {
@@ -38,8 +49,14 @@ function startFakeIdp(codeToClaims: Map<string, Record<string, unknown>>): Promi
             issuer: `http://localhost:${port}`,
             authorization_endpoint: `http://localhost:${port}/authorize`,
             token_endpoint: `http://localhost:${port}/token`,
+            jwks_uri: `http://localhost:${port}/jwks`,
           }),
         )
+        return
+      }
+      if (url.pathname === '/jwks') {
+        res.writeHead(200, { 'Content-Type': 'application/json' })
+        res.end(JSON.stringify({ keys: [{ ...jwk, kid: KID, use: 'sig', alg: 'RS256' }] }))
         return
       }
       if (url.pathname === '/token' && req.method === 'POST') {
@@ -54,7 +71,7 @@ function startFakeIdp(codeToClaims: Map<string, Record<string, unknown>>): Promi
               access_token: 'fake-access-token',
               token_type: 'Bearer',
               expires_in: 3600,
-              id_token: fakeIdToken(claims),
+              id_token: fakeIdToken(claims, privateKey),
             }),
           )
         })

--- a/tests/oidcConfig.test.ts
+++ b/tests/oidcConfig.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { loadOidcConfig, oidcPublicConfig } from '../server/auth.ts'
+
+/**
+ * Pure config-parsing/validation, no server spawn needed - same pattern as
+ * tests/publicUrl.test.ts. The HTTP-facing side (GET /api/oidc-config) is
+ * covered separately in tests/oidc.test.ts against a real server.
+ */
+
+const OIDC_VARS = ['OIDC_ISSUER', 'OIDC_CLIENT_ID', 'OIDC_CLIENT_SECRET', 'OIDC_SCOPES', 'OIDC_PROVIDER_NAME'] as const
+const saved: Record<string, string | undefined> = {}
+
+beforeEach(() => {
+  for (const key of OIDC_VARS) {
+    saved[key] = process.env[key]
+    delete process.env[key]
+  }
+})
+
+afterEach(() => {
+  for (const key of OIDC_VARS) {
+    if (saved[key] === undefined) delete process.env[key]
+    else process.env[key] = saved[key]
+  }
+})
+
+function setRequiredOidcEnv(): void {
+  process.env.OIDC_ISSUER = 'https://idp.example.com'
+  process.env.OIDC_CLIENT_ID = 'client-abc'
+  process.env.OIDC_CLIENT_SECRET = 'secret-xyz'
+}
+
+describe('loadOidcConfig', () => {
+  it('returns null when none of the required vars are set', () => {
+    expect(loadOidcConfig()).toBeNull()
+  })
+
+  it.each([
+    { OIDC_ISSUER: 'https://idp.example.com' },
+    { OIDC_CLIENT_ID: 'abc' },
+    { OIDC_ISSUER: 'https://idp.example.com', OIDC_CLIENT_ID: 'abc' },
+    { OIDC_CLIENT_ID: 'abc', OIDC_CLIENT_SECRET: 'shh' },
+  ])('throws when only some required vars are set: %o', (partial) => {
+    Object.assign(process.env, partial)
+    expect(() => loadOidcConfig()).toThrow(/OIDC_ISSUER.*OIDC_CLIENT_ID.*OIDC_CLIENT_SECRET/)
+  })
+
+  it('returns a full config with default scopes and provider name when all three required vars are set', () => {
+    setRequiredOidcEnv()
+
+    expect(loadOidcConfig()).toEqual({
+      issuer: 'https://idp.example.com',
+      clientId: 'client-abc',
+      clientSecret: 'secret-xyz',
+      scopes: ['openid', 'email', 'profile'],
+      providerName: 'SSO',
+    })
+  })
+
+  it('parses comma-separated OIDC_SCOPES', () => {
+    setRequiredOidcEnv()
+    process.env.OIDC_SCOPES = 'openid,email,groups'
+
+    expect(loadOidcConfig()?.scopes).toEqual(['openid', 'email', 'groups'])
+  })
+
+  it('parses space-separated OIDC_SCOPES', () => {
+    setRequiredOidcEnv()
+    process.env.OIDC_SCOPES = 'openid email groups'
+
+    expect(loadOidcConfig()?.scopes).toEqual(['openid', 'email', 'groups'])
+  })
+
+  it('uses OIDC_PROVIDER_NAME as the provider name when set', () => {
+    setRequiredOidcEnv()
+    process.env.OIDC_PROVIDER_NAME = 'Zitadel'
+
+    expect(loadOidcConfig()?.providerName).toBe('Zitadel')
+  })
+})
+
+describe('oidcPublicConfig', () => {
+  it('reports disabled with no other fields when unset', () => {
+    expect(oidcPublicConfig()).toEqual({ enabled: false })
+  })
+
+  it('reports enabled with the display name when configured', () => {
+    setRequiredOidcEnv()
+    process.env.OIDC_PROVIDER_NAME = 'Zitadel'
+
+    expect(oidcPublicConfig()).toEqual({ enabled: true, displayName: 'Zitadel' })
+  })
+
+  it('falls back to "SSO" as the display name when OIDC_PROVIDER_NAME is unset', () => {
+    setRequiredOidcEnv()
+
+    expect(oidcPublicConfig()).toEqual({ enabled: true, displayName: 'SSO' })
+  })
+
+  it('never leaks the client secret', () => {
+    setRequiredOidcEnv()
+
+    expect(JSON.stringify(oidcPublicConfig())).not.toContain('secret-xyz')
+  })
+})


### PR DESCRIPTION
Closes #46.

Adds env-gated SSO against an external OIDC provider (Zitadel, Okta, Authentik, Keycloak, etc.), additive alongside the existing email/password login - no behavior change for instances that don't configure it.

## What's included

- **`server/auth.ts`**: `genericOAuth` plugin wired in when `OIDC_ISSUER`, `OIDC_CLIENT_ID`, and `OIDC_CLIENT_SECRET` are all set; the server refuses to boot on a partial set (treated as a misconfiguration, not a valid state).
- **Account linking that actually works on a self-hosted instance with no SMTP**: better-auth's own linking gate requires the *local* user row to already be `emailVerified` before it'll link an OIDC sign-in to an existing account - unreachable on an SMTP-less deploy, since no local account can ever verify itself without a mailer. That's exactly the case an operator adding SSO is usually trying to serve (migrating existing users), so `linkVerifiedOidcEmail` (used as `mapProfileToUser`) flips the local flag first when the IdP has already proven ownership, then lets better-auth's own default linking logic do the rest.
- **`GET /api/oidc-config`**: the public shape (`{enabled, displayName}`, never the secret) the static client bundle needs to know whether SSO is configured for a given deploy.
- **Login page**: a conditional SSO button, error handling for both the initiating request and the post-redirect callback (`errorCallbackURL` + a mount-time `?error=` handler so a failed callback doesn't strand the user outside the SPA), and a same-origin check on the `redirect_to`/`redirect_uri` resume target (this also fixed a pre-existing open-redirect gap in the same pattern used by the interrupted-MCP-flow resume logic).
- **`.env.example` / `README.md`**: documents the five `OIDC_*` vars and the linking behavior.
- **Tests**: config parsing/validation, the `/api/oidc-config` endpoint, the boot-time refusal, and an end-to-end account-linking proof driven against a fake local OIDC IdP (unsigned JWT, matching better-auth's own unverified default for generic OIDC providers) - this one exercises the real callback flow end to end, not just the config wiring.

## Design doc

Full design/rationale in [`docs/superpowers/specs/2026-08-31-oidc-sso-design.md`](docs/superpowers/specs/2026-08-31-oidc-sso-design.md), written up front and referenced throughout.

## Test plan

- [x] `bun run typecheck`
- [x] `bun run test` (full suite green)
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] `bun run build`
- [x] Manual smoke test in a real browser: SSO button hidden when unconfigured, renders correctly when configured, error path surfaces cleanly on a failed callback, signup-mode wording correct.