### PR TITLE
refactor(desktop): migrate traffic-light placement off the deprecated cocoa crate

### DIFF
--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -256,12 +256,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "block"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
-
-[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -472,35 +466,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cocoa"
-version = "0.26.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad36507aeb7e16159dfe68db81ccc27571c3ccd4b76fb2fb72fc59e7a4b1b64c"
-dependencies = [
- "bitflags 2.13.1",
- "block",
- "cocoa-foundation",
- "core-foundation",
- "core-graphics 0.24.0",
- "foreign-types",
- "libc",
- "objc",
-]
-
-[[package]]
-name = "cocoa-foundation"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81411967c50ee9a1fc11365f8c585f863a22a9697c89239c452292c40ba79b0d"
-dependencies = [
- "bitflags 2.13.1",
- "block",
- "core-foundation",
- "core-graphics-types",
- "objc",
-]
-
-[[package]]
 name = "combine"
 version = "4.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -544,19 +509,6 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
-
-[[package]]
-name = "core-graphics"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa95a34622365fa5bbf40b20b75dba8dfa8c94c734aea8ac9a5ca38af14316f1"
-dependencies = [
- "bitflags 2.13.1",
- "core-foundation",
- "core-graphics-types",
- "foreign-types",
- "libc",
-]
 
 [[package]]
 name = "core-graphics"
@@ -866,8 +818,7 @@ dependencies = [
 name = "doop-desktop"
 version = "0.1.2"
 dependencies = [
- "cocoa",
- "objc",
+ "objc2-app-kit",
  "tauri",
  "tauri-build",
  "tauri-plugin-opener",
@@ -2068,15 +2019,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
 
 [[package]]
-name = "malloc_buf"
-version = "0.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "markup5ever"
 version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2228,15 +2170,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "objc"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
-dependencies = [
- "malloc_buf",
-]
-
-[[package]]
 name = "objc2"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2254,9 +2187,17 @@ checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
  "bitflags 2.13.1",
  "block2",
+ "libc",
  "objc2",
+ "objc2-cloud-kit",
+ "objc2-core-data",
  "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-core-image",
+ "objc2-core-text",
+ "objc2-core-video",
  "objc2-foundation",
+ "objc2-quartz-core",
 ]
 
 [[package]]
@@ -2276,6 +2217,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa"
 dependencies = [
+ "bitflags 2.13.1",
  "objc2",
  "objc2-foundation",
 ]
@@ -2334,6 +2276,19 @@ dependencies = [
  "objc2",
  "objc2-core-foundation",
  "objc2-core-graphics",
+]
+
+[[package]]
+name = "objc2-core-video"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d425caf1df73233f29fd8a5c3e5edbc30d2d4307870f802d18f00d83dc5141a6"
+dependencies = [
+ "bitflags 2.13.1",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-io-surface",
 ]
 
 [[package]]
@@ -3408,7 +3363,7 @@ dependencies = [
  "bitflags 2.13.1",
  "block2",
  "core-foundation",
- "core-graphics 0.25.0",
+ "core-graphics",
  "crossbeam-channel",
  "dbus",
  "dispatch2",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -14,8 +14,7 @@ tauri-plugin-opener = "2"
 # Repositioning the traffic lights over the web app's tab strip (main.rs);
 # AppKit resets them on window events, so the shell moves them itself.
 [target.'cfg(target_os = "macos")'.dependencies]
-cocoa = "0.26"
-objc = "0.2"
+objc2-app-kit = { version = "0.3", features = ["NSButton", "NSControl", "NSResponder", "NSView", "NSWindow"] }
 
 [profile.release]
 strip = true

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -49,33 +49,38 @@ const TRAFFIC_LIGHTS: (f64, f64) = (13.0, 21.0);
 /// shell puts them back after every such event.
 #[cfg(target_os = "macos")]
 fn place_traffic_lights(ns_window_ptr: *mut std::ffi::c_void) {
-    use cocoa::appkit::{NSView, NSWindow, NSWindowButton};
-    use cocoa::base::id;
-    use cocoa::foundation::NSRect;
-    use objc::{msg_send, sel, sel_impl};
+    use objc2_app_kit::{NSWindow, NSWindowButton};
 
-    let ns_window = ns_window_ptr as id;
+    // SAFETY: Tauri hands out a live NSWindow pointer, and window events are
+    // delivered on the main thread — the only place AppKit may be touched.
     unsafe {
-        let close = ns_window.standardWindowButton_(NSWindowButton::NSWindowCloseButton);
-        let mini = ns_window.standardWindowButton_(NSWindowButton::NSWindowMiniaturizeButton);
-        let zoom = ns_window.standardWindowButton_(NSWindowButton::NSWindowZoomButton);
-        if close.is_null() || mini.is_null() || zoom.is_null() {
+        let ns_window = &*ns_window_ptr.cast::<NSWindow>();
+        let (Some(close), Some(mini), Some(zoom)) = (
+            ns_window.standardWindowButton(NSWindowButton::CloseButton),
+            ns_window.standardWindowButton(NSWindowButton::MiniaturizeButton),
+            ns_window.standardWindowButton(NSWindowButton::ZoomButton),
+        ) else {
             return;
-        }
+        };
+        let (Some(container), Some(content)) = (
+            close.superview().and_then(|v| v.superview()),
+            ns_window.contentView(),
+        ) else {
+            return;
+        };
         // The buttons live in a title-bar container view anchored to the top;
         // grow it so the buttons can sit lower, then move each button.
-        let container = close.superview().superview();
-        let button = NSView::frame(close);
+        let button = close.frame();
         let bar_height = button.size.height + TRAFFIC_LIGHTS.1;
-        let mut container_rect = NSView::frame(container);
-        container_rect.origin.y = NSView::frame(ns_window.contentView()).size.height - bar_height;
+        let mut container_rect = container.frame();
+        container_rect.origin.y = content.frame().size.height - bar_height;
         container_rect.size.height = bar_height;
-        let _: () = msg_send![container, setFrame: container_rect];
-        let gap = NSView::frame(mini).origin.x - button.origin.x;
+        container.setFrame(container_rect);
+        let gap = mini.frame().origin.x - button.origin.x;
         for (i, b) in [close, mini, zoom].into_iter().enumerate() {
-            let mut rect: NSRect = NSView::frame(b);
-            rect.origin.x = TRAFFIC_LIGHTS.0 + i as f64 * gap;
-            b.setFrameOrigin(rect.origin);
+            let mut origin = b.frame().origin;
+            origin.x = TRAFFIC_LIGHTS.0 + i as f64 * gap;
+            b.setFrameOrigin(origin);
         }
     }
 }


### PR DESCRIPTION
The macOS traffic-light button placement moves from the deprecated `cocoa` crate to `objc2`, keeping the Tauri shell building against current crates.

Ported from the upstream private repo (upstream #97).

🤖 Generated with [Claude Code](https://claude.com/claude-code)