### PR TITLE
fix(github-app): handle already-installed accounts; surface install failures on the canvas

### DIFF
--- a/server/githubApp.ts
+++ b/server/githubApp.ts
@@ -231,3 +231,35 @@ export function verifyInstallPass(pass: string, canvasId: string): { installatio
 export function installUrl(state: string): string {
   return `https://github.com/apps/${appSlug()}/installations/new?state=${encodeURIComponent(state)}`
 }
+
+/* ------------------------------------------------------------------ */
+/* Already-installed bounce                                            */
+
+/* same env read as server/auth.ts — not imported, so this module stays
+   loadable in unit tests without the auth stack */
+const PUBLIC_ORIGIN = process.env.BETTER_AUTH_URL || 'http://localhost:4300'
+
+/** When the app is ALREADY installed on the chosen GitHub account, the
+ *  install screen becomes a configure screen and GitHub redirects back
+ *  WITHOUT an OAuth code — leaving the ownership check nothing to verify.
+ *  This second signed token carries the canvas + installation through an
+ *  explicit OAuth authorize round-trip that exists purely to produce that
+ *  code; the callback then verifies ownership exactly like a fresh install. */
+export function signOauthState(canvasId: string, installationId: string, now = Date.now()): string {
+  if (/[.]/.test(canvasId + installationId)) throw new Error('invalid id')
+  return pack('gh-oauth', [canvasId, installationId], now + STATE_TTL_MS)
+}
+
+export function verifyOauthState(state: string): { canvasId: string; installationId: string } | undefined {
+  const fields = unpack('gh-oauth', state, 2)
+  return fields ? { canvasId: fields[0]!, installationId: fields[1]! } : undefined
+}
+
+export function oauthBounceUrl(oauthState: string): string {
+  const params = new URLSearchParams({
+    client_id: process.env.GITHUB_APP_CLIENT_ID ?? '',
+    redirect_uri: `${PUBLIC_ORIGIN}/api/github/app/setup`,
+    state: oauthState,
+  })
+  return `https://github.com/login/oauth/authorize?${params}`
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -893,17 +893,47 @@ app.post('/api/canvases/:id/github/app/start', (req, res) => {
    state could bind someone else's installation. Then swaps state for a pass
    and returns to the canvas, where the import modal shows the repo picker. */
 app.get('/api/github/app/setup', async (req, res) => {
-  const state = githubApp.verifyInstallState(String(req.query.state ?? ''))
-  const installationId = String(req.query.installation_id ?? '')
-  if (!state || !/^\d+$/.test(installationId)) return res.redirect('/')
-  try {
-    if (!(await githubApp.verifyInstallationOwner(String(req.query.code ?? ''), installationId)))
-      return res.redirect('/')
-  } catch {
-    return res.redirect('/')
+  const rawState = String(req.query.state ?? '')
+  const code = String(req.query.code ?? '')
+  /* failures land back on the canvas with a visible reason — a silent
+     homepage redirect reads as "nothing happened" */
+  const fail = (canvasId: string, reason: string) =>
+    res.redirect(`/c/${encodeURIComponent(canvasId)}?ghError=${encodeURIComponent(reason)}`)
+  const succeed = (canvasId: string, installationId: string) =>
+    res.redirect(
+      `/c/${encodeURIComponent(canvasId)}?ghInstall=${encodeURIComponent(githubApp.signInstallPass(canvasId, installationId))}`,
+    )
+
+  /* return leg of the already-installed bounce: the authorize round-trip
+     produced the code the configure screen didn't */
+  const oauth = githubApp.verifyOauthState(rawState)
+  if (oauth) {
+    try {
+      if (await githubApp.verifyInstallationOwner(code, oauth.installationId))
+        return succeed(oauth.canvasId, oauth.installationId)
+    } catch {
+      /* fall through to the error redirect */
+    }
+    return fail(oauth.canvasId, 'GitHub couldn’t confirm you own that installation — try connecting again')
   }
-  const pass = githubApp.signInstallPass(state.canvasId, installationId)
-  res.redirect(`/c/${encodeURIComponent(state.canvasId)}?ghInstall=${encodeURIComponent(pass)}`)
+
+  const state = githubApp.verifyInstallState(rawState)
+  if (!state) return res.redirect('/')
+  const installationId = String(req.query.installation_id ?? '')
+  if (!/^\d+$/.test(installationId))
+    return fail(state.canvasId, 'GitHub sent no installation back — try connecting again')
+
+  /* app already installed on that account: GitHub showed the configure
+     screen and returned WITHOUT an OAuth code — bounce through authorize
+     (instant for an already-authorized user) purely to get one */
+  if (!code) return res.redirect(githubApp.oauthBounceUrl(githubApp.signOauthState(state.canvasId, installationId)))
+
+  try {
+    if (await githubApp.verifyInstallationOwner(code, installationId)) return succeed(state.canvasId, installationId)
+  } catch {
+    /* fall through to the error redirect */
+  }
+  return fail(state.canvasId, 'GitHub couldn’t confirm you own that installation — try connecting again')
 })
 
 app.get('/api/canvases/:id/github/app/repos', async (req, res) => {

--- a/src/pages/CanvasPage.tsx
+++ b/src/pages/CanvasPage.tsx
@@ -89,7 +89,13 @@ export function CanvasPage({ canvasId }: { canvasId: string }) {
     if (pass) history.replaceState(null, '', location.pathname)
     return pass
   })
-  const [showImport, setShowImport] = useState(!!ghInstallPass)
+  /* a failed install round-trip also lands here, with the reason to show */
+  const [ghInstallError] = useState<string | null>(() => {
+    const err = new URLSearchParams(location.search).get('ghError')
+    if (err) history.replaceState(null, '', location.pathname)
+    return err
+  })
+  const [showImport, setShowImport] = useState(!!ghInstallPass || !!ghInstallError)
   const [showMobileActions, setShowMobileActions] = useState(false)
   const [renaming, setRenaming] = useState(false)
   const [toast, setToast] = useState<string | null>(null)
@@ -498,6 +504,7 @@ export function CanvasPage({ canvasId }: { canvasId: string }) {
         <ImportModal
           canvasId={canvasId}
           installPass={ghInstallPass}
+          installError={ghInstallError}
           onClose={() => {
             setShowImport(false)
             setGhInstallPass(null)
@@ -526,11 +533,13 @@ export function CanvasPage({ canvasId }: { canvasId: string }) {
 function ImportModal({
   canvasId,
   installPass,
+  installError,
   onClose,
   onDone,
 }: {
   canvasId: string
   installPass: string | null
+  installError: string | null
   onClose: () => void
   onDone: (frameIds: string[], failedCount: number) => void
 }) {
@@ -852,7 +861,12 @@ function ImportModal({
               </Button>
             </ModalActions>
             <SyncKeysSection canvasId={canvasId} />
-            <GithubSection canvasId={canvasId} installPass={installPass} onReview={openRepoReview} />
+            <GithubSection
+              canvasId={canvasId}
+              installPass={installPass}
+              installError={installError}
+              onReview={openRepoReview}
+            />
           </>
         ) : (
           <>
@@ -1278,10 +1292,12 @@ function SyncKeysSection({ canvasId }: { canvasId: string }) {
 function GithubSection({
   canvasId,
   installPass,
+  installError,
   onReview,
 }: {
   canvasId: string
   installPass: string | null
+  installError: string | null
   onReview: (connection: GithubConnectionInfo, manifest: RepoManifest) => void
 }) {
   const [connections, setConnections] = useState<GithubConnectionInfo[] | null>(null)
@@ -1291,7 +1307,7 @@ function GithubSection({
   const [repo, setRepo] = useState('')
   const [token, setToken] = useState('')
   const [busy, setBusy] = useState<'connecting' | string | null>(null)
-  const [error, setError] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(installError)
   const [forbidden, setForbidden] = useState(false)
 
   useEffect(() => {

--- a/tests/githubApp.test.ts
+++ b/tests/githubApp.test.ts
@@ -4,10 +4,13 @@ import {
   appEnabled,
   appJwt,
   installUrl,
+  oauthBounceUrl,
   signInstallPass,
   signInstallState,
+  signOauthState,
   verifyInstallPass,
   verifyInstallState,
+  verifyOauthState,
 } from '../server/githubApp.ts'
 import { Client, startServer, type Server } from './harness.ts'
 
@@ -35,6 +38,29 @@ describe('install handoff signatures', () => {
     expect(verifyInstallPass(expired, 'canvas1')).toBeUndefined()
     /* a state is not a pass */
     expect(verifyInstallPass(signInstallState('canvas1', 'user1'), 'canvas1')).toBeUndefined()
+  })
+
+  it('keeps the oauth-bounce state distinct from install state and pass', () => {
+    const oauth = signOauthState('canvas1', '12345')
+    expect(verifyOauthState(oauth)).toEqual({ canvasId: 'canvas1', installationId: '12345' })
+    /* the three kinds must never be interchangeable */
+    expect(verifyOauthState(signInstallState('canvas1', 'user1'))).toBeUndefined()
+    expect(verifyOauthState(signInstallPass('canvas1', '12345'))).toBeUndefined()
+    expect(verifyInstallPass(oauth, 'canvas1')).toBeUndefined()
+    expect(verifyInstallState(oauth)).toBeUndefined()
+  })
+
+  it('builds the authorize bounce URL from the app client id', () => {
+    process.env.GITHUB_APP_CLIENT_ID = 'Iv1.test'
+    try {
+      const url = new URL(oauthBounceUrl('s1'))
+      expect(url.origin + url.pathname).toBe('https://github.com/login/oauth/authorize')
+      expect(url.searchParams.get('client_id')).toBe('Iv1.test')
+      expect(url.searchParams.get('state')).toBe('s1')
+      expect(url.searchParams.get('redirect_uri')).toContain('/api/github/app/setup')
+    } finally {
+      delete process.env.GITHUB_APP_CLIENT_ID
+    }
   })
 })
 


### PR DESCRIPTION
Accounts that already installed the GitHub App no longer dead-end (the callback resolves the existing installation), and install failures surface on the canvas instead of vanishing into the redirect.

Ported from the upstream private repo (upstream #114).

🤖 Generated with [Claude Code](https://claude.com/claude-code)