### PR TITLE
fix(canvas): open the frame details panel only from a frame-name click

### DIFF
--- a/src/components/FrameView.tsx
+++ b/src/components/FrameView.tsx
@@ -83,7 +83,7 @@ export const FrameView = memo(function FrameView({ frame, raster }: { frame: Fra
     }, 50),
   ).current
 
-  function startDrag(e: React.PointerEvent, mode: 'move' | 'resize', probeOnClick = false) {
+  function startDrag(e: React.PointerEvent, mode: 'move' | 'resize', probeOnClick = false, panelOnClick = false) {
     if (e.button !== 0) return
     e.stopPropagation()
     e.preventDefault()
@@ -131,6 +131,8 @@ export const FrameView = memo(function FrameView({ frame, raster }: { frame: Fra
          the cursor: probe it and show the element toolbar */
       if (!moved && probeOnClick) probeAt(off.x, off.y)
       else if (moved) closePopovers()
+      /* a click (no drag) on the frame name opens the details panel */
+      if (!moved && panelOnClick) useStore.getState().setInspectorOpen(true)
     }
     window.addEventListener('pointermove', onMove)
     window.addEventListener('pointerup', onUp)
@@ -403,7 +405,7 @@ export const FrameView = memo(function FrameView({ frame, raster }: { frame: Fra
               'absolute -top-[26px] left-0 right-0 flex origin-bottom-left cursor-grab select-none items-center gap-2 whitespace-nowrap text-[12px] font-semibold text-ink-soft',
               COUNTER_SCALE,
             )}
-            onPointerDown={(e) => startDrag(e, 'move')}
+            onPointerDown={(e) => startDrag(e, 'move', false, true)}
           >
             <span className="overflow-hidden text-ellipsis">{frame.name}</span>
             <span className="flex gap-1">

--- a/src/components/Stage.tsx
+++ b/src/components/Stage.tsx
@@ -130,6 +130,8 @@ export function Stage({ onAddFrame }: { onAddFrame: () => void }) {
       zoom,
     })
     select(f.id)
+    /* a shared frame link asks for this exact frame — show its details too */
+    useStore.getState().setInspectorOpen(true)
   }
 
   function fit() {

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -39,6 +39,9 @@ interface State {
    *  toast anywhere in the app can jump straight to the Memory tab */
   panelTab: 'tasks' | 'activity' | 'memory'
   selectedId: string | null
+  /** the Inspector panel is showing — opened by clicking a frame's name, not
+   *  by mere selection, so clicking around a frame doesn't slide the panel in */
+  inspectorOpen: boolean
   /** open frame context menu; deferPanel hides the Inspector until it closes
    *  (right-click selecting a frame must not slide a panel in under the menu) */
   ctxMenu: { frameId: string; deferPanel: boolean } | null
@@ -96,6 +99,7 @@ interface State {
   allowanceChanged(): void
   requestFlyTo(frameId: string): void
   select(id: string | null): void
+  setInspectorOpen(v: boolean): void
   openCtxMenu(menu: { frameId: string; deferPanel: boolean }): void
   closeCtxMenu(): void
   setViewport(v: Viewport): void
@@ -119,6 +123,7 @@ export const useStore = create<State>((set, get) => ({
   allowanceVersion: 0,
   flyTo: null,
   selectedId: null,
+  inspectorOpen: false,
   ctxMenu: null,
   viewport: { x: 0, y: 0, zoom: 1 },
   snapGuides: [],
@@ -247,7 +252,12 @@ export const useStore = create<State>((set, get) => ({
   setLimitWall: (limitWall) => set({ limitWall }),
   allowanceChanged: () => set((s) => ({ allowanceVersion: s.allowanceVersion + 1 })),
   requestFlyTo: (frameId) => set({ flyTo: { frameId, at: Date.now() } }),
-  select: (selectedId) => set({ selectedId }),
+  /* selecting a different frame (or deselecting) closes the Inspector — the
+     panel must not follow surface clicks, paste, or undo onto another frame.
+     Re-selecting the same frame keeps an open panel open. */
+  select: (selectedId) =>
+    set((s) => (s.selectedId === selectedId ? { selectedId } : { selectedId, inspectorOpen: false })),
+  setInspectorOpen: (inspectorOpen) => set({ inspectorOpen }),
   openCtxMenu: (ctxMenu) => set({ ctxMenu }),
   closeCtxMenu: () => set({ ctxMenu: null }),
   setViewport: (viewport) => set({ viewport }),

--- a/src/pages/CanvasPage.tsx
+++ b/src/pages/CanvasPage.tsx
@@ -209,6 +209,9 @@ export function CanvasPage({ canvasId }: { canvasId: string }) {
   )
 
   const selectedFrame = canvas?.frames.find((f) => f.id === selectedId) ?? null
+  /* the panel only shows when a frame-name click (or deep link) opened it —
+     selecting a frame by clicking its surface must not slide it in */
+  const inspectorOpen = useStore((s) => s.inspectorOpen)
   /* a right-click that selected the frame keeps the Inspector out until the
      context menu closes — it would slide in right under the open menu */
   const deferPanel = useStore((s) => !!s.ctxMenu?.deferPanel)
@@ -373,7 +376,7 @@ export function CanvasPage({ canvasId }: { canvasId: string }) {
             <WorkingNow />
             <PromptBar canvasId={canvasId} />
             <Onboarding />
-            {!isMobile && selectedFrame && !deferPanel && <Inspector frame={selectedFrame} />}
+            {!isMobile && selectedFrame && inspectorOpen && !deferPanel && <Inspector frame={selectedFrame} />}
             {!isMobile && showActivity && <ActivityPanel onClose={() => setShowActivity(false)} />}
           </>
         )}
@@ -424,7 +427,7 @@ export function CanvasPage({ canvasId }: { canvasId: string }) {
             </SheetContent>
           </Sheet>
           <Sheet
-            open={!!selectedFrame && !deferPanel}
+            open={!!selectedFrame && inspectorOpen && !deferPanel}
             onOpenChange={(open) => {
               if (!open) select(null)
             }}


### PR DESCRIPTION
Selecting a frame no longer pops the details panel — only clicking the frame's name does, so selection stays lightweight.

Ported from the upstream private repo (upstream #100).

🤖 Generated with [Claude Code](https://claude.com/claude-code)