### PR TITLE
fix(agent): only a connected model account lifts the resident meter

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -76,8 +76,9 @@
 # Free-tier meter: resident tasks each account may start (default 0 — the
 # Doop Agent runs on whatever model account the user connects, their ChatGPT
 # subscription or OpenAI key, from the first task). Set it above 0 to grant
-# free tasks on the server's key. Users who connect their own agent via MCP
-# are never metered.
+# free tasks on the server's key. Only a connected model account lifts the
+# meter — an MCP agent of your own runs on your model already and does not
+# entitle resident runs to the server's key.
 #RESIDENT_TASK_LIMIT=0
 # Model overrides for the resident team and the guideline distiller.
 #DOOP_AGENT_MODEL=

--- a/README.md
+++ b/README.md
@@ -203,11 +203,12 @@ own agent over MCP.
 | `DOOP_DISTILL_MODEL`            | `claude-haiku-4-5-20251001` | Model for the guideline distiller                                                    |
 
 `RESIDENT_TASK_LIMIT` is the free-tier meter. By default it is `0`: the Doop Agent only runs once
-the user connects a model account (their ChatGPT subscription or an OpenAI key) or their own MCP
-agent — connected users are never metered. Set it above 0 to grant that many free tasks on the
-server's key; everything that triggers resident work counts, including feedback and retries. There
-is no "unlimited" value: self-hosting with your own key, set it to a large number, since you're
-paying Anthropic directly either way.
+the user connects a model account (their ChatGPT subscription or an OpenAI key) — a connected
+account is never metered. Connecting your own MCP agent does not lift the meter: it runs on your
+model when _it_ designs, but resident tasks still bill a credential. Set the limit above 0 to
+grant that many free tasks on the server's key; everything that triggers resident work counts,
+including feedback and retries. There is no "unlimited" value: self-hosting with your own key, set
+it to a large number, since you're paying Anthropic directly either way.
 
 ## Accounts
 

--- a/server/allowance.ts
+++ b/server/allowance.ts
@@ -9,12 +9,14 @@ import type { AccountKind } from './modelAccounts.ts'
  * Free-tier metering for the resident design team. Anything that triggers
  * resident work consumes one of RESIDENT_TASK_LIMIT free tasks: a board card,
  * an element comment that @mentions a resident, feedback on a task, and every
- * retry. Two things lift the meter entirely: connecting your own MCP agent
- * (Claude Code, Codex — your subscription, your model, driving the canvas
- * from outside), or connecting a model account so the Doop Agent itself runs
- * on your ChatGPT subscription or OpenAI key. Both take effect immediately —
- * a connected user is never metered again, and their remaining free tasks
- * simply stop being relevant.
+ * retry. Connecting a model account lifts the meter entirely — the Doop Agent
+ * itself then runs on the user's ChatGPT subscription or OpenAI key,
+ * immediately, without spending remaining free tasks first.
+ *
+ * Connecting an MCP agent (Claude Code, Codex) does NOT lift it: those
+ * sessions run on the user's own model already, but resident tasks still
+ * bill a credential, and an OAuth token ever issued must not turn into
+ * unlimited runs on the server's key.
  *
  * The default is 0: the Doop Agent runs on an account the user connects, from
  * the first task. Self-hosters footing their own model bill can grant an
@@ -77,11 +79,10 @@ export async function getAllowance(userId: string): Promise<Allowance> {
 }
 
 /** Spend one resident task. ok:false = the free tier is used up and the user
- *  has neither connected an agent of their own nor a model account for the
- *  Doop Agent to run on. */
+ *  has no model account for the Doop Agent to run on. */
 export async function consumeResidentTask(userId: string): Promise<Allowance & { ok: boolean }> {
   const current = await getAllowance(userId)
-  if (current.connected || current.byoModel) return { ...current, ok: true }
+  if (current.byoModel) return { ...current, ok: true }
   if (current.used >= current.limit) return { ...current, ok: false }
   /* guarded upsert: concurrent requests can never push `used` past the limit */
   const rows = await db

--- a/server/resident.ts
+++ b/server/resident.ts
@@ -1,6 +1,7 @@
 import type Anthropic from '@anthropic-ai/sdk'
 import { store } from './store.ts'
 import { ModelAuthError, pickModel } from './agentModel.ts'
+import { RESIDENT_TASK_LIMIT } from './allowance.ts'
 import * as actions from './actions.ts'
 import { inspectFrame, renderFrame } from './screenshot.ts'
 import { AGENT_ROLES, DEFAULT_ROLE_ID, roleById, roleByAgentName, roleName } from '../shared/agents.ts'
@@ -198,6 +199,19 @@ async function runAgent(canvasId: string, agentName: string, stalled: Set<string
   const canvasOwner = store.getCanvas(canvasId)?.ownerId
   const model = await pickModel(payer || canvasOwner)
   if (!model) {
+    stalled.add(payer)
+    return 'no-model'
+  }
+  /* With no free tier, the server's key never pays for resident work. Work
+     can still reach this point without a payable account — queued before the
+     account was disconnected, or before metering tightened — and it must
+     fail visibly with a fix, not crash on a key that was never meant to pay. */
+  if (!model.userId && RESIDENT_TASK_LIMIT <= 0) {
+    const reason =
+      'The Doop Agent needs a connected account — connect your ChatGPT subscription or OpenAI key in Settings, then retry.'
+    for (const f of actions.takeFeedbackFor(canvasId, role.name, payer)) actions.failTaskFeedback(f.id, reason)
+    for (const c of actions.takeAgentCommentsFor(canvasId, role.name, payer)) actions.failComment(c.id, reason)
+    for (const c of actions.takeQueuedCardsFor(canvasId, role.name, payer)) actions.failCard(canvasId, c.id, reason)
     stalled.add(payer)
     return 'no-model'
   }

--- a/src/components/PromptBar.tsx
+++ b/src/components/PromptBar.tsx
@@ -111,17 +111,16 @@ export function PromptBar({ canvasId }: { canvasId: string }) {
   async function submit(prompt: string) {
     const clean = prompt.trim()
     if (!clean || busy) return
-    /* known-doomed send: no free tasks and nothing connected. Open the wall
+    /* known-doomed send: no free tasks and no model account. Open the wall
        up front instead of uploading attachments only to 403 — but confirm
-       against the server first, since connecting an MCP agent happens
-       out-of-band and the cached allowance can be stale. The server enforces
-       either way, so an unreachable check just falls through. Text stays in
-       place. */
-    if (allowance && !allowance.connected && !allowance.byoModel && allowance.used >= allowance.limit) {
+       against the server first, since the cached allowance can be stale
+       (an account connected in another tab). The server enforces either
+       way, so an unreachable check just falls through. Text stays in place. */
+    if (allowance && !allowance.byoModel && allowance.used >= allowance.limit) {
       setBusy(true)
       const fresh = await api.agentAllowance().catch(() => null)
       setBusy(false)
-      if (fresh && !fresh.connected && !fresh.byoModel && fresh.used >= fresh.limit) {
+      if (fresh && !fresh.byoModel && fresh.used >= fresh.limit) {
         useStore.getState().setLimitWall(true)
         return
       }

--- a/src/components/TeamAllowance.tsx
+++ b/src/components/TeamAllowance.tsx
@@ -6,7 +6,6 @@ import { useStore } from '../lib/store'
 import { navigate } from '../App'
 import { ConnectBody, AgentArrival } from './ConnectModal'
 import { Button } from './ui/button'
-import { Collapsible, CollapsibleContent, CollapsibleTrigger } from './ui/collapsible'
 import { Modal, ModalActions, ModalLede, ModalTitle } from './ui/modal'
 import { cn } from '@/lib/utils'
 
@@ -36,7 +35,7 @@ export function isResidentLimit(err: unknown): boolean {
 }
 
 export function MeterLine({ allowance }: { allowance: Allowance | null }) {
-  if (!allowance || allowance.connected) return null
+  if (!allowance) return null
   /* their own account is behind the agent now — say so instead of counting,
      and say it even where there is no free tier to count (limit 0) */
   if (allowance.byoModel) {
@@ -66,7 +65,6 @@ export function MeterLine({ allowance }: { allowance: Allowance | null }) {
 }
 
 export function LimitWall({ canvasId, onClose }: { canvasId: string; onClose: () => void }) {
-  const [showMcp, setShowMcp] = useState(false)
   const { allowance } = useAllowance()
   /* "used up" only fits a server that granted free tasks in the first place;
      everywhere else (the default, limit 0) this wall IS the getting-started
@@ -109,17 +107,17 @@ export function LimitWall({ canvasId, onClose }: { canvasId: string; onClose: ()
           </Button>
         </ModalActions>
 
-        <Collapsible open={showMcp} onOpenChange={setShowMcp}>
-          <CollapsibleTrigger className="mt-4 text-[12.5px] text-ink-faint hover:text-ink">
+        {/* the second path stays fully visible — a divider, not a disclosure:
+            people who live in Claude Code/Codex should see it without hunting */}
+        <div className="mt-5 border-t border-line pt-4">
+          <p className="text-[12.5px] font-semibold text-ink">
             Or drive the canvas from your own agent (Claude Code, Codex)
-          </CollapsibleTrigger>
-          <CollapsibleContent>
-            <ConnectBody canvasId={canvasId} />
-            <ModalActions>
-              <AgentArrival />
-            </ModalActions>
-          </CollapsibleContent>
-        </Collapsible>
+          </p>
+          <ConnectBody canvasId={canvasId} />
+          <ModalActions>
+            <AgentArrival />
+          </ModalActions>
+        </div>
 
         <ModalActions>
           <Button onClick={onClose}>Close</Button>

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -52,16 +52,15 @@ export function Settings() {
     if (!openCanvasTab(canvas.id, canvas.name)) navigate(`/c/${canvas.id}`)
   }
 
-  const meter =
-    allowance && !allowance.connected
-      ? allowance.byoModel
-        ? `Running on your ${allowance.byoKind === 'openai-key' ? 'OpenAI key' : 'ChatGPT subscription'}.`
-        : allowance.limit <= 0
-          ? 'No free tasks on this server — connect an account to use the Doop Agent.'
-          : left === 0
-            ? 'Your free tasks are used up.'
-            : `${left} of ${allowance.limit} free task${allowance.limit === 1 ? '' : 's'} left.`
-      : null
+  const meter = allowance
+    ? allowance.byoModel
+      ? `Running on your ${allowance.byoKind === 'openai-key' ? 'OpenAI key' : 'ChatGPT subscription'}.`
+      : allowance.limit <= 0
+        ? 'No free tasks on this server — connect an account to use the Doop Agent.'
+        : left === 0
+          ? 'Your free tasks are used up.'
+          : `${left} of ${allowance.limit} free task${allowance.limit === 1 ? '' : 's'} left.`
+    : null
 
   return (
     <DashLayout>


### PR DESCRIPTION
Connecting an MCP agent no longer bypasses the resident task meter — only a connected model account (ChatGPT subscription or OpenAI key) does, since that's what actually shifts the cost off the server key.

Ported from the upstream private repo (upstream #96).

🤖 Generated with [Claude Code](https://claude.com/claude-code)