### PR TITLE
feat(canvas): sync icon on frames pushed by the design-sync snippet

### DIFF
--- a/src/components/FlowOverlay.tsx
+++ b/src/components/FlowOverlay.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from 'react'
 import { useStore } from '../lib/store'
 import { api, type SyncFlow } from '../lib/api'
+import { isSyncedFrame } from '../lib/sync'
 
 /**
  * The information architecture of a synced app, drawn on the canvas: when a
@@ -10,8 +11,6 @@ import { api, type SyncFlow } from '../lib/api'
  * turn a synced canvas into spaghetti. Purely presentational overlay in world
  * coordinates; pointer events pass through.
  */
-
-const SYNC_MARKER = 'name="doop-sync-page"'
 
 interface Connector {
   /** hotspot outline on the source frame, world coords */
@@ -30,7 +29,7 @@ export function FlowOverlay() {
   const [flow, setFlow] = useState<SyncFlow | null>(null)
 
   const selected = canvas?.frames.find((f) => f.id === selectedId)
-  const selectedIsSynced = !!selected && selected.html.includes(SYNC_MARKER)
+  const selectedIsSynced = !!selected && isSyncedFrame(selected.html)
 
   /* fetch lazily, on the first selection of a synced frame (and refresh on
      later selections — sync updates land while the canvas is open) */

--- a/src/components/FrameView.tsx
+++ b/src/components/FrameView.tsx
@@ -19,6 +19,8 @@ import { cn } from '@/lib/utils'
 import { Button } from './ui/button'
 import { Textarea } from './ui/textarea'
 import { Tooltip } from './ui/tooltip'
+import { SyncIcon } from './ui/icons'
+import { isSyncedFrame } from '../lib/sync'
 
 /* Counter-scale contract: chrome that keeps constant on-screen size divides
    by the `--zoom` variable the Stage publishes (capped at 2.4× when zoomed
@@ -407,6 +409,13 @@ export const FrameView = memo(function FrameView({ frame, raster }: { frame: Fra
             )}
             onPointerDown={(e) => startDrag(e, 'move', false, true)}
           >
+            {isSyncedFrame(frame.html) && (
+              <Tooltip label="Synced from a live app" side="top" align="start">
+                <span className="flex shrink-0 items-center text-brand">
+                  <SyncIcon width={11} height={11} />
+                </span>
+              </Tooltip>
+            )}
             <span className="overflow-hidden text-ellipsis">{frame.name}</span>
             <span className="flex gap-1">
               {stream && (

--- a/src/components/ui/icons.tsx
+++ b/src/components/ui/icons.tsx
@@ -34,3 +34,14 @@ export function ChevronRightIcon(props: SVGProps<SVGSVGElement>) {
     </svg>
   )
 }
+
+export function SyncIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg {...iconProps} {...props}>
+      <path d="M3 12a9 9 0 0 1 9-9 9.75 9.75 0 0 1 6.74 2.74L21 8" />
+      <path d="M21 3v5h-5" />
+      <path d="M21 12a9 9 0 0 1-9 9 9.75 9.75 0 0 1-6.74-2.74L3 16" />
+      <path d="M8 16H3v5" />
+    </svg>
+  )
+}

--- a/src/lib/sync.ts
+++ b/src/lib/sync.ts
@@ -1,0 +1,8 @@
+/** Frames pushed in by the design-sync snippet carry a marker meta tag the
+ *  ingest endpoint stamps into their HTML (server/ingest.ts). Its presence is
+ *  the whole client-side signal — the key/page it encodes stays server-only. */
+const SYNC_MARKER = 'name="doop-sync-page"'
+
+export function isSyncedFrame(html: string): boolean {
+  return html.includes(SYNC_MARKER)
+}


### PR DESCRIPTION
Frames that arrived via the design-sync snippet carry a sync icon in their chrome, so synced screens are distinguishable from hand-made or agent-made frames at a glance.

Ported from the upstream private repo (upstream #101).

🤖 Generated with [Claude Code](https://claude.com/claude-code)