### PR TITLE
feat(agent): design-brief inspiration retrieval — style recipes + live refero search

### DIFF
--- a/server/guide.ts
+++ b/server/guide.ts
@@ -4,6 +4,7 @@
  */
 
 import { AGENT_ROLES } from '../shared/agents.ts'
+import { STYLE_RECIPE_MENU } from './recipes.ts'
 
 export const GUIDE_TOPICS = ['doop-instructions'] as const
 
@@ -31,6 +32,39 @@ export const DESIGN_QUALITY = `- Commit to ONE clear aesthetic direction per fra
   between them.
 - Realistic content everywhere. No lorem ipsum, no "Your text here". When placeholder
   content needs a design tool as an example, it is Doop — never a competitor.`
+
+/** The brief-first ritual with its inspiration-retrieval mandate. Shared by the
+ *  MCP guide and the resident system prompt (both toolsets expose
+ *  get_style_recipe, search_inspiration, set_status and save_decision) so the
+ *  ritual cannot drift. */
+export const DESIGN_BRIEF = `Before creating frames on a canvas whose style is not already established, commit to a
+brief. It is part of the deliverable, not private scratch work:
+
+1. **Retrieve inspiration first.** Scan the recipe menu below for your design's
+   category and fetch the closest match with get_style_recipe (fetching two and
+   picking the better fit beats guessing). A recipe is a starting point you ADAPT —
+   keep its logic (ground, accent discipline, type moves) and swap the specifics your
+   brief needs; copying it verbatim makes every canvas look the same. A near-miss
+   category still transfers: an appetite recipe can drive any bold consumer page.
+   When no recipe is even a near miss — or you want live exemplars beside one —
+   call search_inspiration with the category plus page type ("law firm landing
+   page"): you SEE real curated pages with their mood line, palette and fonts, and
+   distill your own direction from them.
+2. **Write the brief**: mood candidates → the mood chosen (not your first instinct,
+   and say why) → palette with roles (5–6 hexes) → type (faces, weights, scale) →
+   one-line direction. NAME the recipe you adapted or the search_inspiration
+   exemplars you distilled from — or state that none fit and the brief derives from
+   the design-quality principles alone.
+3. **Post it.** Summarize in set_status ("Designing grocery landing — candlelit mood,
+   via oatside-soft-shelf") and persist the full brief with save_decision so humans
+   and later agents see what you committed to.
+
+Skip the brief only when the canvas already dictates the style — established frames,
+style guides or pinned references — or when the human handed you a complete design
+system. Then those are the brief; follow them.
+
+Recipe menu (fetch full recipes with get_style_recipe):
+${STYLE_RECIPE_MENU}`
 
 export const DOOP_GUIDE = `# Doop Agent Guide
 
@@ -106,19 +140,7 @@ humans watching lose work they may have been reacting to.
 
 ## Design brief — before your first frame
 
-Before creating frames on a canvas whose style is not already established, commit to a
-brief. It is part of the deliverable, not private scratch work:
-
-1. **Write the brief**: mood candidates → the mood chosen (not your first instinct, and
-   say why) → palette with roles (5–6 hexes) → type (faces, weights, scale) → one-line
-   direction, derived from the design-quality principles below.
-2. **Post it.** Summarize in set_status ("Designing grocery landing — candlelit mood")
-   and persist the full brief with save_decision so humans and later agents see what
-   you committed to.
-
-Skip the brief only when the canvas already dictates the style — established frames,
-style guides or pinned references — or when the human handed you a complete design
-system. Then those are the brief; follow them.
+${DESIGN_BRIEF}
 
 ## Streaming — how to write designs
 
@@ -245,6 +267,9 @@ commit to directions, then deliver a choice:
   rhythm, radii, shadows, patterns, backgrounds, component styling, section layout.
   "Direction B — further out": same product, same real copy and facts, but freer —
   reinterpret the palette and push the aesthetic somewhere genuinely different.
+  Direction B must NOT be invented from vibes: retrieve category inspiration —
+  get_style_recipe for the closest recipe, search_inspiration for live exemplars —
+  adapt it, and name it in the redesign doc so the direction is traceable.
 - Deliver TWO new frames side by side, named "<source> — A (on-brand)" and
   "<source> — B (departure)", each executing its direction precisely; screenshot both.
   In both: keep the source's real copy and product facts, restructure sections when it

--- a/server/inspiration.ts
+++ b/server/inspiration.ts
@@ -1,0 +1,82 @@
+/**
+ * Live design inspiration for agents (roadmap 20): search the Refero Styles
+ * gallery (styles.refero.design) by category and get back real, curated
+ * landing pages WITH visual thumbnails plus pre-distilled style facts — a
+ * north-star mood line, a named palette, and the fonts in use.
+ *
+ * Powers the search_inspiration tool in mcp.ts and resident.ts. Keyless, same
+ * API the validated scripts/refero-extract.ts pipeline uses. Results are
+ * INSPIRATION to look at and adapt in a brief — never imagery to embed in
+ * frames (the screenshots are other companies' copyrighted pages).
+ */
+
+const REFERO_ENDPOINT = 'https://styles.refero.design/api/styles/search'
+const UA = { 'user-agent': 'Mozilla/5.0 (compatible; doop-design-agent)' }
+const FETCH_TIMEOUT_MS = 15_000
+
+export interface InspirationResult {
+  site: string
+  /** The live site the style was captured from. */
+  source_url: string
+  /** Refero's detail page for the capture. */
+  refero_url: string
+  /** Pre-distilled one-line mood direction, e.g. "Editorial fintech on warm marble". */
+  north_star: string | null
+  color_scheme: string | null
+  palette: { name: string; hex: string }[]
+  fonts: string[]
+  /** Small (~800px) jpg preview used for the visual thumbnail block. */
+  thumb_url: string
+}
+
+interface ReferoStyle {
+  id: string
+  url: string
+  siteName: string
+  screenshotUrl: string | null
+  thumbnailUrl: string | null
+  previewVideoPosterUrl: string | null
+  previewVideoDetailPosterUrl: string | null
+  colorScheme: string | null
+  colors: { name: string; hex: string }[] | null
+  fonts: string[] | null
+  northStar: string | null
+}
+
+export async function searchInspiration(query: string, count = 4): Promise<InspirationResult[]> {
+  const take = Math.max(1, Math.min(count, 6))
+  const res = await fetch(`${REFERO_ENDPOINT}?q=${encodeURIComponent(query)}`, {
+    headers: UA,
+    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+  })
+  if (!res.ok) throw new Error(`inspiration search failed: HTTP ${res.status}`)
+  const body = (await res.json()) as { styles?: ReferoStyle[] }
+  return (body.styles ?? [])
+    .map((s) => ({ style: s, thumb: s.thumbnailUrl ?? s.previewVideoPosterUrl ?? s.screenshotUrl }))
+    .filter((x): x is { style: ReferoStyle; thumb: string } => Boolean(x.thumb))
+    .slice(0, take)
+    .map(({ style: s, thumb }) => ({
+      site: s.siteName,
+      source_url: s.url,
+      refero_url: `https://styles.refero.design/style/${s.id}`,
+      north_star: s.northStar,
+      color_scheme: s.colorScheme,
+      palette: s.colors ?? [],
+      fonts: s.fonts ?? [],
+      thumb_url: thumb,
+    }))
+}
+
+export const INSPIRATION_USAGE_NOTE =
+  'These are real pages by other companies: study them, then ADAPT — steal the logic (ground/accent discipline, type contrast, density, mood), never the identity. Do not embed these screenshots or copy a palette hex-for-hex into a frame; distill what fits your brief, name the exemplar(s) in it, and diverge on the specifics.'
+
+export function describeInspiration(r: InspirationResult, index: number): string {
+  const palette = r.palette.length > 0 ? r.palette.map((c) => `${c.hex} (${c.name})`).join(', ') : 'n/a'
+  const facts = [
+    r.north_star ? `north star: "${r.north_star}"` : null,
+    `palette: ${palette}`,
+    r.fonts.length > 0 ? `fonts: ${r.fonts.join(', ')}` : null,
+    r.color_scheme ? `scheme: ${r.color_scheme}` : null,
+  ].filter(Boolean)
+  return `#${index + 1} — ${r.site} (${r.source_url})\n${facts.join('\n')}`
+}

--- a/server/mcp.ts
+++ b/server/mcp.ts
@@ -10,6 +10,8 @@ import { auth, getUserName, isBanned, PUBLIC_ORIGIN } from './auth.ts'
 import { capture, captureThrottled } from './analytics.ts'
 import { renderFrame } from './screenshot.ts'
 import { DOOP_GUIDE, GUIDE_TOPICS } from './guide.ts'
+import { getStyleRecipe, STYLE_RECIPES } from './recipes.ts'
+import { describeInspiration, INSPIRATION_USAGE_NOTE, searchInspiration } from './inspiration.ts'
 import { ESCAPED_HTML_NOTE, looksEscapedHtml } from './escapedHtml.ts'
 import { describeSyncFlow, getSyncFlow } from './ingest.ts'
 import * as assets from './assets.ts'
@@ -207,6 +209,74 @@ export function buildMcpServer(owner?: string, ownerId?: string): McpServer {
       },
     },
     async () => text(DOOP_GUIDE),
+  )
+
+  server.registerTool(
+    'get_style_recipe',
+    {
+      title: 'Get style recipe',
+      description:
+        "Fetch one of the built-in style recipes — complete, executable style directions (mood north star, palette with roles, type pairing, signature moves) distilled from real gallery exemplars. The agent guide's design-brief ritual lists the menu; fetch the closest match for your category before writing a brief, then ADAPT it to the brand rather than copying it verbatim.",
+      inputSchema: {
+        name: z
+          .enum(STYLE_RECIPES.map((r) => r.name) as [string, ...string[]])
+          .describe('Recipe slug from the menu in the agent guide'),
+        canvas_id: z.string().optional().describe('The canvas you are designing on (lets human feedback reach you)'),
+        agent_name: agentName,
+      },
+    },
+    async ({ name, canvas_id, agent_name }) => {
+      const recipe = getStyleRecipe(name)
+      if (!recipe) return err(`no recipe named "${name}"`)
+      const result = text({ ok: true, name: recipe.name, category: recipe.category, recipe: recipe.markdown })
+      return canvas_id ? withFeedback(result, canvas_id, actorFrom(agent_name)) : result
+    },
+  )
+
+  server.registerTool(
+    'search_inspiration',
+    {
+      title: 'Search design inspiration',
+      description:
+        'Search a curated gallery of real, well-designed live websites by category and SEE thumbnails of each, with pre-distilled style facts (one-line mood north star, named palette, fonts). Use it while writing a design brief — especially for landing pages — when no built-in recipe fits the category, or alongside one: query the category plus the page type ("law firm landing page", "dark fintech dashboard"). Adapt what you see into the brief and name the exemplars; never embed these screenshots or copy an identity.',
+      inputSchema: {
+        query: z.string().describe('Category + page type, e.g. "grocery delivery landing page"'),
+        count: z.number().min(1).max(6).optional().describe('Exemplars to return, default 4'),
+        canvas_id: z.string().optional().describe('The canvas you are designing on (lets human feedback reach you)'),
+        agent_name: agentName,
+      },
+    },
+    async ({ query, count, canvas_id, agent_name }) => {
+      const now = Date.now()
+      const limitKey = ownerId ?? agent_name
+      const hits = (searchHits.get(limitKey) ?? []).filter((t) => now - t < 60_000)
+      if (hits.length >= SEARCHES_PER_MIN) return err('search rate limit — wait a minute')
+      hits.push(now)
+      searchHits.set(limitKey, hits)
+      try {
+        const results = await searchInspiration(query, count ?? 4)
+        if (results.length === 0)
+          return text({ ok: true, results: [], note: `No inspiration for "${query}" — try a broader category.` })
+        const thumbs = await Promise.all(results.map((r) => imageSearch.fetchThumb(r.thumb_url)))
+        type ResultBlock = { type: 'text'; text: string } | { type: 'image'; data: string; mimeType: string }
+        const content: ResultBlock[] = [
+          {
+            type: 'text' as const,
+            text: `${results.length} exemplar(s) for "${query}" — study each thumbnail with its style facts:`,
+          },
+        ]
+        results.forEach((r, i) => {
+          const thumb = thumbs[i]
+          if (thumb) content.push({ type: 'image' as const, data: thumb.data, mimeType: thumb.mime })
+          content.push({ type: 'text' as const, text: describeInspiration(r, i) })
+        })
+        content.push({ type: 'text' as const, text: INSPIRATION_USAGE_NOTE })
+        const result = { content }
+        return canvas_id ? withFeedback(result, canvas_id, actorFrom(agent_name)) : result
+      } catch (e) {
+        return err(e instanceof Error ? e.message : 'inspiration search failed')
+      }
+    },
   )
 
   server.registerTool(

--- a/server/recipes.ts
+++ b/server/recipes.ts
@@ -1,0 +1,210 @@
+/**
+ * Built-in style recipes — the interim inspiration library (roadmap 12b).
+ *
+ * Distilled from real gallery exemplars during the inspo-recipe experiment;
+ * each is a complete, executable style direction an agent adapts to its brief.
+ * This static library is the v0 backend for get_style_recipe; the Phase 5
+ * inspiration tools (search_inspiration over a curated corpus) replace the
+ * plumbing without changing the workflow.
+ */
+
+export interface StyleRecipe {
+  /** slug agents pass to get_style_recipe */
+  name: string
+  title: string
+  /** the design category the recipe was distilled for */
+  category: string
+  /** shown in the guide's recipe menu — enough to decide whether to fetch */
+  oneLiner: string
+  markdown: string
+}
+
+export const STYLE_RECIPES: StyleRecipe[] = [
+  {
+    name: 'crav-loud-appetite',
+    title: 'CRAV — loud appetite',
+    category: 'food & drink, consumer brands with attitude',
+    oneLiner: 'Loud retro food branding: chunky display type, burgundy–mustard–lettuce palette, appetite over polish',
+    markdown: `# CRAV — loud appetite
+
+North star: a hand-painted diner sign, not a startup. The page should feel hungry —
+saturated food colors, type with real weight, zero corporate restraint.
+
+## Palette (derive tints from these, no outsiders)
+- Ground: deep burgundy #5C1A1B — walls of the diner
+- Accent: mustard #E3A72F — the squeeze bottle; CTAs and highlights
+- Support: lettuce green #7BA05B — freshness cues, badges, small accents
+- Paper: warm cream #F6EEDD — text panels, cards
+- Ink: near-black espresso #241512 — body text on cream
+
+## Type
+- Display: Modak (Google Fonts) — huge, single words or short phrases only; it
+  collapses at paragraph scale.
+- Alt display / subheads: Mouse Memoirs — condensed, friendly shout.
+- Body: a plain grotesque (Archivo) at normal weight; the display faces do ALL the
+  personality work.
+- Scale contrast is the move: hero display 6–8× body size.
+
+## Moves
+- Full-bleed color blocks per section; alternate burgundy / cream / mustard grounds.
+- Product photography or food illustration big and cropped, never floating in white.
+- Sticker/badge shapes (rotated pills, starbursts drawn as CSS/SVG) for prices and
+  claims — ASCII/entities only, no emoji, no decorative glyphs that risk tofu.
+- Buttons: fat, pill or slab, ink outline + hard offset shadow; hover shifts the fill.
+
+## Fits / avoid
+Fits: restaurants, snacks, beverages, bold DTC food brands. Avoid: anything that
+needs to read premium-quiet or enterprise-trustworthy.`,
+  },
+  {
+    name: 'oatside-soft-shelf',
+    title: 'Oatside — soft shelf',
+    category: 'food & drink, friendly consumer packaged goods',
+    oneLiner: 'Cream-grounded CPG warmth: rounded serif display, milky palette, illustration-led charm',
+    markdown: `# Oatside — soft shelf
+
+North star: the friendliest carton on the supermarket shelf. Everything soft:
+rounded type, milky colors, generous air, small jokes in the microcopy.
+
+## Palette
+- Ground: oat cream #F3E9D7 — the whole page sits on it; white only inside cards
+- Ink: roasted brown #3B2B20 — headings and body, never pure black
+- Accent: caramel #C6803B — CTAs, links, highlights
+- Support: milk-coffee tan #D9BE9C and a muted sky #A8C3CE for variety blocks
+
+## Type
+- Display: Fraunces (Google Fonts), SOFT optical sizing, medium-to-black weights —
+  rounded, slightly retro serif presence.
+- Body: a warm humanist sans (Nunito Sans) — round terminals keep the tone.
+- Sentence case everywhere; headlines conversational ("Made for mornings"), not
+  feature-speak.
+
+## Moves
+- Sections separated by background tone shifts within the cream family, not rules.
+- Chunky rounded corners (16–24px) on cards, images, buttons — one radius, applied
+  everywhere.
+- Product/mascot illustration beats photography; if photographic, warm-toned and
+  prop-styled, never stocky office scenes.
+- Small delight details: wavy SVG section dividers, a rotating badge, underline
+  squiggles on key words.
+
+## Fits / avoid
+Fits: CPG, cafés, breakfast/snack brands, anything cozy-consumer. Avoid: data-heavy
+SaaS, security, finance — the softness reads unserious there.`,
+  },
+  {
+    name: 'datacurve-warm-paper',
+    title: 'Datacurve — warm paper',
+    category: 'SaaS and developer tools',
+    oneLiner: 'Warm-paper SaaS: quiet grotesk system, disciplined neutrals, ONE hot pink accent doing all the talking',
+    markdown: `# Datacurve — warm paper
+
+North star: a crisp technical document printed on good paper, with one fluorescent
+highlighter stroke. Precision from restraint; energy from a single loud accent.
+
+## Palette
+- Ground: warm paper #F7F4EE — not white, not gray; the warmth is the point
+- Ink: soft black #16130F
+- Accent: hot pink #FF24BD — used SPARINGLY: primary CTA, one highlighted word,
+  active states. If it appears more than a handful of times, the recipe is broken.
+- Support: paper-shadow #E7E1D5 for borders/wells; muted olive #6B6A4F for
+  secondary labels
+
+## Type
+- Display + body: one grotesk family, Schibsted Grotesk (Google Fonts) — weight and
+  size do the hierarchy, not face changes.
+- Eyebrow labels: 11–12px, uppercase, generous letter-spacing, muted olive.
+- Numbers/metrics may drop into a mono (Spline Sans Mono) for instrument feel.
+
+## Moves
+- Hairline borders (1px, paper-shadow) outline cards and split sections — layout
+  reads as a printed grid.
+- Real product UI screenshots framed in thin borders on paper, slight offset shadow;
+  no glassy mockup floats.
+- Diagrams as flat line-art SVG in ink + accent, not decorative 3D blobs.
+- Density is welcome: tight tables, small caps labels, footnote-style meta text.
+
+## Fits / avoid
+Fits: dev tools, data/API products, technical B2B. Avoid: lifestyle/consumer where
+the restraint reads cold.`,
+  },
+  {
+    name: 'ponder-editorial-hairline',
+    title: 'Ponder — editorial hairline',
+    category: 'SaaS, research and knowledge products',
+    oneLiner: 'Editorial-minimal SaaS: mono eyebrows, hairline rules, serif headlines, magazine calm',
+    markdown: `# Ponder — editorial hairline
+
+North star: a well-set journal article about software, not a software ad. The page
+persuades by reading beautifully — structure from typography and hairlines alone.
+
+## Palette
+- Ground: gallery off-white #FAF8F4
+- Ink: charcoal #1F1D1A
+- Accent: oxide red #B4432E — links, key numbers, one underline per viewport
+- Support: hairline gray #DCD7CE; stone #8A8377 for meta text
+
+## Type
+- Display: a text serif with presence (Newsreader or Source Serif 4, Google Fonts),
+  regular weight, LARGE — elegance from size, not boldness.
+- Eyebrows/meta: Fragment Mono, 11–12px uppercase, wide tracking — the signature
+  move; every section opens with a mono eyebrow over the serif headline.
+- Body: the serif at reading size, 1.6–1.7 line-height, measure ~65ch.
+
+## Moves
+- Hairline rules (1px) structure everything: under the nav, between sections,
+  around figures — never boxes with fills, never shadows.
+- Two-column asymmetric layouts: narrow mono-labeled rail + wide reading column.
+- Figures captioned like a publication (mono caption under a hairline).
+- Motionless confidence: no gradients, no cards, at most a background tone shift
+  for one featured section.
+
+## Fits / avoid
+Fits: research tools, note-taking, AI/knowledge products, studios, essays-as-landing.
+Avoid: playful consumer or promo-heavy pages that need loud CTAs.`,
+  },
+  {
+    name: 'feather-dusk-glow',
+    title: 'Feather — dusk glow',
+    category: 'SaaS, finance and premium consumer software',
+    oneLiner: 'Dark premium SaaS: near-black dusk ground, one luminous gradient glow, thin light type, product-as-hero',
+    markdown: `# Feather — dusk glow
+
+North star: the product screen glowing alone in a dark room. Premium through
+darkness and restraint — one light source, everything else recedes.
+
+## Palette
+- Ground: dusk #0C0E12 — blue-black, never pure #000
+- Ink: moonlight #E8EAF0 for headings; slate #9BA3B5 for body
+- Glow: ONE luminous accent — aurora teal #57E6C2 — appearing as (a) a soft radial
+  gradient bloom behind the hero product shot and (b) tiny sharp touches (link
+  hover, live-dot, one metric). Nowhere else.
+- Support: raised-surface #151922 for cards; hairline #232936 for borders
+
+## Type
+- Display: a refined sans at LIGHT weight, large and tightly tracked
+  (Instrument Sans or Inter Tight, 300–400) — thin type on dark is the luxury cue.
+- Body: same family, small and quiet; slate color keeps hierarchy without bolding.
+- Mono (JetBrains Mono) for tickers, figures, timestamps.
+
+## Moves
+- The product UI is the hero: large, sharp screenshot or recreated UI panel, edge-lit
+  by the glow gradient; everything else supports it.
+- Raised surfaces separate from the ground by tone (#151922) + 1px hairline, not
+  shadows.
+- Section rhythm: vast dark breathing room, then a tight dense feature cluster.
+- Charts/sparklines drawn as thin luminous lines (SVG) — data as light.
+
+## Fits / avoid
+Fits: fintech, analytics, pro/prosumer tools, anything selling calm mastery. Avoid:
+warm/friendly consumer brands and content-heavy reading pages (dark long-form tires).`,
+  },
+]
+
+export function getStyleRecipe(name: string): StyleRecipe | undefined {
+  return STYLE_RECIPES.find((r) => r.name === name.trim().toLowerCase())
+}
+
+/** The menu embedded in the agent guide and resident prompt: enough to decide
+ *  which recipe (if any) to retrieve for the brief. */
+export const STYLE_RECIPE_MENU = STYLE_RECIPES.map((r) => `- ${r.name} (${r.category}) — ${r.oneLiner}`).join('\n')

--- a/server/resident.ts
+++ b/server/resident.ts
@@ -10,7 +10,9 @@ import * as imageSearch from './imageSearch.ts'
 import * as ingest from './ingest.ts'
 import { viewWebsite, referencedUrls } from './website.ts'
 import { createImportedWebpageFrame, findImportedWebpageFrame } from './webpageImport.ts'
-import { DESIGN_QUALITY } from './guide.ts'
+import { DESIGN_BRIEF, DESIGN_QUALITY } from './guide.ts'
+import { getStyleRecipe } from './recipes.ts'
+import { describeInspiration, INSPIRATION_USAGE_NOTE, searchInspiration } from './inspiration.ts'
 import type { Frame } from '../shared/types.ts'
 import { websiteAccessErrorMessage } from './websiteAccess.ts'
 import { executeGuardedBatch } from './guardedBatch.ts'
@@ -108,7 +110,10 @@ Rules:
 - Your final message should be one or two sentences: what you changed and where.
 
 Design quality — the bar for anything you originate or restyle (canvas guidelines and pinned style references outrank it; a frame you are only editing keeps its established direction):
-${DESIGN_QUALITY}`
+${DESIGN_QUALITY}
+
+Design brief — when your card asks you to ORIGINATE new design work:
+${DESIGN_BRIEF}`
 
 /** The system prompt for one agent: the shared harness rules plus its specialty. */
 function systemFor(role: AgentRole): string {
@@ -160,7 +165,7 @@ function strategyFor(text: string, frames: NonNullable<ReturnType<typeof store.g
   const redesignNote = isRedesign
     ? ' For the redesign itself, work audit-first and deliver TWO drafts:' +
       ' (1) Audit the source — inspect_frame on a source frame for its computed palette, type, spacing, radii and shadows (import_webpage first for a live site), plus a screenshot for layout.' +
-      ' (2) Persist the audit with set_guidelines as a doc named "redesign-<source>" (e.g. "redesign-pipefile-com"): a "Source baseline" recording the old system (palette hexes, type, spacing/radii, and the section map — each section\'s purpose and one-line message) as a descriptive record of what you are redesigning away from, NOT rules to follow; then two binding directions. "Direction A — closer to home": the brand stays recognizable — logo, name, core brand colors (re-weighted freely, with new neutrals and tints) — while every detail is redesigned: typography, spacing rhythm, radii, shadows, patterns, background treatments, button and component styling, section layout. "Direction B — further out": same product, same real copy and facts, but freer — reinterpret the palette and push the aesthetic somewhere genuinely different.' +
+      ' (2) Persist the audit with set_guidelines as a doc named "redesign-<source>" (e.g. "redesign-pipefile-com"): a "Source baseline" recording the old system (palette hexes, type, spacing/radii, and the section map — each section\'s purpose and one-line message) as a descriptive record of what you are redesigning away from, NOT rules to follow; then two binding directions. "Direction A — closer to home": the brand stays recognizable — logo, name, core brand colors (re-weighted freely, with new neutrals and tints) — while every detail is redesigned: typography, spacing rhythm, radii, shadows, patterns, background treatments, button and component styling, section layout. "Direction B — further out": same product, same real copy and facts, but freer — reinterpret the palette and push the aesthetic somewhere genuinely different; do not invent it from vibes — retrieve category inspiration (get_style_recipe for the closest recipe, search_inspiration for live exemplars), adapt it, and name it in the redesign doc.' +
       ' (3) Deliver TWO new frames side by side, named "<source> — A (on-brand)" and "<source> — B (departure)", each executing its direction precisely; screenshot both. Both frames together are this card\'s deliverable. In both: keep the source\'s real copy and product facts, restructure sections when it strengthens the page\'s argument, and give details a genuinely new treatment rather than reordering the old elements.' +
       ' Exception: if the request already fixes the scope ("keep it subtle", "same style", "go wild", "rebrand"), deliver ONE draft at that scope instead.' +
       ' If your canvas guidelines already include a redesign doc for this source, skip (1)-(2) and follow its directions.'
@@ -773,6 +778,47 @@ const TOOLS: Anthropic.Tool[] = [
     },
   },
   {
+    name: 'get_style_recipe',
+    description:
+      'Fetch one of the built-in style recipes — complete, executable style directions (mood north star, palette with roles, type pairing, signature moves) distilled from real gallery exemplars. The design-brief ritual in your instructions lists the menu; fetch the closest match for your category before writing a brief, then ADAPT it to the brand rather than copying it verbatim.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        name: { type: 'string', description: 'Recipe slug from the menu in your instructions' },
+      },
+      required: ['name'],
+    },
+  },
+  {
+    name: 'search_inspiration',
+    description:
+      'Search a curated gallery of real, well-designed live websites by category and SEE thumbnails with pre-distilled style facts (one-line mood north star, named palette, fonts). Use it while writing a design brief — especially for landing pages — when no built-in recipe fits the category, or alongside one: query the category plus the page type ("law firm landing page", "dark fintech dashboard"). Adapt what you see into the brief and name the exemplars; never embed these screenshots or copy an identity.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        query: { type: 'string', description: 'Category + page type, e.g. "grocery delivery landing page"' },
+        count: { type: 'number', description: 'Exemplars to return, default 4, max 6' },
+      },
+      required: ['query'],
+    },
+  },
+  {
+    name: 'save_decision',
+    description:
+      'Persist a design decision to the canvas Memory so humans and later agents see what was committed to — this is how you post your design brief (mood, recipe adapted, palette roles, type). Keep it under 500 chars. Design taste only, never one-off content edits.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        decision: {
+          type: 'string',
+          description:
+            'The decision, e.g. "Brief: candlelit mood via oatside-soft-shelf — cream ground, caramel accent, Fraunces/Nunito Sans"',
+        },
+      },
+      required: ['decision'],
+    },
+  },
+  {
     name: 'set_guidelines',
     description:
       "Create, replace or delete a named style guide on this canvas (markdown, max 24,000 chars; empty string deletes). Write rules other designers and agents can execute directly: palette hexes, font families, spacing/radius/shadow conventions, layout recipes, do/don't lists. Also how you persist a redesign audit (binding Direction + descriptive source baseline) so every later job inherits it.",
@@ -1172,6 +1218,52 @@ async function execTool(
             `HTML${truncated ? ` (first ${MAX_HTML_READ_CHARS} of ${ref.html.length} characters — lift the design tokens from the <style> head and the screenshot)` : ''}:\n${ref.html.slice(0, MAX_HTML_READ_CHARS)}`,
         })
         return ok(blocks)
+      }
+      case 'get_style_recipe': {
+        const recipe = getStyleRecipe(String(input.name ?? ''))
+        if (!recipe) return fail(`no recipe named "${input.name}" — use a slug from the menu in your instructions`)
+        return ok(`# ${recipe.title} (${recipe.category})\n\n${recipe.markdown}`)
+      }
+      case 'search_inspiration': {
+        const raw = block.input as { query?: string; count?: number }
+        const query = String(raw.query || '').trim()
+        if (!query) return fail('query must be a non-empty string')
+        const results = await searchInspiration(query, Number(raw.count) || 4)
+        if (results.length === 0) return ok(`no inspiration for "${query}" — try a broader category`)
+        const thumbs = await Promise.all(results.map((r) => imageSearch.fetchThumb(r.thumb_url)))
+        const blocks: NonNullable<Exclude<Anthropic.ToolResultBlockParam['content'], string>> = [
+          {
+            type: 'text',
+            text: `${results.length} exemplar(s) for "${query}" — study each thumbnail with its style facts:`,
+          },
+        ]
+        results.forEach((r, i) => {
+          const thumb = thumbs[i]
+          if (thumb)
+            blocks.push({
+              type: 'image',
+              source: {
+                type: 'base64',
+                media_type: thumb.mime as 'image/jpeg' | 'image/png' | 'image/webp' | 'image/gif',
+                data: thumb.data,
+              },
+            })
+          blocks.push({ type: 'text', text: describeInspiration(r, i) })
+        })
+        blocks.push({ type: 'text', text: INSPIRATION_USAGE_NOTE })
+        return ok(blocks)
+      }
+      case 'save_decision': {
+        const decision = String(input.decision ?? '')
+        try {
+          const saved = actions.recordChatDecision(canvasId, decision, actor)
+          if (saved === undefined) return fail('canvas not found')
+          return ok(
+            saved ? 'saved to the canvas Memory' : 'already in Memory — this exact decision was recorded before',
+          )
+        } catch (e) {
+          return fail(e instanceof Error ? e.message : 'invalid decision')
+        }
       }
       case 'set_guidelines': {
         const raw = block.input as { name?: string; markdown?: string; title?: string }


### PR DESCRIPTION
Before designing, agents can now pull inspiration: a curated set of style recipes (`server/recipes.ts`) and a live refero.design search (`server/inspiration.ts`), surfaced through the guide and an MCP tool, feeding the design brief instead of designing from a cold start.

Ported from the upstream private repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)