### PR TITLE
fix(canvas): raise the element toolbar above the pin-to-memory brain button

### DIFF
--- a/src/components/FrameView.tsx
+++ b/src/components/FrameView.tsx
@@ -593,7 +593,7 @@ export const FrameView = memo(function FrameView({ frame, raster }: { frame: Fra
 
                 {anchor && selected && (
                   <div
-                    className="pointer-events-auto absolute z-[5] origin-top-left [transform:scale(min(calc(1/var(--zoom,1)),2.4))_translateY(calc(-100%_-_8px))]"
+                    className="pointer-events-auto absolute z-[7] origin-top-left [transform:scale(min(calc(1/var(--zoom,1)),2.4))_translateY(calc(-100%_-_8px))]"
                     style={{
                       left: Math.min(Math.max(anchor.rect.x, 4), Math.max(4, frame.width - 60)),
                       top: Math.max(anchor.rect.y, 2),


### PR DESCRIPTION
The element toolbar rendered underneath the brain button, making its trailing actions unclickable at some frame positions; raises its z-order.

Ported from the upstream private repo (upstream #102).

🤖 Generated with [Claude Code](https://claude.com/claude-code)