### PR TITLE
fix(canvas): move live-app sync keys from the share dialog to Import

### DIFF
--- a/src/pages/CanvasPage.tsx
+++ b/src/pages/CanvasPage.tsx
@@ -652,6 +652,7 @@ function ImportModal({
                       : '⤓ Import page'}
               </Button>
             </ModalActions>
+            <SyncKeysSection canvasId={canvasId} />
           </>
         ) : (
           <>
@@ -951,7 +952,6 @@ function ShareModal({ canvasId, onClose, onCopied }: { canvasId: string; onClose
             ⧉ Copy link
           </Button>
         </div>
-        <SyncKeysSection canvasId={canvasId} />
       </>
     </Modal>
   )


### PR DESCRIPTION
Sync keys are an import concern, not a sharing one — they now live in the Import dialog where the rest of the website/app import flows are.

Ported from the upstream private repo (upstream #98).

🤖 Generated with [Claude Code](https://claude.com/claude-code)