### PR TITLE
feat(github-import): agent reconstruction of code-only screens

### DIFF
--- a/server/github.ts
+++ b/server/github.ts
@@ -329,9 +329,19 @@ export async function analyzeConnection(conn: GithubConnection): Promise<RepoMan
   }
 }
 
+/** The repo's blob paths at the branch head — the reconstruction pass uses
+ *  this to resolve a screen's import closure. */
+export async function fetchTreePaths(conn: GithubConnection): Promise<string[]> {
+  const tree = await ghJson<{ tree: { path: string; type: string }[] }>(
+    await connectionAuth(conn),
+    `/repos/${conn.repo}/git/trees/${encodeURIComponent(conn.branch)}?recursive=1`,
+  )
+  return tree.tree.filter((e) => e.type === 'blob').map((e) => e.path)
+}
+
 const MAX_FILE_BYTES = 1_500_000
 
-async function fetchRepoFile(conn: GithubConnection, path: string): Promise<string> {
+export async function fetchRepoFile(conn: GithubConnection, path: string): Promise<string> {
   const res = await gh(
     await connectionAuth(conn),
     `/repos/${conn.repo}/contents/${path.split('/').map(encodeURIComponent).join('/')}?ref=${encodeURIComponent(conn.branch)}`,
@@ -414,24 +424,49 @@ export function wrapRepoHtml(
   return injectHead(sanitizeSnapshotHtml(html), inject)
 }
 
-/** The stand-in frame for a screen no lane can reach yet: it holds the
- *  screen's place in the product map until the sync snippet (or a future
- *  reconstruction pass) fills it in. */
+/** A model-generated reconstruction → frame HTML: same scrub + marker as
+ *  repo HTML, but no raw.githubusercontent base — the document is
+ *  self-contained by instruction. */
+export function wrapGeneratedHtml(
+  html: string,
+  conn: Pick<GithubConnection, 'id' | 'repo' | 'branch'>,
+  screen: { kind: ScreenKind; route: string; sourcePath: string },
+): string {
+  const inject = markerMeta(conn.id, screen) + `<meta http-equiv="Content-Security-Policy" content="${SNAPSHOT_CSP}">`
+  return injectHead(sanitizeSnapshotHtml(html), inject)
+}
+
+/** The stand-in frame for a screen that only exists as code. When the agent
+ *  is about to reconstruct it, the copy says so ('sketching'); otherwise it
+ *  is a plain outline, and a failed run gets an honest note. */
 export function placeholderHtml(
   conn: Pick<GithubConnection, 'id' | 'repo'>,
   screen: { kind: ScreenKind; route: string; sourcePath: string; title: string },
+  state: 'plain' | 'sketching' | 'failed' = 'plain',
 ): string {
   const reason =
-    screen.kind === 'story'
-      ? 'A Storybook story from the repo — it exists as code, not renderable HTML. Ask an agent to design it here.'
-      : 'This screen exists in the repo as code, not renderable HTML. Ask an agent to design it here.'
+    state === 'sketching'
+      ? 'Doop is reading this screen’s source and sketching it here — give it a moment.'
+      : state === 'failed'
+        ? 'Doop tried to sketch this screen from its source but the run failed — delete the frame and re-import to retry.'
+        : screen.kind === 'story'
+          ? 'A Storybook story, imported as an outline — the repo holds its code.'
+          : 'Imported as an outline — the repo holds this screen’s code.'
+  /* people who drive their own agent over MCP get a ready-made prompt — that
+     agent usually has the repo checked out, making it the best builder here */
+  const byoPrompt =
+    state === 'plain'
+      ? `<p style="margin-top:14px">Using your own agent with this repo checked out? Try:</p>` +
+        `<p style="margin-top:8px;font-family:ui-monospace,monospace;font-size:11.5px;background:#f7f7f8;border:1px solid #eee;border-radius:8px;padding:10px 12px;text-align:left">` +
+        `“On my doop canvas, design the outline frames imported from ${escapeHtml(conn.repo)} — read each screen’s source (the frame lists its file path) and set_frame_html a faithful version.”</p>`
+      : ''
   return (
     '<!doctype html>\n<html><head>' +
     markerMeta(conn.id, screen) +
     `<meta name="${PLACEHOLDER_META}" content="1">` +
     `<meta http-equiv="Content-Security-Policy" content="${SNAPSHOT_CSP}">` +
     '<style>*{margin:0;box-sizing:border-box}body{font-family:system-ui,sans-serif;height:100vh;display:grid;place-items:center;background:repeating-linear-gradient(45deg,#fafafa,#fafafa 12px,#f4f4f5 12px,#f4f4f5 24px);color:#555}main{text-align:center;max-width:420px;padding:32px;background:#fff;border:1px dashed #ccc;border-radius:12px}h1{font-size:18px;margin-bottom:6px}code{font-size:12px;color:#888}p{font-size:13px;line-height:1.5;color:#777;margin-top:10px}</style>' +
-    `</head><body><main><h1>${escapeHtml(screen.title)}</h1><code>${escapeHtml(screen.route)}</code><p>${reason}</p></main></body></html>`
+    `</head><body><main><h1>${escapeHtml(screen.title)}</h1><code>${escapeHtml(screen.sourcePath || screen.route)}</code><p>${reason}</p>${byoPrompt}</main></body></html>`
   )
 }
 
@@ -449,6 +484,8 @@ const DEFAULT_H = 900
 export interface GithubImportResult {
   frames: Frame[]
   failures: { route: string; error: string }[]
+  /** outline frames awaiting the reconstruction pass (server-side only) */
+  pending: { frameId: string; screen: RepoScreen }[]
 }
 
 /** A screen's identity across analyze → import → resync. */
@@ -487,15 +524,18 @@ export function matchSelection(manifest: RepoScreen[], raw: unknown): { screens:
 }
 
 /** Import the selected screens — a one-time, code-only job: repo HTML lands
- *  directly, everything that exists only as code lands as a labeled outline
- *  frame holding the screen's place in the product map. Nothing here touches
- *  the live site — that is the website importer's territory. The manifest is
- *  recomputed and the selection resolved against it — see matchSelection. */
+ *  directly; screens that only exist as code land as outline frames, listed
+ *  in `pending` so the caller can hand them to the reconstruction pass
+ *  (githubRecon.ts) when a model is available — `sketch` says whether one
+ *  is, which the outline copy reflects. Nothing here touches the live site —
+ *  that is the website importer's territory. The manifest is recomputed and
+ *  the selection resolved against it — see matchSelection. */
 export async function importScreens(
   conn: GithubConnection,
   canvas: { id: string; frames: Frame[] },
   rawSelection: unknown,
   actor: Actor,
+  options: { sketch?: boolean } = {},
 ): Promise<GithubImportResult> {
   const manifest = await analyzeConnection(conn)
   const { screens: selection, rejected } = matchSelection(manifest.screens, rawSelection)
@@ -531,19 +571,23 @@ export async function importScreens(
     return frame
   }
 
+  const pending: { frameId: string; screen: RepoScreen }[] = []
   for (const screen of selection) {
     try {
       let html: string
       const width = DEFAULT_W
       let height = DEFAULT_H
       const name = screen.title
+      let outline = false
       if (screen.source === 'static') {
         html = wrapRepoHtml(await fetchRepoFile(conn, screen.sourcePath), conn, screen)
       } else {
-        html = placeholderHtml(conn, screen)
+        html = placeholderHtml(conn, screen, options.sketch ? 'sketching' : 'plain')
         height = 800
+        outline = true
       }
       const frame = place(name, html, width, height)
+      if (frame && outline && options.sketch) pending.push({ frameId: frame.id, screen })
       if (!frame) {
         failures.push({ route: screen.route, error: 'canvas not found' })
         continue
@@ -562,7 +606,7 @@ export async function importScreens(
     .where(eq(githubConnections.id, conn.id))
     .catch((err: unknown) => console.error('[github] lastSyncedAt write failed', err))
 
-  return { frames, failures }
+  return { frames, failures, pending }
 }
 
 export function isGithubPlaceholderHtml(html: string): boolean {

--- a/server/githubRecon.ts
+++ b/server/githubRecon.ts
@@ -1,0 +1,202 @@
+import { pickModel } from './agentModel.ts'
+import * as actions from './actions.ts'
+import {
+  fetchRepoFile,
+  fetchTreePaths,
+  placeholderHtml,
+  wrapGeneratedHtml,
+  type GithubConnection,
+  type RepoScreen,
+} from './github.ts'
+import type { Actor } from '../shared/types.ts'
+
+/**
+ * Reconstruction: the agent-designed lane of the GitHub import. A screen that
+ * only exists as code (a Next page, a story) is imported as an outline frame
+ * immediately; this pass then reads the screen's source closure from the
+ * repo, has the model rewrite it into ONE self-contained HTML document, and
+ * morphs it into the outline in place — people watching the canvas see the
+ * sketch fill in. Runs only when a model is available (the requester's
+ * connected account, else the server's agent tier); with no model the
+ * outline simply stays, which is the honest fallback.
+ *
+ * This is still the one-time, code-only contract: everything the model sees
+ * comes from the repository. Nothing here touches the live site.
+ */
+
+/** Bounded source closure: the screen's file, its resolvable local imports
+ *  (depth-first, small), and the styling context that shapes every screen. */
+const MAX_CLOSURE_FILES = 10
+const MAX_CLOSURE_BYTES = 60_000
+const MAX_RECONSTRUCTIONS_PER_IMPORT = 12
+const RECON_CONCURRENCY = 2
+const MODEL_MAX_TOKENS = 20_000
+
+const RESOLVE_EXTS = ['', '.tsx', '.ts', '.jsx', '.js', '.css', '/index.tsx', '/index.ts', '/index.jsx', '/index.js']
+
+function dirOf(path: string): string {
+  return path.includes('/') ? path.slice(0, path.lastIndexOf('/')) : ''
+}
+
+function normalize(path: string): string {
+  const parts: string[] = []
+  for (const part of path.split('/')) {
+    if (!part || part === '.') continue
+    if (part === '..') parts.pop()
+    else parts.push(part)
+  }
+  return parts.join('/')
+}
+
+/** Resolve one import specifier against the repo tree, or undefined. `@/x`
+ *  and `~/x` map to the conventional src root nearest the importing file. */
+export function resolveImport(spec: string, fromPath: string, paths: Set<string>): string | undefined {
+  let base: string | undefined
+  if (spec.startsWith('./') || spec.startsWith('../')) {
+    base = normalize(`${dirOf(fromPath)}/${spec}`)
+  } else if (spec.startsWith('@/') || spec.startsWith('~/')) {
+    /* alias roots to try, closest to the importing file first */
+    const root = fromPath.includes('/src/') ? fromPath.slice(0, fromPath.indexOf('/src/') + 5) : 'src/'
+    for (const prefix of [root, 'src/', '']) {
+      const candidate = resolveImport('./' + spec.slice(2), prefix + 'x', paths)
+      if (candidate) return candidate
+    }
+    return undefined
+  } else {
+    return undefined /* a package — the model knows the ecosystem */
+  }
+  for (const ext of RESOLVE_EXTS) {
+    if (paths.has(base + ext)) return base + ext
+  }
+  return undefined
+}
+
+const IMPORT_RE = /import\s[^'"]*?['"]([^'"]+)['"]|from\s+['"]([^'"]+)['"]/g
+
+/** Collect the screen's bounded source closure as prompt-ready sections. */
+export async function collectClosure(
+  conn: GithubConnection,
+  screen: RepoScreen,
+  paths: string[],
+): Promise<{ path: string; text: string }[]> {
+  const pathSet = new Set(paths)
+  const files: { path: string; text: string }[] = []
+  let budget = MAX_CLOSURE_BYTES
+  const queue: string[] = [screen.sourcePath]
+  const seen = new Set<string>(queue)
+
+  /* styling context first-class: the app shell and global styles shape every
+     screen, so include them whenever they exist near the page's root */
+  const root = screen.sourcePath.includes('/app/')
+    ? screen.sourcePath.slice(0, screen.sourcePath.indexOf('/app/') + 5)
+    : screen.sourcePath.includes('/pages/')
+      ? screen.sourcePath.slice(0, screen.sourcePath.indexOf('/pages/') + 7)
+      : ''
+  for (const context of [
+    root + 'layout.tsx',
+    root.replace(/pages\/$/, 'pages/') + '_app.tsx',
+    ...paths.filter((p) => /(^|\/)(globals?|app|main|index)\.css$/.test(p) && !p.includes('node_modules')).slice(0, 2),
+    ...paths.filter((p) => /(^|\/)tailwind\.config\.[jt]s$/.test(p)).slice(0, 1),
+  ]) {
+    if (pathSet.has(context) && !seen.has(context)) {
+      seen.add(context)
+      queue.push(context)
+    }
+  }
+
+  while (queue.length && files.length < MAX_CLOSURE_FILES && budget > 0) {
+    const path = queue.shift()!
+    let text: string
+    try {
+      text = await fetchRepoFile(conn, path)
+    } catch {
+      continue /* deleted/oversized — the model works from what resolves */
+    }
+    if (text.length > budget) text = text.slice(0, budget) + '\n/* …truncated… */'
+    budget -= text.length
+    files.push({ path, text })
+    for (const match of text.matchAll(IMPORT_RE)) {
+      const resolved = resolveImport(match[1] ?? match[2] ?? '', path, pathSet)
+      if (resolved && !seen.has(resolved)) {
+        seen.add(resolved)
+        queue.push(resolved)
+      }
+    }
+  }
+  return files
+}
+
+const SYSTEM_PROMPT = `You are Doop's senior product designer. You receive the source code of ONE screen from a product's repository (the screen's file, some of its imported components, and global styling context). Rewrite it as a single COMPLETE, self-contained HTML document that faithfully renders this screen.
+
+Rules:
+- Interpret the component structure and its styling (Tailwind utility classes, CSS modules, styled components) into real inline <style> CSS. Match the product's actual look — colors, spacing, radii, type — as closely as the source allows.
+- The document is exactly 1280px wide. Choose the natural height for the content and declare it as the LAST line of your output, an HTML comment: <!-- doop-height: 900 -->
+- Replace dynamic data with realistic, specific placeholder content (plausible names, numbers, dates — never lorem ipsum or "Item 1").
+- No <script> tags, no external CSS or JS. Google Fonts via <link> are allowed when the source names a font.
+- Images: use a solid-color or CSS-gradient stand-in with the right aspect ratio; never invent external image URLs.
+- Start with <!doctype html>. Output ONLY the HTML document (plus the final height comment) — no markdown fences, no commentary.`
+
+export function extractHtml(blocks: { type: string; text?: string }[]): { html: string; height: number } {
+  const text = blocks
+    .filter((b) => b.type === 'text' && b.text)
+    .map((b) => b.text)
+    .join('\n')
+  const fenced = text.match(/```(?:html)?\s*([\s\S]*?)```/)
+  let html = (fenced ? fenced[1]! : text).trim()
+  const start = html.search(/<!doctype/i)
+  if (start === -1) throw new Error('the model returned no HTML document')
+  html = html.slice(start)
+  const height = Math.min(3000, Math.max(480, Number(html.match(/doop-height:\s*(\d+)/)?.[1]) || 900))
+  return { html, height }
+}
+
+/** Reconstruct the given outline frames in the background. Fire-and-forget
+ *  from the import route — every failure lands in the frame itself (the
+ *  outline flips to a 'failed' note) and in the log, never in the response. */
+export function scheduleReconstructions(
+  conn: GithubConnection,
+  jobs: { frameId: string; screen: RepoScreen }[],
+  actor: Actor,
+  payerId: string,
+): void {
+  if (!jobs.length) return
+  void (async () => {
+    const model = await pickModel(payerId)
+    if (!model) return /* no model — outlines stay, which the copy reflects */
+    const paths = await fetchTreePaths(conn)
+    const queue = jobs.slice(0, MAX_RECONSTRUCTIONS_PER_IMPORT)
+    console.log(`[github-recon] ${queue.length} screen(s) from ${conn.repo} on ${model.label}`)
+
+    async function runOne(job: { frameId: string; screen: RepoScreen }) {
+      try {
+        const closure = await collectClosure(conn, job.screen, paths)
+        if (!closure.length) throw new Error('no readable source')
+        const source = closure.map((f) => `===== ${f.path} =====\n${f.text}`).join('\n\n')
+        const result = await model!.run({
+          system: [{ text: SYSTEM_PROMPT, cache: true }],
+          tools: [],
+          messages: [
+            {
+              role: 'user',
+              content: `Screen: ${job.screen.title} (route ${job.screen.route}) from ${conn.repo}.\n\n${source}`,
+            },
+          ],
+          maxTokens: MODEL_MAX_TOKENS,
+        })
+        const { html, height } = extractHtml(result.content as { type: string; text?: string }[])
+        actions.updateFrame(job.frameId, { html: wrapGeneratedHtml(html, conn, job.screen), height }, actor)
+      } catch (err) {
+        console.error(`[github-recon] ${job.screen.route} failed`, err)
+        actions.updateFrame(job.frameId, { html: placeholderHtml(conn, job.screen, 'failed') }, actor)
+      }
+    }
+
+    /* small worker pool: steady progress on the canvas without hammering
+       the model or the GitHub API */
+    const workers = Array.from({ length: Math.min(RECON_CONCURRENCY, queue.length) }, async () => {
+      for (let job = queue.shift(); job; job = queue.shift()) await runOne(job)
+    })
+    await Promise.all(workers)
+    console.log(`[github-recon] ${conn.repo} done`)
+  })().catch((err) => console.error('[github-recon] pass failed', err))
+}

--- a/server/guide.ts
+++ b/server/guide.ts
@@ -171,6 +171,22 @@ Viewers watch designs assemble live. Stream with append_frame_html:
   component 480×360, square social post 640×640. Set width/height on create_frame, or
   adjust later with update_frame.
 
+## GitHub outline frames — design them from source
+
+Frames whose HTML carries a "doop-github-screen" marker meta were imported from a
+connected GitHub repository. Ones that ALSO carry "doop-github-placeholder" are
+outlines: the screen exists in that repo only as code (a Next.js page, a Storybook
+story) and is waiting to be designed. The marker records the repo, the route and the
+source file path.
+
+If you have that repository available (checked out locally, or reachable through your
+own tools), you are the best agent for the job: read the screen's source file and the
+components it imports, then set_frame_html a complete self-contained document that
+faithfully renders it — real CSS derived from its actual classes and design tokens,
+realistic placeholder data, no scripts. Design at the frame's width and resize the
+frame to the content. Updating the outline in place (not a new frame) is correct here —
+that is what the outline is for.
+
 ## Images — search first, then upload
 
 Real imagery is what separates an appealing design from a wireframe. Frames can load

--- a/server/index.ts
+++ b/server/index.ts
@@ -29,6 +29,8 @@ import {
 import * as ingest from './ingest.ts'
 import * as github from './github.ts'
 import * as githubApp from './githubApp.ts'
+import { scheduleReconstructions } from './githubRecon.ts'
+import { pickModel } from './agentModel.ts'
 import { seed } from './seed.ts'
 import * as allowance from './allowance.ts'
 import * as modelAccounts from './modelAccounts.ts'
@@ -940,11 +942,16 @@ app.post('/api/canvases/:id/github/:connId/import', async (req, res) => {
   if (!c) return
   const conn = await github.getConnection(c.id, req.params.connId)
   if (!conn) return res.status(404).json({ error: 'connection not found' })
-  /* live captures open Chromium — same budget as website imports */
   if (!takeImportSlot(req.user!.id)) return res.status(429).json({ error: 'too many imports — wait a minute' })
   try {
     const actor = actions.resolveActor({ name: req.user!.name, kind: 'user' })
-    res.json(await github.importScreens(conn, c, req.body?.screens, actor))
+    /* code-only screens get agent reconstruction when a model can run it —
+       the requester's own account, else the server tier (same resolution as
+       every other agent task, billed to the same person) */
+    const sketch = !!(await pickModel(req.user!.id))
+    const { pending, ...result } = await github.importScreens(conn, c, req.body?.screens, actor, { sketch })
+    scheduleReconstructions(conn, pending, actor, req.user!.id)
+    res.json(result)
   } catch (e) {
     res.status(400).json({ error: e instanceof Error ? e.message : 'import failed' })
   }

--- a/src/pages/CanvasPage.tsx
+++ b/src/pages/CanvasPage.tsx
@@ -673,7 +673,7 @@ function ImportModal({
   const selectedCount = selected.size
   const laneLabel: Record<RepoScreen['source'], string> = {
     static: 'from repo',
-    placeholder: 'outline',
+    placeholder: 'agent sketch',
   }
 
   return (

--- a/tests/githubRecon.test.ts
+++ b/tests/githubRecon.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest'
+import { extractHtml, resolveImport } from '../server/githubRecon.ts'
+
+/** The reconstruction pass's pure core: import resolution against a repo
+ *  tree, and pulling the HTML document (+ declared height) out of a model
+ *  reply. The model call itself is exercised in production, not here. */
+
+describe('resolveImport', () => {
+  const paths = new Set([
+    'src/pages/index.tsx',
+    'src/components/Hero.tsx',
+    'src/components/ui/index.ts',
+    'src/styles/globals.css',
+    'apps/web/src/lib/util.ts',
+  ])
+
+  it('resolves relative specifiers with extension and index probing', () => {
+    expect(resolveImport('../components/Hero', 'src/pages/index.tsx', paths)).toBe('src/components/Hero.tsx')
+    expect(resolveImport('../components/ui', 'src/pages/index.tsx', paths)).toBe('src/components/ui/index.ts')
+    expect(resolveImport('../styles/globals.css', 'src/pages/index.tsx', paths)).toBe('src/styles/globals.css')
+  })
+
+  it('maps @/ aliases to the nearest src root', () => {
+    expect(resolveImport('@/components/Hero', 'src/pages/index.tsx', paths)).toBe('src/components/Hero.tsx')
+    expect(resolveImport('@/lib/util', 'apps/web/src/pages/x.tsx', paths)).toBe('apps/web/src/lib/util.ts')
+  })
+
+  it('ignores package imports and unresolvable paths', () => {
+    expect(resolveImport('react', 'src/pages/index.tsx', paths)).toBeUndefined()
+    expect(resolveImport('./missing', 'src/pages/index.tsx', paths)).toBeUndefined()
+  })
+})
+
+describe('extractHtml', () => {
+  it('takes the document from plain text and reads the height comment', () => {
+    const { html, height } = extractHtml([
+      { type: 'text', text: 'Here it is:\n<!doctype html><html><body>x</body></html>\n<!-- doop-height: 1240 -->' },
+    ])
+    expect(html.startsWith('<!doctype html>')).toBe(true)
+    expect(height).toBe(1240)
+  })
+
+  it('unwraps markdown fences, clamps silly heights, defaults sans comment', () => {
+    const fenced = extractHtml([
+      { type: 'text', text: '```html\n<!doctype html><p>x</p>\n<!-- doop-height: 99999 -->\n```' },
+    ])
+    expect(fenced.height).toBe(3000)
+    expect(extractHtml([{ type: 'text', text: '<!doctype html><p>x</p>' }]).height).toBe(900)
+    expect(() => extractHtml([{ type: 'text', text: 'sorry, no' }])).toThrow(/no HTML/)
+  })
+})


### PR DESCRIPTION
When a repo has no live deployment, the Doop Agent reconstructs the screens from the code itself: it reads the routes/components and sketches each screen as a frame, replacing dead placeholders with drafts a human can react to.

Ported from the upstream private repo (upstream #111).

🤖 Generated with [Claude Code](https://claude.com/claude-code)