### PR TITLE
refactor(github-import): one-time, code-only import — no live-site entanglement

### DIFF
--- a/server/github.ts
+++ b/server/github.ts
@@ -93,7 +93,6 @@ export async function createConnection(input: {
   /** app mode — the caller must have verified the install handoff (pass) */
   installationId?: string
   branch?: string
-  deployUrl?: string
   createdBy: string
 }): Promise<GithubConnection> {
   const repo = input.repo
@@ -113,19 +112,13 @@ export async function createConnection(input: {
       throw new Error('that repository is not part of the GitHub App installation')
   }
 
-  /* Verify reachability up front and pick up the repo's own metadata: the
-     default branch when none was given, the homepage as the capture base. */
+  /* Verify reachability up front and pick up the default branch when none
+     was given. Import is a one-time, code-only job: what lands on the canvas
+     comes from the repository itself — live-site capture belongs to the
+     website importer and stays out of this flow entirely. */
   const auth = await connectionAuth({ token, installationId })
-  const meta = await ghJson<{ default_branch: string; homepage: string | null }>(auth, `/repos/${repo}`)
+  const meta = await ghJson<{ default_branch: string }>(auth, `/repos/${repo}`)
   const branch = input.branch?.trim() || meta.default_branch
-  let deployUrl: string | null = null
-  const candidate = input.deployUrl?.trim() || meta.homepage || ''
-  try {
-    const url = new URL(/^https?:\/\//i.test(candidate) ? candidate : `https://${candidate}`)
-    if (candidate && (url.protocol === 'http:' || url.protocol === 'https:')) deployUrl = url.href
-  } catch {
-    /* no usable deployment URL — the live-capture lane just stays off */
-  }
 
   const row: GithubConnection = {
     id: nanoid(8),
@@ -134,35 +127,13 @@ export async function createConnection(input: {
     branch,
     token,
     installationId,
-    deployUrl,
+    deployUrl: null,
     createdBy: input.createdBy,
     createdAt: Date.now(),
     lastSyncedAt: null,
   }
   await db.insert(githubConnections).values(row)
   return row
-}
-
-/** Normalize a user-supplied deployment URL; '' clears it, garbage throws. */
-function cleanDeployUrl(raw: string): string | null {
-  const candidate = raw.trim()
-  if (!candidate) return null
-  const url = new URL(/^https?:\/\//i.test(candidate) ? candidate : `https://${candidate}`)
-  if (url.protocol !== 'http:' && url.protocol !== 'https:') throw new Error('the deployment URL must be http(s)')
-  return url.href
-}
-
-/** Set or clear the connection's deployment URL — the app-install flow has
- *  no URL prompt, so connections often start without one (every page screen
- *  lands as a placeholder until this is set). */
-export async function setDeployUrl(canvasId: string, id: string, raw: string): Promise<GithubConnection | undefined> {
-  const deployUrl = cleanDeployUrl(raw)
-  const [row] = await db
-    .update(githubConnections)
-    .set({ deployUrl })
-    .where(and(eq(githubConnections.id, id), eq(githubConnections.canvasId, canvasId)))
-    .returning()
-  return row ?? undefined
 }
 
 export function listConnections(canvasId: string): Promise<GithubConnection[]> {
@@ -193,7 +164,7 @@ export async function deleteConnection(canvasId: string, id: string): Promise<bo
 /* Screen detection — pure functions over the repo's file listing      */
 
 export type ScreenKind = 'page' | 'story' | 'static'
-export type PixelSource = 'live' | 'static' | 'placeholder'
+export type PixelSource = 'static' | 'placeholder'
 
 export interface RepoScreen {
   kind: ScreenKind
@@ -350,12 +321,6 @@ export async function analyzeConnection(conn: GithubConnection): Promise<RepoMan
   }
 
   const screens = detectScreens(paths, pkg)
-  /* Lane assignment needs the connection, so it happens here, not in the
-     pure detector: concrete page routes capture live when a deployment is
-     known; everything else that isn't repo HTML starts as a placeholder. */
-  for (const s of screens) {
-    if (s.kind === 'page' && conn.deployUrl && !s.dynamic) s.source = 'live'
-  }
   return {
     connection: connectionInfo(conn),
     framework: detectFramework(pkg),
@@ -458,8 +423,8 @@ export function placeholderHtml(
 ): string {
   const reason =
     screen.kind === 'story'
-      ? 'A Storybook story — capture it from a running Storybook, or design it here.'
-      : 'This screen could not be captured — it may need a login. Browse it with the doop-sync snippet installed, or design it here.'
+      ? 'A Storybook story from the repo — it exists as code, not renderable HTML. Ask an agent to design it here.'
+      : 'This screen exists in the repo as code, not renderable HTML. Ask an agent to design it here.'
   return (
     '<!doctype html>\n<html><head>' +
     markerMeta(conn.id, screen) +
@@ -521,11 +486,11 @@ export function matchSelection(manifest: RepoScreen[], raw: unknown): { screens:
   return { screens, rejected }
 }
 
-/** Import the selected screens: live captures via the page importer, repo
- *  HTML directly, placeholders for the rest. The manifest is recomputed here
- *  and the selection resolved against it — see matchSelection. A screen that
- *  fails its lane degrades to a placeholder rather than vanishing — the map
- *  stays complete and the frame says how to fill it in. */
+/** Import the selected screens — a one-time, code-only job: repo HTML lands
+ *  directly, everything that exists only as code lands as a labeled outline
+ *  frame holding the screen's place in the product map. Nothing here touches
+ *  the live site — that is the website importer's territory. The manifest is
+ *  recomputed and the selection resolved against it — see matchSelection. */
 export async function importScreens(
   conn: GithubConnection,
   canvas: { id: string; frames: Frame[] },
@@ -534,7 +499,6 @@ export async function importScreens(
 ): Promise<GithubImportResult> {
   const manifest = await analyzeConnection(conn)
   const { screens: selection, rejected } = matchSelection(manifest.screens, rawSelection)
-  const { importPage, assertPublicHttpUrl } = await import('./importer.ts')
 
   /* same grid the site importer uses: 3 columns to the right of everything */
   const rightmost = canvas.frames.reduce((right, f) => Math.max(right, f.x + f.width), 0)
@@ -570,17 +534,10 @@ export async function importScreens(
   for (const screen of selection) {
     try {
       let html: string
-      let width = DEFAULT_W
+      const width = DEFAULT_W
       let height = DEFAULT_H
-      let name = screen.title
-      if (screen.source === 'live' && conn.deployUrl) {
-        const url = assertPublicHttpUrl(new URL(screen.route, conn.deployUrl).href)
-        const imported = await importPage(url.href)
-        html = injectHead(imported.html, markerMeta(conn.id, screen))
-        width = imported.width
-        height = imported.height
-        name = imported.title || screen.title
-      } else if (screen.source === 'static') {
+      const name = screen.title
+      if (screen.source === 'static') {
         html = wrapRepoHtml(await fetchRepoFile(conn, screen.sourcePath), conn, screen)
       } else {
         html = placeholderHtml(conn, screen)
@@ -606,74 +563,6 @@ export async function importScreens(
     .catch((err: unknown) => console.error('[github] lastSyncedAt write failed', err))
 
   return { frames, failures }
-}
-
-/** Refresh every frame this connection imported, in place: repo HTML re-reads
- *  the branch head, live captures re-run. Positions the user arranged stay —
- *  only content (and captured height) track the source, mirroring the
- *  design-sync update contract. Placeholder frames whose screen now HAS a
- *  reachable lane (a deployment URL was added after import) are upgraded to
- *  real pixels in place; placeholders that still have no lane stay put.
- *
- *  Markers live in frame HTML, which any member can edit — so they are only
- *  trusted as far as the freshly computed manifest confirms them. A marker
- *  pointing at a path the repo's screen scan doesn't list (hand-edited, or
- *  the file moved) is skipped, never fetched. */
-export async function resyncConnection(
-  conn: GithubConnection,
-  canvas: { id: string; frames: Frame[] },
-  actor: Actor,
-): Promise<{ updated: number; failures: { route: string; error: string }[] }> {
-  const { importPage, assertPublicHttpUrl } = await import('./importer.ts')
-  const manifest = await analyzeConnection(conn)
-  const byIdentity = new Map(manifest.screens.map((s) => [screenIdentity(s), s]))
-  const mine = canvas.frames
-    .flatMap((frame) => {
-      const marker = githubFrameMarker(frame.html)
-      if (marker?.connectionId !== conn.id) return []
-      const screen = byIdentity.get(screenIdentity(marker))
-      return screen ? [{ frame, screen }] : []
-    })
-    .slice(0, MAX_IMPORT_SCREENS)
-
-  let updated = 0
-  const failures: { route: string; error: string }[] = []
-  for (const { frame, screen } of mine) {
-    /* a placeholder only re-runs when its screen now has a real lane */
-    if (isGithubPlaceholderHtml(frame.html) && screen.source === 'placeholder') continue
-    try {
-      if (screen.source === 'static') {
-        const html = wrapRepoHtml(await fetchRepoFile(conn, screen.sourcePath), conn, screen)
-        if (html !== frame.html) {
-          actions.updateFrame(frame.id, { html }, actor)
-          updated++
-        }
-      } else if (screen.source === 'live' && conn.deployUrl) {
-        const url = assertPublicHttpUrl(new URL(screen.route, conn.deployUrl).href)
-        const imported = await importPage(url.href)
-        const html = injectHead(imported.html, markerMeta(conn.id, screen))
-        if (html !== frame.html) {
-          /* upgrading a placeholder also adopts the capture's real width */
-          const wasPlaceholder = isGithubPlaceholderHtml(frame.html)
-          actions.updateFrame(
-            frame.id,
-            { html, height: imported.height, ...(wasPlaceholder ? { width: imported.width } : {}) },
-            actor,
-          )
-          updated++
-        }
-      }
-    } catch (e) {
-      failures.push({ route: screen.route, error: e instanceof Error ? e.message : 'resync failed' })
-    }
-  }
-
-  db.update(githubConnections)
-    .set({ lastSyncedAt: Date.now() })
-    .where(eq(githubConnections.id, conn.id))
-    .catch((err: unknown) => console.error('[github] lastSyncedAt write failed', err))
-
-  return { updated, failures }
 }
 
 export function isGithubPlaceholderHtml(html: string): boolean {

--- a/server/index.ts
+++ b/server/index.ts
@@ -860,7 +860,6 @@ app.post('/api/canvases/:id/github', async (req, res) => {
       token: typeof req.body?.token === 'string' ? req.body.token : undefined,
       installationId,
       branch: typeof req.body?.branch === 'string' ? req.body.branch : undefined,
-      deployUrl: typeof req.body?.deployUrl === 'string' ? req.body.deployUrl : undefined,
       createdBy: req.user!.id,
     })
     res.json({ ...github.connectionInfo(conn), frames: 0 })
@@ -924,20 +923,6 @@ app.delete('/api/canvases/:id/github/:connId', async (req, res) => {
   res.json({ ok: true })
 })
 
-/* set/clear the deployment URL that powers the live-capture lane — the
-   app-install flow never asks for one, so it's often added after connect */
-app.patch('/api/canvases/:id/github/:connId', async (req, res) => {
-  const c = requireDurableCanvas(req, res, req.params.id)
-  if (!c) return
-  try {
-    const conn = await github.setDeployUrl(c.id, req.params.connId, String(req.body?.deployUrl ?? ''))
-    if (!conn) return res.status(404).json({ error: 'connection not found' })
-    res.json({ ...github.connectionInfo(conn), frames: github.importedFrameCount(c, conn.id) })
-  } catch (e) {
-    res.status(400).json({ error: e instanceof Error ? e.message : 'invalid deployment URL' })
-  }
-})
-
 app.post('/api/canvases/:id/github/:connId/analyze', async (req, res) => {
   const c = requireDurableCanvas(req, res, req.params.id)
   if (!c) return
@@ -962,20 +947,6 @@ app.post('/api/canvases/:id/github/:connId/import', async (req, res) => {
     res.json(await github.importScreens(conn, c, req.body?.screens, actor))
   } catch (e) {
     res.status(400).json({ error: e instanceof Error ? e.message : 'import failed' })
-  }
-})
-
-app.post('/api/canvases/:id/github/:connId/resync', async (req, res) => {
-  const c = requireDurableCanvas(req, res, req.params.id)
-  if (!c) return
-  const conn = await github.getConnection(c.id, req.params.connId)
-  if (!conn) return res.status(404).json({ error: 'connection not found' })
-  if (!takeImportSlot(req.user!.id)) return res.status(429).json({ error: 'too many imports — wait a minute' })
-  try {
-    const actor = actions.resolveActor({ name: req.user!.name, kind: 'user' })
-    res.json(await github.resyncConnection(conn, c, actor))
-  } catch (e) {
-    res.status(400).json({ error: e instanceof Error ? e.message : 'resync failed' })
   }
 })
 

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -44,7 +44,6 @@ export interface GithubConnectionInfo {
   canvasId: string
   repo: string
   branch: string
-  deployUrl: string | null
   createdAt: number
   lastSyncedAt: number | null
   /** how the connection authenticates: the GitHub App, or a pasted token */
@@ -64,8 +63,8 @@ export interface RepoScreen {
   sourcePath: string
   title: string
   dynamic: boolean
-  /** which lane supplies the pixels: live capture, repo HTML, or a placeholder */
-  source: 'live' | 'static' | 'placeholder'
+  /** where the pixels come from: repo HTML, or an outline placeholder */
+  source: 'static' | 'placeholder'
 }
 
 export interface RepoManifest {
@@ -196,10 +195,8 @@ export const api = {
   syncFlow: (canvasId: string) => req<SyncFlow>(`/api/canvases/${canvasId}/sync-flow`),
   /* GitHub repos connected as import sources */
   listGithubConnections: (canvasId: string) => req<GithubConnectionInfo[]>(`/api/canvases/${canvasId}/github`),
-  connectGithub: (
-    canvasId: string,
-    input: { repo: string; token?: string; pass?: string; branch?: string; deployUrl?: string },
-  ) => req<GithubConnectionInfo>(`/api/canvases/${canvasId}/github`, { method: 'POST', body: JSON.stringify(input) }),
+  connectGithub: (canvasId: string, input: { repo: string; token?: string; pass?: string; branch?: string }) =>
+    req<GithubConnectionInfo>(`/api/canvases/${canvasId}/github`, { method: 'POST', body: JSON.stringify(input) }),
   githubAppInfo: () => req<{ enabled: boolean; slug: string }>('/api/github/app'),
   startGithubInstall: (canvasId: string) =>
     req<{ url: string }>(`/api/canvases/${canvasId}/github/app/start`, { method: 'POST' }),
@@ -207,11 +204,6 @@ export const api = {
     req<InstallationRepo[]>(`/api/canvases/${canvasId}/github/app/repos?pass=${encodeURIComponent(pass)}`),
   deleteGithubConnection: (canvasId: string, connId: string) =>
     req(`/api/canvases/${canvasId}/github/${connId}`, { method: 'DELETE' }),
-  setGithubDeployUrl: (canvasId: string, connId: string, deployUrl: string) =>
-    req<GithubConnectionInfo>(`/api/canvases/${canvasId}/github/${connId}`, {
-      method: 'PATCH',
-      body: JSON.stringify({ deployUrl }),
-    }),
   analyzeGithub: (canvasId: string, connId: string) =>
     req<RepoManifest>(`/api/canvases/${canvasId}/github/${connId}/analyze`, { method: 'POST' }),
   importGithubScreens: (canvasId: string, connId: string, screens: RepoScreen[]) =>
@@ -219,11 +211,6 @@ export const api = {
       method: 'POST',
       body: JSON.stringify({ screens }),
     }),
-  resyncGithub: (canvasId: string, connId: string) =>
-    req<{ updated: number; failures: { route: string; error: string }[] }>(
-      `/api/canvases/${canvasId}/github/${connId}/resync`,
-      { method: 'POST' },
-    ),
   guidelineHistory: (canvasId: string, name: string) =>
     req<{ markdown: string; savedAt: number; savedBy: string }[]>(
       `/api/canvases/${canvasId}/guidelines/${encodeURIComponent(name)}/history`,

--- a/src/pages/CanvasPage.tsx
+++ b/src/pages/CanvasPage.tsx
@@ -672,9 +672,8 @@ function ImportModal({
 
   const selectedCount = selected.size
   const laneLabel: Record<RepoScreen['source'], string> = {
-    live: 'live capture',
     static: 'from repo',
-    placeholder: 'placeholder',
+    placeholder: 'outline',
   }
 
   return (
@@ -694,9 +693,8 @@ function ImportModal({
             <ModalLede>
               {repoReview.manifest.screens.length} {repoReview.manifest.screens.length === 1 ? 'screen' : 'screens'}{' '}
               found
-              {repoReview.manifest.framework ? ` in a ${repoReview.manifest.framework} app` : ''}. Pages capture from
-              the live deployment, repo HTML imports directly, and the rest hold their place as placeholders until the
-              sync snippet fills them in.
+              {repoReview.manifest.framework ? ` in a ${repoReview.manifest.framework} app` : ''}. A one-time import:
+              repo HTML lands as frames, and screens that only exist as code land as outlines to design into.
             </ModalLede>
             <div className="mt-5 flex items-center justify-between px-[2px] pb-[9px]">
               <b className="text-[12px] text-ink-soft">
@@ -766,7 +764,7 @@ function ImportModal({
             )}
             {busy === 'importing' && (
               <p className={cn(importNoteCls, 'text-accent-ink')}>
-                Importing {repoSelected.size} screens — live captures can take a few minutes.
+                Importing {repoSelected.size} screens from the repository…
               </p>
             )}
             {error && <p className={errorNoteCls}>{error}</p>}
@@ -1292,12 +1290,8 @@ function GithubSection({
   const [pickerRepos, setPickerRepos] = useState<InstallationRepo[] | null>(null)
   const [repo, setRepo] = useState('')
   const [token, setToken] = useState('')
-  const [deployUrl, setDeployUrl] = useState('')
-  /* per-connection deploy-URL drafts, for connections created without one */
-  const [urlDrafts, setUrlDrafts] = useState<Record<string, string>>({})
   const [busy, setBusy] = useState<'connecting' | string | null>(null)
   const [error, setError] = useState<string | null>(null)
-  const [notice, setNotice] = useState<string | null>(null)
   const [forbidden, setForbidden] = useState(false)
 
   useEffect(() => {
@@ -1364,12 +1358,10 @@ function GithubSection({
       const conn = await api.connectGithub(canvasId, {
         repo: repo.trim(),
         token: token.trim(),
-        ...(deployUrl.trim() ? { deployUrl: deployUrl.trim() } : {}),
       })
       setConnections((c) => [conn, ...(c ?? [])])
       setRepo('')
       setToken('')
-      setDeployUrl('')
       setBusy(null)
       posthog.capture('github_repo_connected', { via: 'token' })
     } catch (e) {
@@ -1394,46 +1386,9 @@ function GithubSection({
     }
   }
 
-  async function resync(conn: GithubConnectionInfo) {
-    if (busy) return
-    setBusy(conn.id + ':resync')
-    setError(null)
-    setNotice(null)
-    try {
-      const result = await api.resyncGithub(canvasId, conn.id)
-      setNotice(
-        result.updated
-          ? `${result.updated} frame${result.updated === 1 ? '' : 's'} refreshed from ${conn.repo}`
-          : 'everything already matches the repo',
-      )
-      setBusy(null)
-    } catch (e) {
-      failed(e, 'resync failed')
-    }
-  }
-
   function disconnect(connId: string) {
     api.deleteGithubConnection(canvasId, connId).catch(console.error)
     setConnections((c) => c?.filter((x) => x.id !== connId) ?? null)
-  }
-
-  async function saveDeployUrl(conn: GithubConnectionInfo) {
-    const draft = (urlDrafts[conn.id] ?? '').trim()
-    if (busy || !draft) return
-    setBusy(conn.id + ':url')
-    setError(null)
-    try {
-      const updated = await api.setGithubDeployUrl(canvasId, conn.id, draft)
-      setConnections((c) => c?.map((x) => (x.id === conn.id ? updated : x)) ?? null)
-      setNotice(
-        conn.frames
-          ? 'deployment URL saved — hit ↻ Re-sync to capture placeholder screens for real'
-          : 'deployment URL saved — pages will now capture live',
-      )
-      setBusy(null)
-    } catch (e) {
-      failed(e, 'could not save the deployment URL')
-    }
   }
 
   if (forbidden) return null
@@ -1459,11 +1414,6 @@ function GithubSection({
             <Button size="sm" className="px-2.5 text-xs" disabled={!!busy} onClick={() => analyze(conn)}>
               {busy === conn.id ? 'Scanning…' : 'Find screens'}
             </Button>
-            {conn.frames > 0 && (
-              <Button size="sm" className="px-2.5 text-xs" disabled={!!busy} onClick={() => resync(conn)}>
-                {busy === conn.id + ':resync' ? 'Syncing…' : '↻ Re-sync'}
-              </Button>
-            )}
             <Button
               variant="bare"
               size="icon-sm"
@@ -1474,26 +1424,6 @@ function GithubSection({
               ✕
             </Button>
           </div>
-          {!conn.deployUrl && (
-            <div className="flex flex-col items-stretch gap-2 sm:flex-row">
-              <Input
-                className="flex-1 rounded-[10px] bg-paper font-mono text-[12px] focus:ring-0"
-                placeholder="Deployed URL — without it, pages import as placeholders"
-                value={urlDrafts[conn.id] ?? ''}
-                disabled={!!busy}
-                onChange={(e) => setUrlDrafts((d) => ({ ...d, [conn.id]: e.target.value }))}
-                onKeyDown={(e) => e.key === 'Enter' && saveDeployUrl(conn)}
-              />
-              <Button
-                size="sm"
-                className="justify-center px-2.5 text-xs"
-                disabled={!!busy || !(urlDrafts[conn.id] ?? '').trim()}
-                onClick={() => saveDeployUrl(conn)}
-              >
-                {busy === conn.id + ':url' ? 'Saving…' : 'Save URL'}
-              </Button>
-            </div>
-          )}
         </div>
       ))}
       {pickerRepos && (
@@ -1558,30 +1488,20 @@ function GithubSection({
                 setToken(e.target.value)
                 setError(null)
               }}
-            />
-          </div>
-          <div className="flex flex-col items-stretch gap-2 sm:flex-row">
-            <Input
-              className="flex-1 rounded-[10px] bg-paper font-mono text-[12px] focus:ring-0"
-              placeholder="Deployed URL for live captures (optional)"
-              value={deployUrl}
-              disabled={!!busy}
-              onChange={(e) => setDeployUrl(e.target.value)}
               onKeyDown={(e) => e.key === 'Enter' && connectRepo()}
             />
-            <Button
-              variant="primary"
-              className="justify-center"
-              disabled={!!busy || !repo.trim() || !token.trim()}
-              onClick={connectRepo}
-            >
-              {busy === 'connecting' ? 'Connecting…' : 'Connect'}
-            </Button>
           </div>
+          <Button
+            variant="primary"
+            className="justify-center self-start"
+            disabled={!!busy || !repo.trim() || !token.trim()}
+            onClick={connectRepo}
+          >
+            {busy === 'connecting' ? 'Connecting…' : 'Connect'}
+          </Button>
         </div>
       )}
       {error && <p className={errorNoteCls}>{error}</p>}
-      {notice && <p className={cn(importNoteCls, 'mt-0')}>{notice}</p>}
     </div>
   )
 }

--- a/tests/github.test.ts
+++ b/tests/github.test.ts
@@ -72,7 +72,7 @@ describe('screen enumeration', () => {
       ['static', 'public/landing.html'],
       ['static', 'dist/index.html'],
     ])
-    expect(screens.every((s) => s.source !== 'live')).toBe(true)
+    expect(screens.every((s) => (s.kind === 'static' ? s.source === 'static' : s.source === 'placeholder'))).toBe(true)
   })
 })
 
@@ -201,21 +201,9 @@ describe('github connection REST', () => {
     expect(noToken.status).toBe(400)
   })
 
-  it('validates deploy-URL patches and gates them like other connection routes', async () => {
-    expect((await stranger.patch(`/api/canvases/${canvasId}/github/nope`, { deployUrl: 'https://x.dev' })).status).toBe(
-      403,
-    )
-    expect((await owner.patch(`/api/canvases/${canvasId}/github/nope`, { deployUrl: 'https://x.dev' })).status).toBe(
-      404,
-    )
-    const bad = await owner.patch(`/api/canvases/${canvasId}/github/nope`, { deployUrl: 'http://' })
-    expect(bad.status).toBe(400)
-  })
-
-  it('404s analyze/import/resync for unknown connections', async () => {
+  it('404s analyze/import for unknown connections', async () => {
     expect((await owner.post(`/api/canvases/${canvasId}/github/nope/analyze`)).status).toBe(404)
     expect((await owner.post(`/api/canvases/${canvasId}/github/nope/import`, { screens: [] })).status).toBe(404)
-    expect((await owner.post(`/api/canvases/${canvasId}/github/nope/resync`)).status).toBe(404)
     expect((await stranger.post(`/api/canvases/${canvasId}/github/nope/analyze`)).status).toBe(403)
   })
 })


### PR DESCRIPTION
The GitHub import becomes a one-time, code-only pass: no deploy-URL coupling, no live-site capture in the loop — the repo's code is the sole source.

Ported from the upstream private repo (upstream #110).

🤖 Generated with [Claude Code](https://claude.com/claude-code)