### PR TITLE
feat(github-import): one-click GitHub App install flow

### DIFF
--- a/server/db/migrations/0007_colorful_firedrake.sql
+++ b/server/db/migrations/0007_colorful_firedrake.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "github_connections" ALTER COLUMN "token" DROP NOT NULL;--> statement-breakpoint
+ALTER TABLE "github_connections" ADD COLUMN "installation_id" text;

--- a/server/db/migrations/meta/0007_snapshot.json
+++ b/server/db/migrations/meta/0007_snapshot.json
@@ -1,0 +1,2218 @@
+{
+  "id": "ab4fb165-fe80-4701-ad38-2b9a4c25d94d",
+  "prevId": "aeded106-b024-4321-92fc-ab20dd5dfc07",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.activity": {
+      "name": "activity",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "canvas_id": {
+          "name": "canvas_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_kind": {
+          "name": "actor_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_color": {
+          "name": "actor_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frame_id": {
+          "name": "frame_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "at": {
+          "name": "at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "activity_canvas_idx": {
+          "name": "activity_canvas_idx",
+          "columns": [
+            {
+              "expression": "canvas_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.asset_refs": {
+      "name": "asset_refs",
+      "schema": "",
+      "columns": {
+        "asset_id": {
+          "name": "asset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frame_id": {
+          "name": "frame_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "asset_refs_frame_idx": {
+          "name": "asset_refs_frame_idx",
+          "columns": [
+            {
+              "expression": "frame_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "asset_refs_asset_id_frame_id_pk": {
+          "name": "asset_refs_asset_id_frame_id_pk",
+          "columns": ["asset_id", "frame_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.assets": {
+      "name": "assets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "canvas_id": {
+          "name": "canvas_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mime": {
+          "name": "mime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ext": {
+          "name": "ext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "assets_canvas_idx": {
+          "name": "assets_canvas_idx",
+          "columns": [
+            {
+              "expression": "canvas_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.canvas_members": {
+      "name": "canvas_members",
+      "schema": "",
+      "columns": {
+        "canvas_id": {
+          "name": "canvas_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "added_by": {
+          "name": "added_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "canvas_members_canvas_id_user_id_pk": {
+          "name": "canvas_members_canvas_id_user_id_pk",
+          "columns": ["canvas_id", "user_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.canvases": {
+      "name": "canvases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_access": {
+          "name": "link_access",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.comments": {
+      "name": "comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "canvas_id": {
+          "name": "canvas_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frame_id": {
+          "name": "frame_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "selector": {
+          "name": "selector",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snippet": {
+          "name": "snippet",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_name": {
+          "name": "from_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_user_id": {
+          "name": "from_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "at": {
+          "name": "at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "for_agent": {
+          "name": "for_agent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "target_agent": {
+          "name": "target_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_by": {
+          "name": "claimed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failed_at": {
+          "name": "failed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "comments_canvas_idx": {
+          "name": "comments_canvas_idx",
+          "columns": [
+            {
+              "expression": "canvas_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.decisions": {
+      "name": "decisions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "canvas_id": {
+          "name": "canvas_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frame_id": {
+          "name": "frame_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_name": {
+          "name": "from_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "at": {
+          "name": "at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "distilled_at": {
+          "name": "distilled_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "decisions_canvas_idx": {
+          "name": "decisions_canvas_idx",
+          "columns": [
+            {
+              "expression": "canvas_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feedback": {
+      "name": "feedback",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canvas_id": {
+          "name": "canvas_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_agent": {
+          "name": "target_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_name": {
+          "name": "from_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_user_id": {
+          "name": "from_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "at": {
+          "name": "at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_by": {
+          "name": "claimed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failed_at": {
+          "name": "failed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "feedback_canvas_idx": {
+          "name": "feedback_canvas_idx",
+          "columns": [
+            {
+              "expression": "canvas_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.founder_emails": {
+      "name": "founder_emails",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skipped": {
+          "name": "skipped",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.frames": {
+      "name": "frames",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "canvas_id": {
+          "name": "canvas_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "x": {
+          "name": "x",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "y": {
+          "name": "y",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "width": {
+          "name": "width",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "height": {
+          "name": "height",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "html": {
+          "name": "html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "demo": {
+          "name": "demo",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "frames_canvas_idx": {
+          "name": "frames_canvas_idx",
+          "columns": [
+            {
+              "expression": "canvas_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_connections": {
+      "name": "github_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "canvas_id": {
+          "name": "canvas_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo": {
+          "name": "repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deploy_url": {
+          "name": "deploy_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "github_connections_canvas_idx": {
+          "name": "github_connections_canvas_idx",
+          "columns": [
+            {
+              "expression": "canvas_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.guideline_versions": {
+      "name": "guideline_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "canvas_id": {
+          "name": "canvas_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "markdown": {
+          "name": "markdown",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "saved_at": {
+          "name": "saved_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "saved_by": {
+          "name": "saved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "guideline_versions_doc_idx": {
+          "name": "guideline_versions_doc_idx",
+          "columns": [
+            {
+              "expression": "canvas_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.guidelines": {
+      "name": "guidelines",
+      "schema": "",
+      "columns": {
+        "canvas_id": {
+          "name": "canvas_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "markdown": {
+          "name": "markdown",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "x": {
+          "name": "x",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "y": {
+          "name": "y",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "guidelines_canvas_id_name_pk": {
+          "name": "guidelines_canvas_id_name_pk",
+          "columns": ["canvas_id", "name"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.memory_proposals": {
+      "name": "memory_proposals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "canvas_id": {
+          "name": "canvas_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guide_name": {
+          "name": "guide_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guide_title": {
+          "name": "guide_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rule": {
+          "name": "rule",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rationale": {
+          "name": "rationale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "based_on": {
+          "name": "based_on",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "at": {
+          "name": "at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "memory_proposals_canvas_idx": {
+          "name": "memory_proposals_canvas_idx",
+          "columns": [
+            {
+              "expression": "canvas_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.memory_references": {
+      "name": "memory_references",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "canvas_id": {
+          "name": "canvas_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frame_id": {
+          "name": "frame_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "html": {
+          "name": "html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "width": {
+          "name": "width",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "height": {
+          "name": "height",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pinned_by": {
+          "name": "pinned_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pinned_at": {
+          "name": "pinned_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "memory_references_canvas_idx": {
+          "name": "memory_references_canvas_idx",
+          "columns": [
+            {
+              "expression": "canvas_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.model_accounts": {
+      "name": "model_accounts",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan": {
+          "name": "plan",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connected_at": {
+          "name": "connected_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.resident_usage": {
+      "name": "resident_usage",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "used": {
+          "name": "used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sync_edges": {
+      "name": "sync_edges",
+      "schema": "",
+      "columns": {
+        "key_id": {
+          "name": "key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_page": {
+          "name": "from_page",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_page": {
+          "name": "to_page",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_at": {
+          "name": "last_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "sync_edges_key_id_from_page_to_page_pk": {
+          "name": "sync_edges_key_id_from_page_to_page_pk",
+          "columns": ["key_id", "from_page", "to_page"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sync_keys": {
+      "name": "sync_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canvas_id": {
+          "name": "canvas_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "sync_keys_canvas_idx": {
+          "name": "sync_keys_canvas_idx",
+          "columns": [
+            {
+              "expression": "canvas_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sync_keys_secret_idx": {
+          "name": "sync_keys_secret_idx",
+          "columns": [
+            {
+              "expression": "secret",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sync_links": {
+      "name": "sync_links",
+      "schema": "",
+      "columns": {
+        "key_id": {
+          "name": "key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "page": {
+          "name": "page",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_page": {
+          "name": "to_page",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "x": {
+          "name": "x",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "y": {
+          "name": "y",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "width": {
+          "name": "width",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "height": {
+          "name": "height",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "sync_links_page_idx": {
+          "name": "sync_links_page_idx",
+          "columns": [
+            {
+              "expression": "key_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "page",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tasks": {
+      "name": "tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "canvas_id": {
+          "name": "canvas_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto": {
+          "name": "auto",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "queued_by": {
+          "name": "queued_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failed_at": {
+          "name": "failed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pipeline": {
+          "name": "pipeline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stage": {
+          "name": "stage",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attachments": {
+          "name": "attachments",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "queued_by_user_id": {
+          "name": "queued_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "tasks_canvas_idx": {
+          "name": "tasks_canvas_idx",
+          "columns": [
+            {
+              "expression": "canvas_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_access_token": {
+      "name": "oauth_access_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_access_token_access_token_unique": {
+          "name": "oauth_access_token_access_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["access_token"]
+        },
+        "oauth_access_token_refresh_token_unique": {
+          "name": "oauth_access_token_refresh_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["refresh_token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_application": {
+      "name": "oauth_application",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_urls": {
+          "name": "redirect_urls",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_application_client_id_unique": {
+          "name": "oauth_application_client_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["client_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_consent": {
+      "name": "oauth_consent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "consent_given": {
+          "name": "consent_given",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/server/db/migrations/meta/_journal.json
+++ b/server/db/migrations/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1788136083709,
       "tag": "0006_known_nightshade",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1788139127832,
+      "tag": "0007_colorful_firedrake",
+      "breakpoints": true
     }
   ]
 }

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -105,12 +105,15 @@ export const syncEdges = pgTable(
   (t) => [primaryKey({ columns: [t.keyId, t.fromPage, t.toPage] })],
 )
 
-/** A GitHub repo connected to a canvas as an import source. The fine-grained
- *  PAT is stored server-side only and never reaches canvas members — API
- *  responses carry connection metadata, not the token. Revocation = row
- *  deletion (plus revoking the PAT on GitHub). Frames imported through a
- *  connection carry a marker meta in their HTML (see server/github.ts), same
- *  provenance pattern as design-sync frames — no frame column. */
+/** A GitHub repo connected to a canvas as an import source. Two credential
+ *  modes: a GitHub App installation (`installationId` set, short-lived
+ *  tokens minted per call — the preferred flow) or a fine-grained PAT
+ *  (`token` set — the paste-a-token fallback). Either way credentials stay
+ *  server-side; API responses carry connection metadata only. Revocation =
+ *  row deletion (plus uninstalling the app / revoking the PAT on GitHub).
+ *  Frames imported through a connection carry a marker meta in their HTML
+ *  (see server/github.ts), same provenance pattern as design-sync frames —
+ *  no frame column. */
 export const githubConnections = pgTable(
   'github_connections',
   {
@@ -119,7 +122,8 @@ export const githubConnections = pgTable(
     /** "owner/name" */
     repo: text('repo').notNull(),
     branch: text('branch').notNull(),
-    token: text('token').notNull(),
+    token: text('token'),
+    installationId: text('installation_id'),
     /** live deployment of this repo; enables the capture lane */
     deployUrl: text('deploy_url'),
     createdBy: text('created_by').notNull(),

--- a/server/github.ts
+++ b/server/github.ts
@@ -4,6 +4,7 @@ import { db } from './db/index.ts'
 import { githubConnections } from './db/schema.ts'
 import * as actions from './actions.ts'
 import { sanitizeSnapshotHtml } from './ingest.ts'
+import * as githubApp from './githubApp.ts'
 import type { Actor, Frame } from '../shared/types.ts'
 
 /**
@@ -26,7 +27,10 @@ export interface GithubConnection {
   canvasId: string
   repo: string
   branch: string
-  token: string
+  /** fine-grained PAT — the paste-a-token fallback; null in app mode */
+  token: string | null
+  /** GitHub App installation — the click-to-install flow; null in PAT mode */
+  installationId: string | null
   deployUrl: string | null
   createdBy: string
   createdAt: number
@@ -34,11 +38,19 @@ export interface GithubConnection {
 }
 
 /** What API responses expose — everything but the token. */
-export type GithubConnectionInfo = Omit<GithubConnection, 'token'>
+export type GithubConnectionInfo = Omit<GithubConnection, 'token'> & { via: 'app' | 'token' }
 
 export function connectionInfo(conn: GithubConnection): GithubConnectionInfo {
   const { token: _token, ...info } = conn
-  return info
+  return { ...info, via: conn.installationId ? 'app' : 'token' }
+}
+
+/** The credential a call should use right now: the stored PAT, or a fresh
+ *  short-lived installation token minted through the app. */
+function connectionAuth(conn: Pick<GithubConnection, 'token' | 'installationId'>): Promise<string> {
+  if (conn.installationId) return githubApp.installationToken(conn.installationId)
+  if (conn.token) return Promise.resolve(conn.token)
+  return Promise.reject(new Error('connection has no credential — reconnect the repository'))
 }
 
 const REPO_RE = /^[\w.-]+\/[\w.-]+$/
@@ -76,7 +88,10 @@ async function ghJson<T>(token: string, path: string): Promise<T> {
 export async function createConnection(input: {
   canvasId: string
   repo: string
-  token: string
+  /** PAT mode; mutually exclusive with installationId */
+  token?: string
+  /** app mode — the caller must have verified the install handoff (pass) */
+  installationId?: string
   branch?: string
   deployUrl?: string
   createdBy: string
@@ -86,12 +101,22 @@ export async function createConnection(input: {
     .replace(/^https?:\/\/github\.com\//i, '')
     .replace(/\.git$/, '')
   if (!REPO_RE.test(repo)) throw new Error('repository must be "owner/name"')
-  const token = input.token.trim()
-  if (!token) throw new Error('a fine-grained personal access token is required')
+  const token = input.token?.trim() || null
+  const installationId = input.installationId?.trim() || null
+  if (!token && !installationId) throw new Error('a fine-grained personal access token is required')
+
+  /* App mode grants exactly the installation's repos — refuse anything the
+     user did not select on GitHub's install screen. */
+  if (installationId) {
+    const repos = await githubApp.listInstallationRepos(installationId)
+    if (!repos.some((r) => r.fullName.toLowerCase() === repo.toLowerCase()))
+      throw new Error('that repository is not part of the GitHub App installation')
+  }
 
   /* Verify reachability up front and pick up the repo's own metadata: the
      default branch when none was given, the homepage as the capture base. */
-  const meta = await ghJson<{ default_branch: string; homepage: string | null }>(token, `/repos/${repo}`)
+  const auth = await connectionAuth({ token, installationId })
+  const meta = await ghJson<{ default_branch: string; homepage: string | null }>(auth, `/repos/${repo}`)
   const branch = input.branch?.trim() || meta.default_branch
   let deployUrl: string | null = null
   const candidate = input.deployUrl?.trim() || meta.homepage || ''
@@ -108,6 +133,7 @@ export async function createConnection(input: {
     repo,
     branch,
     token,
+    installationId,
     deployUrl,
     createdBy: input.createdBy,
     createdAt: Date.now(),
@@ -284,7 +310,7 @@ export function detectScreens(paths: string[], pkg: Record<string, unknown> | nu
 /** Fetch the repo's file listing + package.json and build the manifest. */
 export async function analyzeConnection(conn: GithubConnection): Promise<RepoManifest> {
   const tree = await ghJson<{ tree: { path: string; type: string }[]; truncated: boolean }>(
-    conn.token,
+    await connectionAuth(conn),
     `/repos/${conn.repo}/git/trees/${encodeURIComponent(conn.branch)}?recursive=1`,
   )
   const paths = tree.tree.filter((e) => e.type === 'blob').map((e) => e.path)
@@ -320,7 +346,7 @@ const MAX_FILE_BYTES = 1_500_000
 
 async function fetchRepoFile(conn: GithubConnection, path: string): Promise<string> {
   const res = await gh(
-    conn.token,
+    await connectionAuth(conn),
     `/repos/${conn.repo}/contents/${path.split('/').map(encodeURIComponent).join('/')}?ref=${encodeURIComponent(conn.branch)}`,
     'application/vnd.github.raw+json',
   )

--- a/server/githubApp.ts
+++ b/server/githubApp.ts
@@ -1,0 +1,233 @@
+import { createHmac, createSign, timingSafeEqual } from 'node:crypto'
+
+/**
+ * GitHub App plumbing for the repo import source: the click-to-install flow
+ * that replaces pasting a PAT. The app (registered once, credentials in env)
+ * authenticates as itself with a short-lived RS256 JWT and mints per-call
+ * installation tokens — nothing durable is ever stored per connection, and
+ * users revoke from GitHub's own installation settings.
+ *
+ * Enabled by five env vars; when any is absent every helper reports the
+ * app as off and the UI falls back to the PAT form:
+ *   GITHUB_APP_ID             numeric app id
+ *   GITHUB_APP_SLUG           the app's URL slug (github.com/apps/<slug>)
+ *   GITHUB_APP_PRIVATE_KEY    PKCS#1/PKCS#8 PEM, raw or base64-encoded
+ *   GITHUB_APP_CLIENT_ID/_SECRET  OAuth creds — the app must have
+ *     "request user authorization during installation" on, because the
+ *     OAuth code is how the setup callback proves who installed (below)
+ * plus BETTER_AUTH_SECRET: the handoff signatures must never fall back to
+ * the public dev secret while real installations are bindable.
+ *
+ * Install handoff integrity: installation ids are small guessable integers,
+ * so binding one to a canvas requires proof the install round-trip actually
+ * happened for THAT canvas. `signInstallState` goes out with the install
+ * link; the setup callback verifies it and issues `signInstallPass`
+ * (canvas + installation), which the client must echo to list repos or
+ * create a connection. HMAC over the auth secret, 15-minute expiry.
+ */
+
+const GH_API = 'https://api.github.com'
+
+function privateKey(): string | undefined {
+  const raw = process.env.GITHUB_APP_PRIVATE_KEY
+  if (!raw) return undefined
+  if (raw.includes('BEGIN')) return raw
+  try {
+    const decoded = Buffer.from(raw, 'base64').toString('utf8')
+    return decoded.includes('BEGIN') ? decoded : undefined
+  } catch {
+    return undefined
+  }
+}
+
+export function appEnabled(): boolean {
+  return !!(
+    process.env.GITHUB_APP_ID &&
+    process.env.GITHUB_APP_SLUG &&
+    process.env.GITHUB_APP_CLIENT_ID &&
+    process.env.GITHUB_APP_CLIENT_SECRET &&
+    process.env.BETTER_AUTH_SECRET &&
+    privateKey()
+  )
+}
+
+export function appSlug(): string {
+  return process.env.GITHUB_APP_SLUG ?? ''
+}
+
+/* ------------------------------------------------------------------ */
+/* App JWT + installation tokens                                       */
+
+function b64url(input: Buffer | string): string {
+  return Buffer.from(input).toString('base64url')
+}
+
+/** Compact RS256 JWT authenticating as the app itself — no jose dependency,
+ *  node:crypto signs it. Backdated 30s against clock skew, 8 min lifetime
+ *  (GitHub caps at 10). */
+export function appJwt(now = Date.now()): string {
+  const key = privateKey()
+  if (!key) throw new Error('GitHub App is not configured')
+  const header = b64url(JSON.stringify({ alg: 'RS256', typ: 'JWT' }))
+  const iat = Math.floor(now / 1000) - 30
+  const payload = b64url(JSON.stringify({ iat, exp: iat + 8 * 60, iss: process.env.GITHUB_APP_ID }))
+  const signature = createSign('RSA-SHA256').update(`${header}.${payload}`).sign(key)
+  return `${header}.${payload}.${b64url(signature)}`
+}
+
+async function appFetch(path: string, init: RequestInit = {}): Promise<Response> {
+  return fetch(GH_API + path, {
+    ...init,
+    headers: {
+      Authorization: `Bearer ${appJwt()}`,
+      Accept: 'application/vnd.github+json',
+      'X-GitHub-Api-Version': '2022-11-28',
+      'User-Agent': 'doop-import',
+      ...init.headers,
+    },
+  })
+}
+
+/** Installation tokens last an hour; cache until shortly before expiry so a
+ *  40-screen import doesn't mint 40 of them. */
+const tokenCache = new Map<string, { token: string; expiresAt: number }>()
+
+export async function installationToken(installationId: string): Promise<string> {
+  const cached = tokenCache.get(installationId)
+  if (cached && cached.expiresAt - Date.now() > 5 * 60_000) return cached.token
+  const res = await appFetch(`/app/installations/${encodeURIComponent(installationId)}/access_tokens`, {
+    method: 'POST',
+  })
+  if (res.status === 404) throw new Error('the GitHub App installation no longer exists — reconnect the repository')
+  if (!res.ok) throw new Error(`GitHub App token error ${res.status}`)
+  const body = (await res.json()) as { token: string; expires_at: string }
+  tokenCache.set(installationId, { token: body.token, expiresAt: Date.parse(body.expires_at) })
+  return body.token
+}
+
+export interface InstallationRepo {
+  fullName: string
+  private: boolean
+}
+
+function ghHeaders(token: string) {
+  return {
+    Authorization: `Bearer ${token}`,
+    Accept: 'application/vnd.github+json',
+    'X-GitHub-Api-Version': '2022-11-28',
+    'User-Agent': 'doop-import',
+  }
+}
+
+const MAX_PAGES = 5 // 500 repos/installations — beyond that, narrow the install
+
+/** Repos the installation grants — what the picker shows after install.
+ *  Paginated: a 400-repo installation must not hide repos past page one
+ *  (createConnection rejects anything absent from this list). */
+export async function listInstallationRepos(installationId: string): Promise<InstallationRepo[]> {
+  const token = await installationToken(installationId)
+  const repos: InstallationRepo[] = []
+  for (let page = 1; page <= MAX_PAGES; page++) {
+    const res = await fetch(`${GH_API}/installation/repositories?per_page=100&page=${page}`, {
+      headers: ghHeaders(token),
+    })
+    if (!res.ok) throw new Error(`GitHub App repo listing error ${res.status}`)
+    const body = (await res.json()) as { repositories: { full_name: string; private: boolean }[] }
+    repos.push(...body.repositories.map((r) => ({ fullName: r.full_name, private: r.private })))
+    if (body.repositories.length < 100) break
+  }
+  return repos
+}
+
+/** The setup callback's ownership proof: the app requests user authorization
+ *  during install, so GitHub appends an OAuth code identifying WHO completed
+ *  it. Exchange it and require that user to actually have this installation —
+ *  without this, any valid state could bind a guessed installation id from a
+ *  different account and read its private repo list. The user token is used
+ *  once and discarded. */
+export async function verifyInstallationOwner(code: string, installationId: string): Promise<boolean> {
+  if (!code) return false
+  const res = await fetch('https://github.com/login/oauth/access_token', {
+    method: 'POST',
+    headers: { Accept: 'application/json', 'Content-Type': 'application/json', 'User-Agent': 'doop-import' },
+    body: JSON.stringify({
+      client_id: process.env.GITHUB_APP_CLIENT_ID,
+      client_secret: process.env.GITHUB_APP_CLIENT_SECRET,
+      code,
+    }),
+  })
+  if (!res.ok) return false
+  const { access_token } = (await res.json()) as { access_token?: string }
+  if (!access_token) return false
+  for (let page = 1; page <= MAX_PAGES; page++) {
+    const r = await fetch(`${GH_API}/user/installations?per_page=100&page=${page}`, {
+      headers: ghHeaders(access_token),
+    })
+    if (!r.ok) return false
+    const body = (await r.json()) as { installations: { id: number }[] }
+    if (body.installations.some((i) => String(i.id) === installationId)) return true
+    if (body.installations.length < 100) break
+  }
+  return false
+}
+
+/* ------------------------------------------------------------------ */
+/* Signed install handoff                                              */
+
+const STATE_TTL_MS = 15 * 60_000
+
+function secret(): string {
+  return process.env.BETTER_AUTH_SECRET || 'doop-dev-secret-not-for-production'
+}
+
+function sign(payload: string): string {
+  return createHmac('sha256', secret()).update(payload).digest('base64url')
+}
+
+function pack(kind: string, fields: string[], exp: number): string {
+  const payload = [kind, ...fields, String(exp)].join('.')
+  return `${payload}.${sign(payload)}`
+}
+
+function unpack(kind: string, value: string, fieldCount: number): string[] | undefined {
+  const parts = value.split('.')
+  if (parts.length !== fieldCount + 3 || parts[0] !== kind) return undefined
+  const mac = parts.pop()!
+  const payload = parts.join('.')
+  const expected = sign(payload)
+  const a = Buffer.from(mac)
+  const b = Buffer.from(expected)
+  if (a.length !== b.length || !timingSafeEqual(a, b)) return undefined
+  if (Number(parts[parts.length - 1]) < Date.now()) return undefined
+  return parts.slice(1, -1)
+}
+
+/** Goes out with the install link as `state`; proves the round-trip began
+ *  on this canvas. Dots would collide with the separator, but canvas ids
+ *  and user ids are nanoid/uuid-shaped — reject anything else. */
+export function signInstallState(canvasId: string, userId: string, now = Date.now()): string {
+  if (/[.]/.test(canvasId + userId)) throw new Error('invalid id')
+  return pack('gh-state', [canvasId, userId], now + STATE_TTL_MS)
+}
+
+export function verifyInstallState(state: string): { canvasId: string; userId: string } | undefined {
+  const fields = unpack('gh-state', state, 2)
+  return fields ? { canvasId: fields[0]!, userId: fields[1]! } : undefined
+}
+
+/** Issued by the setup callback after GitHub redirects back; the client
+ *  echoes it to list the installation's repos and bind one to the canvas. */
+export function signInstallPass(canvasId: string, installationId: string, now = Date.now()): string {
+  if (/[.]/.test(canvasId + installationId)) throw new Error('invalid id')
+  return pack('gh-pass', [canvasId, installationId], now + STATE_TTL_MS)
+}
+
+export function verifyInstallPass(pass: string, canvasId: string): { installationId: string } | undefined {
+  const fields = unpack('gh-pass', pass, 2)
+  if (!fields || fields[0] !== canvasId) return undefined
+  return { installationId: fields[1]! }
+}
+
+export function installUrl(state: string): string {
+  return `https://github.com/apps/${appSlug()}/installations/new?state=${encodeURIComponent(state)}`
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -28,6 +28,7 @@ import {
 } from './assets.ts'
 import * as ingest from './ingest.ts'
 import * as github from './github.ts'
+import * as githubApp from './githubApp.ts'
 import { seed } from './seed.ts'
 import * as allowance from './allowance.ts'
 import * as modelAccounts from './modelAccounts.ts'
@@ -845,10 +846,19 @@ app.post('/api/canvases/:id/github', async (req, res) => {
   const c = requireDurableCanvas(req, res, req.params.id)
   if (!c) return
   try {
+    /* app mode: a signed pass from the install round-trip stands in for the
+       token, binding the GitHub App installation to this canvas */
+    let installationId: string | undefined
+    if (typeof req.body?.pass === 'string') {
+      const verified = githubApp.verifyInstallPass(req.body.pass, c.id)
+      if (!verified) return res.status(400).json({ error: 'the GitHub install handoff expired — connect again' })
+      installationId = verified.installationId
+    }
     const conn = await github.createConnection({
       canvasId: c.id,
       repo: String(req.body?.repo ?? ''),
-      token: String(req.body?.token ?? ''),
+      token: typeof req.body?.token === 'string' ? req.body.token : undefined,
+      installationId,
       branch: typeof req.body?.branch === 'string' ? req.body.branch : undefined,
       deployUrl: typeof req.body?.deployUrl === 'string' ? req.body.deployUrl : undefined,
       createdBy: req.user!.id,
@@ -856,6 +866,54 @@ app.post('/api/canvases/:id/github', async (req, res) => {
     res.json({ ...github.connectionInfo(conn), frames: 0 })
   } catch (e) {
     res.status(400).json({ error: e instanceof Error ? e.message : 'could not connect the repository' })
+  }
+})
+
+/* ---- GitHub App install flow: click Connect on the canvas, pick repos on
+   GitHub's install screen, land back on the canvas with a repo picker. The
+   signed state/pass pair keeps guessable installation ids from being bound
+   to canvases that never started an install (server/githubApp.ts). */
+
+app.get('/api/github/app', (req, res) => {
+  res.json({ enabled: githubApp.appEnabled(), slug: githubApp.appSlug() })
+})
+
+app.post('/api/canvases/:id/github/app/start', (req, res) => {
+  const c = requireDurableCanvas(req, res, req.params.id)
+  if (!c) return
+  if (!githubApp.appEnabled()) return res.status(400).json({ error: 'the GitHub App is not configured' })
+  res.json({ url: githubApp.installUrl(githubApp.signInstallState(c.id, req.user!.id)) })
+})
+
+/* GitHub's post-install redirect (the app's callback URL, with "request
+   user authorization during installation" on). Verifies the state minted at
+   start AND that the OAuth code's user actually owns the installation —
+   installation ids are guessable, and without the ownership proof a valid
+   state could bind someone else's installation. Then swaps state for a pass
+   and returns to the canvas, where the import modal shows the repo picker. */
+app.get('/api/github/app/setup', async (req, res) => {
+  const state = githubApp.verifyInstallState(String(req.query.state ?? ''))
+  const installationId = String(req.query.installation_id ?? '')
+  if (!state || !/^\d+$/.test(installationId)) return res.redirect('/')
+  try {
+    if (!(await githubApp.verifyInstallationOwner(String(req.query.code ?? ''), installationId)))
+      return res.redirect('/')
+  } catch {
+    return res.redirect('/')
+  }
+  const pass = githubApp.signInstallPass(state.canvasId, installationId)
+  res.redirect(`/c/${encodeURIComponent(state.canvasId)}?ghInstall=${encodeURIComponent(pass)}`)
+})
+
+app.get('/api/canvases/:id/github/app/repos', async (req, res) => {
+  const c = requireDurableCanvas(req, res, req.params.id)
+  if (!c) return
+  const verified = githubApp.verifyInstallPass(String(req.query.pass ?? ''), c.id)
+  if (!verified) return res.status(400).json({ error: 'the GitHub install handoff expired — connect again' })
+  try {
+    res.json(await githubApp.listInstallationRepos(verified.installationId))
+  } catch (e) {
+    res.status(400).json({ error: e instanceof Error ? e.message : 'could not list the installation’s repositories' })
   }
 })
 

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -47,8 +47,15 @@ export interface GithubConnectionInfo {
   deployUrl: string | null
   createdAt: number
   lastSyncedAt: number | null
+  /** how the connection authenticates: the GitHub App, or a pasted token */
+  via: 'app' | 'token'
   /** frames on the canvas imported through this connection */
   frames: number
+}
+
+export interface InstallationRepo {
+  fullName: string
+  private: boolean
 }
 
 export interface RepoScreen {
@@ -189,8 +196,15 @@ export const api = {
   syncFlow: (canvasId: string) => req<SyncFlow>(`/api/canvases/${canvasId}/sync-flow`),
   /* GitHub repos connected as import sources */
   listGithubConnections: (canvasId: string) => req<GithubConnectionInfo[]>(`/api/canvases/${canvasId}/github`),
-  connectGithub: (canvasId: string, input: { repo: string; token: string; branch?: string; deployUrl?: string }) =>
-    req<GithubConnectionInfo>(`/api/canvases/${canvasId}/github`, { method: 'POST', body: JSON.stringify(input) }),
+  connectGithub: (
+    canvasId: string,
+    input: { repo: string; token?: string; pass?: string; branch?: string; deployUrl?: string },
+  ) => req<GithubConnectionInfo>(`/api/canvases/${canvasId}/github`, { method: 'POST', body: JSON.stringify(input) }),
+  githubAppInfo: () => req<{ enabled: boolean; slug: string }>('/api/github/app'),
+  startGithubInstall: (canvasId: string) =>
+    req<{ url: string }>(`/api/canvases/${canvasId}/github/app/start`, { method: 'POST' }),
+  listInstallationRepos: (canvasId: string, pass: string) =>
+    req<InstallationRepo[]>(`/api/canvases/${canvasId}/github/app/repos?pass=${encodeURIComponent(pass)}`),
   deleteGithubConnection: (canvasId: string, connId: string) =>
     req(`/api/canvases/${canvasId}/github/${connId}`, { method: 'DELETE' }),
   analyzeGithub: (canvasId: string, connId: string) =>

--- a/src/pages/CanvasPage.tsx
+++ b/src/pages/CanvasPage.tsx
@@ -7,6 +7,7 @@ import {
   type CanvasMember,
   type DiscoveredSite,
   type GithubConnectionInfo,
+  type InstallationRepo,
   type RepoManifest,
   type RepoScreen,
   type SyncKeyInfo,
@@ -33,7 +34,7 @@ import { useIsMobile } from '../hooks/use-mobile'
 import { cn } from '@/lib/utils'
 import { Button } from '../components/ui/button'
 import { Sheet, SheetContent, SheetDescription, SheetTitle } from '../components/ui/sheet'
-import { XIcon } from '../components/ui/icons'
+import { GithubIcon, XIcon } from '../components/ui/icons'
 import { Badge } from '../components/ui/badge'
 import { Input } from '../components/ui/input'
 import { Field } from '../components/ui/field'
@@ -81,7 +82,14 @@ export function CanvasPage({ canvasId }: { canvasId: string }) {
   const [view, setView] = useState<'canvas' | 'board'>('canvas')
   const [showConnect, setShowConnect] = useState(false)
   const [showShare, setShowShare] = useState(false)
-  const [showImport, setShowImport] = useState(false)
+  /* returning from a GitHub App install: the setup redirect appends a signed
+     pass — pull it off the URL and open the import modal on the repo picker */
+  const [ghInstallPass, setGhInstallPass] = useState<string | null>(() => {
+    const pass = new URLSearchParams(location.search).get('ghInstall')
+    if (pass) history.replaceState(null, '', location.pathname)
+    return pass
+  })
+  const [showImport, setShowImport] = useState(!!ghInstallPass)
   const [showMobileActions, setShowMobileActions] = useState(false)
   const [renaming, setRenaming] = useState(false)
   const [toast, setToast] = useState<string | null>(null)
@@ -489,7 +497,11 @@ export function CanvasPage({ canvasId }: { canvasId: string }) {
       {showImport && (
         <ImportModal
           canvasId={canvasId}
-          onClose={() => setShowImport(false)}
+          installPass={ghInstallPass}
+          onClose={() => {
+            setShowImport(false)
+            setGhInstallPass(null)
+          }}
           onDone={(frameIds, failedCount) => {
             setShowImport(false)
             setView('canvas')
@@ -513,10 +525,12 @@ export function CanvasPage({ canvasId }: { canvasId: string }) {
 
 function ImportModal({
   canvasId,
+  installPass,
   onClose,
   onDone,
 }: {
   canvasId: string
+  installPass: string | null
   onClose: () => void
   onDone: (frameIds: string[], failedCount: number) => void
 }) {
@@ -840,7 +854,7 @@ function ImportModal({
               </Button>
             </ModalActions>
             <SyncKeysSection canvasId={canvasId} />
-            <GithubSection canvasId={canvasId} onReview={openRepoReview} />
+            <GithubSection canvasId={canvasId} installPass={installPass} onReview={openRepoReview} />
           </>
         ) : (
           <>
@@ -1257,18 +1271,25 @@ function SyncKeysSection({ canvasId }: { canvasId: string }) {
   )
 }
 
-/* GitHub as an import source: connect a repo with a fine-grained token, let
-   doop enumerate its screens, and review them before anything lands. The
-   token stays on the server — this section only ever sees connection
-   metadata. Same durable-access rule as sync keys. */
+/* GitHub as an import source: one click installs the doop GitHub App on the
+   repos you pick and you land back here on a repo picker — no tokens to
+   copy. Pasting a fine-grained PAT stays as the fallback when the app isn't
+   configured (self-hosters) or someone prefers it. Credentials stay on the
+   server either way — this section only ever sees connection metadata.
+   Same durable-access rule as sync keys. */
 function GithubSection({
   canvasId,
+  installPass,
   onReview,
 }: {
   canvasId: string
+  installPass: string | null
   onReview: (connection: GithubConnectionInfo, manifest: RepoManifest) => void
 }) {
   const [connections, setConnections] = useState<GithubConnectionInfo[] | null>(null)
+  const [appEnabled, setAppEnabled] = useState(false)
+  const [showTokenForm, setShowTokenForm] = useState(false)
+  const [pickerRepos, setPickerRepos] = useState<InstallationRepo[] | null>(null)
   const [repo, setRepo] = useState('')
   const [token, setToken] = useState('')
   const [deployUrl, setDeployUrl] = useState('')
@@ -1285,11 +1306,52 @@ function GithubSection({
         if (e instanceof ApiError && e.status === 403) setForbidden(true)
         setConnections([])
       })
+    api
+      .githubAppInfo()
+      .then((info) => setAppEnabled(info.enabled))
+      .catch(() => setAppEnabled(false))
   }, [canvasId])
+
+  /* back from GitHub's install screen: swap the pass for the repo list */
+  useEffect(() => {
+    if (!installPass) return
+    api
+      .listInstallationRepos(canvasId, installPass)
+      .then(setPickerRepos)
+      .catch((e) => failed(e, 'could not list the installed repositories'))
+  }, [canvasId, installPass])
 
   function failed(caught: unknown, fallback: string) {
     setError(caught instanceof ApiError ? String(caught.body.error ?? fallback) : fallback)
     setBusy(null)
+  }
+
+  async function startInstall() {
+    if (busy) return
+    setBusy('connecting')
+    setError(null)
+    try {
+      const { url } = await api.startGithubInstall(canvasId)
+      posthog.capture('github_app_install_started')
+      location.href = url
+    } catch (e) {
+      failed(e, 'could not start the GitHub install')
+    }
+  }
+
+  async function connectInstalledRepo(fullName: string) {
+    if (busy || !installPass) return
+    setBusy('connecting')
+    setError(null)
+    try {
+      const conn = await api.connectGithub(canvasId, { repo: fullName, pass: installPass })
+      setConnections((c) => [conn, ...(c ?? [])])
+      setPickerRepos((r) => r?.filter((x) => x.fullName !== fullName) ?? null)
+      setBusy(null)
+      posthog.capture('github_repo_connected', { via: 'app' })
+    } catch (e) {
+      failed(e, 'could not connect the repository')
+    }
   }
 
   async function connectRepo() {
@@ -1307,7 +1369,7 @@ function GithubSection({
       setToken('')
       setDeployUrl('')
       setBusy(null)
-      posthog.capture('github_repo_connected')
+      posthog.capture('github_repo_connected', { via: 'token' })
     } catch (e) {
       failed(e, 'could not connect the repository')
     }
@@ -1358,8 +1420,10 @@ function GithubSection({
     <div className="mt-3.5 flex flex-col gap-2.5 border-t border-line-soft pt-3.5">
       <h3 className="text-[13px] font-semibold text-ink">Or connect a GitHub repo</h3>
       <Note>
-        Doop reads the repo's routing conventions and lists its screens for review — nothing lands until you pick. Use a
-        fine-grained token scoped to the one repo, read-only contents. The token never leaves the server.
+        Doop reads the repo's routing conventions and lists its screens for review — nothing lands until you pick.
+        {appEnabled
+          ? ' Install the doop app on the repos you choose; access is scoped to exactly those and revocable on GitHub.'
+          : ' Use a fine-grained token scoped to the one repo, read-only contents. The token never leaves the server.'}
       </Note>
       {(connections ?? []).map((conn) => (
         <div key={conn.id} className="flex items-center gap-2 text-[13px]">
@@ -1389,49 +1453,90 @@ function GithubSection({
           </Button>
         </div>
       ))}
-      <div className="flex flex-col gap-2">
-        <div className="flex flex-col items-stretch gap-2 sm:flex-row">
-          <Input
-            className="flex-1 rounded-[10px] bg-paper font-mono text-[12px] focus:ring-0"
-            placeholder="owner/repository"
-            value={repo}
-            disabled={!!busy}
-            onChange={(e) => {
-              setRepo(e.target.value)
-              setError(null)
-            }}
-          />
-          <Input
-            className="flex-1 rounded-[10px] bg-paper font-mono text-[12px] focus:ring-0"
-            type="password"
-            placeholder="Fine-grained token (github_pat_…)"
-            value={token}
-            disabled={!!busy}
-            onChange={(e) => {
-              setToken(e.target.value)
-              setError(null)
-            }}
-          />
+      {pickerRepos && (
+        <div className="flex flex-col gap-1.5 rounded-[11px] border border-line bg-paper p-2.5">
+          <b className="text-[12px] text-ink-soft">Pick a repository to connect to this canvas</b>
+          {pickerRepos.map((r) => (
+            <div key={r.fullName} className="flex items-center gap-2 text-[13px]">
+              <GithubIcon width={13} height={13} className="shrink-0 text-ink-faint" />
+              <span className="min-w-0 flex-1 overflow-hidden text-ellipsis whitespace-nowrap font-mono text-[12px]">
+                {r.fullName}
+                {r.private && <span className="ml-1.5 text-[10px] text-ink-faint">private</span>}
+              </span>
+              <Button
+                size="sm"
+                className="px-2.5 text-xs"
+                disabled={!!busy}
+                onClick={() => connectInstalledRepo(r.fullName)}
+              >
+                {busy === 'connecting' ? 'Connecting…' : 'Connect'}
+              </Button>
+            </div>
+          ))}
+          {!pickerRepos.length && <Note>All installed repositories are connected.</Note>}
         </div>
-        <div className="flex flex-col items-stretch gap-2 sm:flex-row">
-          <Input
-            className="flex-1 rounded-[10px] bg-paper font-mono text-[12px] focus:ring-0"
-            placeholder="Deployed URL for live captures (optional)"
-            value={deployUrl}
-            disabled={!!busy}
-            onChange={(e) => setDeployUrl(e.target.value)}
-            onKeyDown={(e) => e.key === 'Enter' && connectRepo()}
-          />
-          <Button
-            variant="primary"
-            className="justify-center"
-            disabled={!!busy || !repo.trim() || !token.trim()}
-            onClick={connectRepo}
-          >
-            {busy === 'connecting' ? 'Connecting…' : 'Connect'}
-          </Button>
+      )}
+      {appEnabled && !pickerRepos && (
+        <Button variant="primary" className="justify-center gap-2 self-start" disabled={!!busy} onClick={startInstall}>
+          <GithubIcon width={14} height={14} />
+          {busy === 'connecting' ? 'Opening GitHub…' : 'Connect GitHub'}
+        </Button>
+      )}
+      {appEnabled && !showTokenForm && (
+        <Button
+          variant="bare"
+          size="sm"
+          className="self-start p-0 font-mono text-[10.5px] text-ink-faint hover:bg-transparent hover:text-accent-ink"
+          onClick={() => setShowTokenForm(true)}
+        >
+          paste a token instead
+        </Button>
+      )}
+      {(!appEnabled || showTokenForm) && (
+        <div className="flex flex-col gap-2">
+          <div className="flex flex-col items-stretch gap-2 sm:flex-row">
+            <Input
+              className="flex-1 rounded-[10px] bg-paper font-mono text-[12px] focus:ring-0"
+              placeholder="owner/repository"
+              value={repo}
+              disabled={!!busy}
+              onChange={(e) => {
+                setRepo(e.target.value)
+                setError(null)
+              }}
+            />
+            <Input
+              className="flex-1 rounded-[10px] bg-paper font-mono text-[12px] focus:ring-0"
+              type="password"
+              placeholder="Fine-grained token (github_pat_…)"
+              value={token}
+              disabled={!!busy}
+              onChange={(e) => {
+                setToken(e.target.value)
+                setError(null)
+              }}
+            />
+          </div>
+          <div className="flex flex-col items-stretch gap-2 sm:flex-row">
+            <Input
+              className="flex-1 rounded-[10px] bg-paper font-mono text-[12px] focus:ring-0"
+              placeholder="Deployed URL for live captures (optional)"
+              value={deployUrl}
+              disabled={!!busy}
+              onChange={(e) => setDeployUrl(e.target.value)}
+              onKeyDown={(e) => e.key === 'Enter' && connectRepo()}
+            />
+            <Button
+              variant="primary"
+              className="justify-center"
+              disabled={!!busy || !repo.trim() || !token.trim()}
+              onClick={connectRepo}
+            >
+              {busy === 'connecting' ? 'Connecting…' : 'Connect'}
+            </Button>
+          </div>
         </div>
-      </div>
+      )}
       {error && <p className={errorNoteCls}>{error}</p>}
       {notice && <p className={cn(importNoteCls, 'mt-0')}>{notice}</p>}
     </div>

--- a/tests/githubApp.test.ts
+++ b/tests/githubApp.test.ts
@@ -1,0 +1,119 @@
+import { generateKeyPairSync, createVerify } from 'node:crypto'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import {
+  appEnabled,
+  appJwt,
+  installUrl,
+  signInstallPass,
+  signInstallState,
+  verifyInstallPass,
+  verifyInstallState,
+} from '../server/githubApp.ts'
+import { Client, startServer, type Server } from './harness.ts'
+
+/**
+ * GitHub App plumbing: the app JWT and the signed install handoff that keeps
+ * guessable installation ids from being bound to canvases that never started
+ * an install. Plus the REST surface's disabled-mode behavior — the app is
+ * off unless its env vars are set, and every UI falls back to the PAT form.
+ */
+
+describe('install handoff signatures', () => {
+  it('round-trips state and pass', () => {
+    const state = signInstallState('canvas1', 'user1')
+    expect(verifyInstallState(state)).toEqual({ canvasId: 'canvas1', userId: 'user1' })
+    const pass = signInstallPass('canvas1', '12345')
+    expect(verifyInstallPass(pass, 'canvas1')).toEqual({ installationId: '12345' })
+  })
+
+  it('rejects tampering, wrong canvas, and expiry', () => {
+    const pass = signInstallPass('canvas1', '12345')
+    expect(verifyInstallPass(pass.slice(0, -2) + 'xx', 'canvas1')).toBeUndefined()
+    expect(verifyInstallPass(pass.replace('12345', '99999'), 'canvas1')).toBeUndefined()
+    expect(verifyInstallPass(pass, 'canvas2')).toBeUndefined()
+    const expired = signInstallPass('canvas1', '12345', Date.now() - 60 * 60_000)
+    expect(verifyInstallPass(expired, 'canvas1')).toBeUndefined()
+    /* a state is not a pass */
+    expect(verifyInstallPass(signInstallState('canvas1', 'user1'), 'canvas1')).toBeUndefined()
+  })
+})
+
+describe('app jwt', () => {
+  const { privateKey, publicKey } = generateKeyPairSync('rsa', { modulusLength: 2048 })
+
+  it('is off without env config', () => {
+    expect(appEnabled()).toBe(false)
+    expect(() => appJwt()).toThrow(/not configured/)
+  })
+
+  it('signs a verifiable RS256 token when configured', () => {
+    process.env.GITHUB_APP_ID = '123'
+    process.env.GITHUB_APP_SLUG = 'doop-import'
+    process.env.GITHUB_APP_PRIVATE_KEY = Buffer.from(
+      privateKey.export({ type: 'pkcs8', format: 'pem' }) as string,
+    ).toString('base64')
+    try {
+      /* key alone is not enough: the OAuth creds prove install ownership and
+         the auth secret keeps passes unforgeable — no partial enablement */
+      expect(appEnabled()).toBe(false)
+      process.env.GITHUB_APP_CLIENT_ID = 'Iv1.abc'
+      process.env.GITHUB_APP_CLIENT_SECRET = 'shh'
+      process.env.BETTER_AUTH_SECRET = 'test-secret'
+      expect(appEnabled()).toBe(true)
+      const jwt = appJwt()
+      const [header, payload, signature] = jwt.split('.')
+      expect(JSON.parse(Buffer.from(header!, 'base64url').toString())).toEqual({ alg: 'RS256', typ: 'JWT' })
+      const claims = JSON.parse(Buffer.from(payload!, 'base64url').toString())
+      expect(claims.iss).toBe('123')
+      expect(claims.exp - claims.iat).toBe(8 * 60)
+      const ok = createVerify('RSA-SHA256')
+        .update(`${header}.${payload}`)
+        .verify(publicKey, Buffer.from(signature!, 'base64url'))
+      expect(ok).toBe(true)
+      expect(installUrl('s1')).toBe('https://github.com/apps/doop-import/installations/new?state=s1')
+    } finally {
+      delete process.env.GITHUB_APP_ID
+      delete process.env.GITHUB_APP_SLUG
+      delete process.env.GITHUB_APP_PRIVATE_KEY
+      delete process.env.GITHUB_APP_CLIENT_ID
+      delete process.env.GITHUB_APP_CLIENT_SECRET
+      delete process.env.BETTER_AUTH_SECRET
+    }
+  })
+})
+
+/* ---- REST surface with the app unconfigured (the default server state) */
+
+const PORT = 4987
+let server: Server
+
+beforeAll(async () => {
+  server = await startServer(PORT)
+}, 70_000)
+
+afterAll(() => server?.stop())
+
+describe('app REST in disabled mode', () => {
+  it('reports disabled and refuses to start installs', async () => {
+    const owner = await new Client(server).signUp('gh-app@test.dev', 'Owner')
+    const canvasId = (await (await owner.post('/api/canvases', { name: 'App' })).json()).id
+
+    const info = await (await owner.get('/api/github/app')).json()
+    expect(info.enabled).toBe(false)
+
+    const start = await owner.post(`/api/canvases/${canvasId}/github/app/start`)
+    expect(start.status).toBe(400)
+
+    /* setup redirect with garbage state goes home, never errors */
+    const setup = await owner.req('/api/github/app/setup?installation_id=1&state=junk')
+    expect(setup.status).toBe(302)
+    expect(setup.headers.get('location')).toBe('/')
+
+    /* a forged pass cannot list repos or bind a connection */
+    const repos = await owner.get(`/api/canvases/${canvasId}/github/app/repos?pass=forged`)
+    expect(repos.status).toBe(400)
+    const bind = await owner.post(`/api/canvases/${canvasId}/github`, { repo: 'a/b', pass: 'forged' })
+    expect(bind.status).toBe(400)
+    expect((await bind.json()).error).toMatch(/handoff expired/)
+  })
+})


### PR DESCRIPTION
Connecting a repo becomes a one-click GitHub App install: the app grants read access to the chosen repos, the callback lands the installation on the canvas, and tokens stay server-side. Env-gated like the rest of the GitHub import.

Migration note: upstream's `0008_colorful_firedrake` lands as **`0007_colorful_firedrake`** (renumbered chain, snapshot verified against our `0006`).

Ported from the upstream private repo (upstream #108).

🤖 Generated with [Claude Code](https://claude.com/claude-code)