### PR TITLE
fix(github-import): deploy URL editable after connect; resync upgrades placeholders

### DIFF
--- a/server/github.ts
+++ b/server/github.ts
@@ -143,6 +143,28 @@ export async function createConnection(input: {
   return row
 }
 
+/** Normalize a user-supplied deployment URL; '' clears it, garbage throws. */
+function cleanDeployUrl(raw: string): string | null {
+  const candidate = raw.trim()
+  if (!candidate) return null
+  const url = new URL(/^https?:\/\//i.test(candidate) ? candidate : `https://${candidate}`)
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') throw new Error('the deployment URL must be http(s)')
+  return url.href
+}
+
+/** Set or clear the connection's deployment URL — the app-install flow has
+ *  no URL prompt, so connections often start without one (every page screen
+ *  lands as a placeholder until this is set). */
+export async function setDeployUrl(canvasId: string, id: string, raw: string): Promise<GithubConnection | undefined> {
+  const deployUrl = cleanDeployUrl(raw)
+  const [row] = await db
+    .update(githubConnections)
+    .set({ deployUrl })
+    .where(and(eq(githubConnections.id, id), eq(githubConnections.canvasId, canvasId)))
+    .returning()
+  return row ?? undefined
+}
+
 export function listConnections(canvasId: string): Promise<GithubConnection[]> {
   return db
     .select()
@@ -589,7 +611,9 @@ export async function importScreens(
 /** Refresh every frame this connection imported, in place: repo HTML re-reads
  *  the branch head, live captures re-run. Positions the user arranged stay —
  *  only content (and captured height) track the source, mirroring the
- *  design-sync update contract. Placeholders have no source to re-read.
+ *  design-sync update contract. Placeholder frames whose screen now HAS a
+ *  reachable lane (a deployment URL was added after import) are upgraded to
+ *  real pixels in place; placeholders that still have no lane stay put.
  *
  *  Markers live in frame HTML, which any member can edit — so they are only
  *  trusted as far as the freshly computed manifest confirms them. A marker
@@ -615,7 +639,8 @@ export async function resyncConnection(
   let updated = 0
   const failures: { route: string; error: string }[] = []
   for (const { frame, screen } of mine) {
-    if (isGithubPlaceholderHtml(frame.html)) continue
+    /* a placeholder only re-runs when its screen now has a real lane */
+    if (isGithubPlaceholderHtml(frame.html) && screen.source === 'placeholder') continue
     try {
       if (screen.source === 'static') {
         const html = wrapRepoHtml(await fetchRepoFile(conn, screen.sourcePath), conn, screen)
@@ -628,7 +653,13 @@ export async function resyncConnection(
         const imported = await importPage(url.href)
         const html = injectHead(imported.html, markerMeta(conn.id, screen))
         if (html !== frame.html) {
-          actions.updateFrame(frame.id, { html, height: imported.height }, actor)
+          /* upgrading a placeholder also adopts the capture's real width */
+          const wasPlaceholder = isGithubPlaceholderHtml(frame.html)
+          actions.updateFrame(
+            frame.id,
+            { html, height: imported.height, ...(wasPlaceholder ? { width: imported.width } : {}) },
+            actor,
+          )
           updated++
         }
       }

--- a/server/index.ts
+++ b/server/index.ts
@@ -924,6 +924,20 @@ app.delete('/api/canvases/:id/github/:connId', async (req, res) => {
   res.json({ ok: true })
 })
 
+/* set/clear the deployment URL that powers the live-capture lane — the
+   app-install flow never asks for one, so it's often added after connect */
+app.patch('/api/canvases/:id/github/:connId', async (req, res) => {
+  const c = requireDurableCanvas(req, res, req.params.id)
+  if (!c) return
+  try {
+    const conn = await github.setDeployUrl(c.id, req.params.connId, String(req.body?.deployUrl ?? ''))
+    if (!conn) return res.status(404).json({ error: 'connection not found' })
+    res.json({ ...github.connectionInfo(conn), frames: github.importedFrameCount(c, conn.id) })
+  } catch (e) {
+    res.status(400).json({ error: e instanceof Error ? e.message : 'invalid deployment URL' })
+  }
+})
+
 app.post('/api/canvases/:id/github/:connId/analyze', async (req, res) => {
   const c = requireDurableCanvas(req, res, req.params.id)
   if (!c) return

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -207,6 +207,11 @@ export const api = {
     req<InstallationRepo[]>(`/api/canvases/${canvasId}/github/app/repos?pass=${encodeURIComponent(pass)}`),
   deleteGithubConnection: (canvasId: string, connId: string) =>
     req(`/api/canvases/${canvasId}/github/${connId}`, { method: 'DELETE' }),
+  setGithubDeployUrl: (canvasId: string, connId: string, deployUrl: string) =>
+    req<GithubConnectionInfo>(`/api/canvases/${canvasId}/github/${connId}`, {
+      method: 'PATCH',
+      body: JSON.stringify({ deployUrl }),
+    }),
   analyzeGithub: (canvasId: string, connId: string) =>
     req<RepoManifest>(`/api/canvases/${canvasId}/github/${connId}/analyze`, { method: 'POST' }),
   importGithubScreens: (canvasId: string, connId: string, screens: RepoScreen[]) =>

--- a/src/pages/CanvasPage.tsx
+++ b/src/pages/CanvasPage.tsx
@@ -1293,6 +1293,8 @@ function GithubSection({
   const [repo, setRepo] = useState('')
   const [token, setToken] = useState('')
   const [deployUrl, setDeployUrl] = useState('')
+  /* per-connection deploy-URL drafts, for connections created without one */
+  const [urlDrafts, setUrlDrafts] = useState<Record<string, string>>({})
   const [busy, setBusy] = useState<'connecting' | string | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [notice, setNotice] = useState<string | null>(null)
@@ -1415,6 +1417,25 @@ function GithubSection({
     setConnections((c) => c?.filter((x) => x.id !== connId) ?? null)
   }
 
+  async function saveDeployUrl(conn: GithubConnectionInfo) {
+    const draft = (urlDrafts[conn.id] ?? '').trim()
+    if (busy || !draft) return
+    setBusy(conn.id + ':url')
+    setError(null)
+    try {
+      const updated = await api.setGithubDeployUrl(canvasId, conn.id, draft)
+      setConnections((c) => c?.map((x) => (x.id === conn.id ? updated : x)) ?? null)
+      setNotice(
+        conn.frames
+          ? 'deployment URL saved — hit ↻ Re-sync to capture placeholder screens for real'
+          : 'deployment URL saved — pages will now capture live',
+      )
+      setBusy(null)
+    } catch (e) {
+      failed(e, 'could not save the deployment URL')
+    }
+  }
+
   if (forbidden) return null
   return (
     <div className="mt-3.5 flex flex-col gap-2.5 border-t border-line-soft pt-3.5">
@@ -1426,31 +1447,53 @@ function GithubSection({
           : ' Use a fine-grained token scoped to the one repo, read-only contents. The token never leaves the server.'}
       </Note>
       {(connections ?? []).map((conn) => (
-        <div key={conn.id} className="flex items-center gap-2 text-[13px]">
-          <b className="min-w-0 overflow-hidden text-ellipsis whitespace-nowrap font-semibold">
-            {conn.repo}
-            <span className="font-normal text-ink-faint">@{conn.branch}</span>
-          </b>
-          <Note className="mr-auto shrink-0">
-            {conn.frames ? `${conn.frames} screen${conn.frames === 1 ? '' : 's'}` : 'nothing imported yet'}
-          </Note>
-          <Button size="sm" className="px-2.5 text-xs" disabled={!!busy} onClick={() => analyze(conn)}>
-            {busy === conn.id ? 'Scanning…' : 'Find screens'}
-          </Button>
-          {conn.frames > 0 && (
-            <Button size="sm" className="px-2.5 text-xs" disabled={!!busy} onClick={() => resync(conn)}>
-              {busy === conn.id + ':resync' ? 'Syncing…' : '↻ Re-sync'}
+        <div key={conn.id} className="flex flex-col gap-1.5">
+          <div className="flex items-center gap-2 text-[13px]">
+            <b className="min-w-0 overflow-hidden text-ellipsis whitespace-nowrap font-semibold">
+              {conn.repo}
+              <span className="font-normal text-ink-faint">@{conn.branch}</span>
+            </b>
+            <Note className="mr-auto shrink-0">
+              {conn.frames ? `${conn.frames} screen${conn.frames === 1 ? '' : 's'}` : 'nothing imported yet'}
+            </Note>
+            <Button size="sm" className="px-2.5 text-xs" disabled={!!busy} onClick={() => analyze(conn)}>
+              {busy === conn.id ? 'Scanning…' : 'Find screens'}
             </Button>
+            {conn.frames > 0 && (
+              <Button size="sm" className="px-2.5 text-xs" disabled={!!busy} onClick={() => resync(conn)}>
+                {busy === conn.id + ':resync' ? 'Syncing…' : '↻ Re-sync'}
+              </Button>
+            )}
+            <Button
+              variant="bare"
+              size="icon-sm"
+              className="-mr-1.5 text-[13px] hover:bg-brand/10 hover:text-accent-ink"
+              title="Disconnect this repository"
+              onClick={() => disconnect(conn.id)}
+            >
+              ✕
+            </Button>
+          </div>
+          {!conn.deployUrl && (
+            <div className="flex flex-col items-stretch gap-2 sm:flex-row">
+              <Input
+                className="flex-1 rounded-[10px] bg-paper font-mono text-[12px] focus:ring-0"
+                placeholder="Deployed URL — without it, pages import as placeholders"
+                value={urlDrafts[conn.id] ?? ''}
+                disabled={!!busy}
+                onChange={(e) => setUrlDrafts((d) => ({ ...d, [conn.id]: e.target.value }))}
+                onKeyDown={(e) => e.key === 'Enter' && saveDeployUrl(conn)}
+              />
+              <Button
+                size="sm"
+                className="justify-center px-2.5 text-xs"
+                disabled={!!busy || !(urlDrafts[conn.id] ?? '').trim()}
+                onClick={() => saveDeployUrl(conn)}
+              >
+                {busy === conn.id + ':url' ? 'Saving…' : 'Save URL'}
+              </Button>
+            </div>
           )}
-          <Button
-            variant="bare"
-            size="icon-sm"
-            className="-mr-1.5 text-[13px] hover:bg-brand/10 hover:text-accent-ink"
-            title="Disconnect this repository"
-            onClick={() => disconnect(conn.id)}
-          >
-            ✕
-          </Button>
         </div>
       ))}
       {pickerRepos && (

--- a/tests/github.test.ts
+++ b/tests/github.test.ts
@@ -201,6 +201,17 @@ describe('github connection REST', () => {
     expect(noToken.status).toBe(400)
   })
 
+  it('validates deploy-URL patches and gates them like other connection routes', async () => {
+    expect((await stranger.patch(`/api/canvases/${canvasId}/github/nope`, { deployUrl: 'https://x.dev' })).status).toBe(
+      403,
+    )
+    expect((await owner.patch(`/api/canvases/${canvasId}/github/nope`, { deployUrl: 'https://x.dev' })).status).toBe(
+      404,
+    )
+    const bad = await owner.patch(`/api/canvases/${canvasId}/github/nope`, { deployUrl: 'http://' })
+    expect(bad.status).toBe(400)
+  })
+
   it('404s analyze/import/resync for unknown connections', async () => {
     expect((await owner.post(`/api/canvases/${canvasId}/github/nope/analyze`)).status).toBe(404)
     expect((await owner.post(`/api/canvases/${canvasId}/github/nope/import`, { screens: [] })).status).toBe(404)


### PR DESCRIPTION
The deploy URL can be edited after connecting a repo, and a resync upgrades placeholder frames once the URL points at a live deployment.

Ported from the upstream private repo (upstream #109).

🤖 Generated with [Claude Code](https://claude.com/claude-code)