### PR TITLE
feat(github-import): components and design system become the headline

### DIFF
--- a/server/github.ts
+++ b/server/github.ts
@@ -164,7 +164,7 @@ export async function deleteConnection(canvasId: string, id: string): Promise<bo
 /* ------------------------------------------------------------------ */
 /* Screen detection — pure functions over the repo's file listing      */
 
-export type ScreenKind = 'page' | 'story' | 'static'
+export type ScreenKind = 'page' | 'story' | 'component' | 'static'
 export type PixelSource = 'static' | 'placeholder'
 
 export interface RepoScreen {
@@ -282,6 +282,21 @@ export function detectScreens(paths: string[], pkg: Record<string, unknown> | nu
     const m = p.match(/(?:^|\/)([^/]+)\.stories\.(?:tsx|jsx|ts|js|mdx)$/)
     if (!m) continue
     screens.push({ kind: 'story', route: p, sourcePath: p, title: m[1]!, dynamic: false, source: 'placeholder' })
+  }
+
+  /* The component library: PascalCase modules under components/ui dirs — the
+     design system made concrete. Small and self-contained, so these
+     reconstruct far more faithfully than whole pages. */
+  const MAX_COMPONENTS = 60
+  let components = 0
+  for (const p of paths) {
+    if (components >= MAX_COMPONENTS) break
+    if (p.includes('node_modules/')) continue
+    const m = p.match(/(?:^|\/)(?:components|ui)\/(?:.*\/)?([A-Z][\w]*)\.(?:tsx|jsx)$/)
+    if (!m) continue
+    if (/\.(stories|test|spec)\./.test(p)) continue
+    components++
+    screens.push({ kind: 'component', route: p, sourcePath: p, title: m[1]!, dynamic: false, source: 'placeholder' })
   }
 
   /* Plain HTML anywhere (marketing pages, committed dist/ output) */
@@ -606,7 +621,8 @@ export async function importScreens(
   for (const screen of selection) {
     try {
       let html: string
-      const width = DEFAULT_W
+      const compact = screen.kind === 'component' || screen.kind === 'story'
+      const width = compact ? 640 : DEFAULT_W
       let height = DEFAULT_H
       const name = screen.title
       let outline = false
@@ -614,7 +630,7 @@ export async function importScreens(
         html = wrapRepoHtml(await fetchRepoFile(conn, screen.sourcePath), conn, screen)
       } else {
         html = placeholderHtml(conn, screen, options.sketch ? 'sketching' : 'plain')
-        height = 800
+        height = compact ? 420 : 800
         outline = true
       }
       const frame = place(name, html, width, height)

--- a/server/githubRecon.ts
+++ b/server/githubRecon.ts
@@ -211,6 +211,110 @@ export function extractHtml(blocks: { type: string; text?: string }[]): { html: 
   return { html, height }
 }
 
+const DESIGN_SYSTEM_PROMPT = `You are Doop's design-system archaeologist. From the given repository files (theme/token modules, tailwind/framework config, global styles, app shell, package.json), distill the product's ACTUAL design system into a style guide for design agents.
+
+Output ONLY markdown with these sections:
+- **Palette** — every meaningful color as hex with its role (ground, ink, accent, success…), taken from the code, not invented.
+- **Typography** — the real faces, weights and scale; include ready-to-paste Google Fonts <link> tags when the fonts are on Google Fonts.
+- **Shape & space** — radii, spacing rhythm, shadows, border style.
+- **Component idioms** — how buttons, cards, inputs and nav actually look (fills, radii, hover states) in a few crisp bullets.
+- **CSS variables** — one ready-to-paste :root block encoding the above.
+Rules the agents must follow verbatim belong here; keep it under 350 lines. No commentary outside the markdown.`
+
+/** Distill the repo's design system into style-guide markdown. Reuses the
+ *  same seeding logic as screen closures but aimed at the system files. */
+export async function extractDesignSystem(
+  conn: GithubConnection,
+  paths: string[],
+  model: NonNullable<Awaited<ReturnType<typeof pickModel>>>,
+): Promise<string> {
+  const seeds = [
+    'package.json',
+    ...paths.filter((p) => !p.includes('node_modules') && /(^|\/)tailwind\.config\.[jt]s$/.test(p)).slice(0, 1),
+    ...paths.filter((p) => !p.includes('node_modules') && /(^|\/)(theme|tokens|colors)\.[jt]sx?$/i.test(p)).slice(0, 3),
+    ...paths
+      .filter((p) => !p.includes('node_modules') && /(^|\/)(globals?|app|main|index)\.(css|scss)$/.test(p))
+      .slice(0, 3),
+    ...paths.filter((p) => !p.includes('node_modules') && /(^|\/)_(document|app)\.[jt]sx$/.test(p)).slice(0, 2),
+  ]
+  const sections: string[] = []
+  let budget = MAX_CLOSURE_BYTES
+  for (const p of [...new Set(seeds)]) {
+    if (budget <= 0) break
+    try {
+      let text = await fetchRepoFile(conn, p)
+      if (text.length > budget) text = text.slice(0, budget)
+      budget -= text.length
+      sections.push(`===== ${p} =====\n${text}`)
+    } catch {
+      /* missing seed — the tree round below can recover it */
+    }
+  }
+  const messages: Parameters<typeof model.run>[0]['messages'] = [
+    {
+      role: 'user',
+      content:
+        `Repository ${conn.repo}. File tree (request more files if the system lives elsewhere):\n` +
+        `${treeExcerpt(paths, 'src/x')}\n\n${sections.join('\n\n')}`,
+    },
+  ]
+  const pathSet = new Set(paths)
+  let requestedBudget = MAX_REQUESTED_BYTES
+  let result = await model.run({
+    system: [{ text: DESIGN_SYSTEM_PROMPT, cache: true }],
+    tools: [REQUEST_FILES_TOOL],
+    messages,
+    maxTokens: 16_000,
+  })
+  if (result.stop_reason === 'tool_use') {
+    const calls = result.content.filter((b) => b.type === 'tool_use')
+    messages.push({ role: 'assistant', content: result.content })
+    const results = []
+    for (const call of calls) {
+      const wanted = (
+        Array.isArray((call.input as { paths?: unknown })?.paths)
+          ? ((call.input as { paths: unknown[] }).paths as unknown[])
+          : []
+      )
+        .map(String)
+        .filter((p) => pathSet.has(p))
+        .slice(0, MAX_REQUESTED_FILES)
+      const parts: string[] = []
+      for (const p of wanted) {
+        if (requestedBudget <= 0) break
+        try {
+          let text = await fetchRepoFile(conn, p)
+          if (text.length > requestedBudget) text = text.slice(0, requestedBudget)
+          requestedBudget -= text.length
+          parts.push(`===== ${p} =====\n${text}`)
+        } catch {
+          parts.push(`===== ${p} =====\n/* unreadable */`)
+        }
+      }
+      results.push({
+        type: 'tool_result' as const,
+        tool_use_id: call.id,
+        content: parts.join('\n\n') || 'none of those paths exist',
+      })
+    }
+    messages.push({ role: 'user', content: results })
+    result = await model.run({
+      system: [{ text: DESIGN_SYSTEM_PROMPT, cache: true }],
+      tools: [],
+      messages,
+      maxTokens: 16_000,
+    })
+  }
+  const md = result.content
+    .filter((b) => b.type === 'text' && 'text' in b)
+    .map((b) => (b as { text: string }).text)
+    .join('\n')
+    .replace(/^```(?:markdown|md)?\s*|```\s*$/g, '')
+    .trim()
+  if (!md) throw new Error('the model returned no design system')
+  return md
+}
+
 const REPO_REF_RE = /(["'(])repo:([^"')\s]+)(["')])/g
 const MAX_TRANSPLANTED_ASSETS = 12
 const TRANSPARENT_PX = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7'
@@ -250,8 +354,9 @@ export function scheduleReconstructions(
   jobs: { frameId: string; screen: RepoScreen }[],
   requester: Actor,
   payerId: string,
+  opts: { designSystem?: boolean } = {},
 ): void {
-  if (!jobs.length) return
+  if (!jobs.length && !opts.designSystem) return
   void (async () => {
     const model = await pickModel(payerId)
     if (!model) return /* no model — outlines stay, which the copy reflects */
@@ -261,7 +366,30 @@ export function scheduleReconstructions(
        of the human who clicked Import. */
     const actor = actions.resolveActor({ name: 'Doop', kind: 'agent', owner: requester.name })
     const paths = await fetchTreePaths(conn)
+
+    /* the design system first: it becomes a pinned canvas guideline every
+       agent follows, and it grounds the sketches below */
+    let designSystemMd = ''
+    if (opts.designSystem) {
+      try {
+        actions.setAgentStatus(conn.canvasId, actor, `Reading ${conn.repo}’s design system — theme, tokens, type`)
+        designSystemMd = await extractDesignSystem(conn, paths, model)
+        const slug = `${conn.repo
+          .split('/')
+          .pop()!
+          .toLowerCase()
+          .replace(/[^a-z0-9-]+/g, '-')}-design-system`
+        actions.setGuideline(conn.canvasId, slug, designSystemMd, actor, undefined, `${conn.repo} design system`)
+      } catch (err) {
+        console.error(`[github-recon] design system extraction for ${conn.repo} failed`, err)
+      }
+    }
+
     const queue = jobs.slice(0, MAX_RECONSTRUCTIONS_PER_IMPORT)
+    if (!queue.length) {
+      actions.setAgentStatus(conn.canvasId, actor, '')
+      return
+    }
     const plural = queue.length === 1 ? 'screen' : 'screens'
     actions.setAgentStatus(
       conn.canvasId,
@@ -288,11 +416,20 @@ export function scheduleReconstructions(
         const closure = await collectClosure(conn, job.screen, paths)
         if (!closure.length) throw new Error('no readable source')
         const source = closure.map((f) => `===== ${f.path} =====\n${f.text}`).join('\n\n')
+        const componentBrief =
+          job.screen.kind === 'component' || job.screen.kind === 'story'
+            ? `This is a COMPONENT, not a page: present it as an isolated library card — a quiet neutral backdrop, the component rendered at natural size, and its key variants/states side by side when the source defines them. Keep the card compact.\n\n`
+            : ''
+        const systemContext = designSystemMd
+          ? `The product's design system, distilled from this repo (follow it exactly):\n${designSystemMd}\n\n`
+          : ''
         const messages: Parameters<NonNullable<typeof model>['run']>[0]['messages'] = [
           {
             role: 'user',
             content:
               `Screen: ${job.screen.title} (route ${job.screen.route}) from ${conn.repo}.\n\n` +
+              componentBrief +
+              systemContext +
               `Repository file tree (investigate with request_files):\n${treeExcerpt(paths, job.screen.sourcePath)}\n\n${source}`,
           },
         ]

--- a/server/index.ts
+++ b/server/index.ts
@@ -979,8 +979,9 @@ app.post('/api/canvases/:id/github/:connId/import', async (req, res) => {
        the requester's own account, else the server tier (same resolution as
        every other agent task, billed to the same person) */
     const sketch = !!(await pickModel(req.user!.id))
+    const designSystem = sketch && req.body?.design_system !== false
     const { pending, ...result } = await github.importScreens(conn, c, req.body?.screens, actor, { sketch })
-    scheduleReconstructions(conn, pending, actor, req.user!.id)
+    scheduleReconstructions(conn, pending, actor, req.user!.id, { designSystem })
     res.json(result)
   } catch (e) {
     res.status(400).json({ error: e instanceof Error ? e.message : 'import failed' })

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -58,7 +58,7 @@ export interface InstallationRepo {
 }
 
 export interface RepoScreen {
-  kind: 'page' | 'story' | 'static'
+  kind: 'page' | 'story' | 'component' | 'static'
   route: string
   sourcePath: string
   title: string
@@ -206,10 +206,10 @@ export const api = {
     req(`/api/canvases/${canvasId}/github/${connId}`, { method: 'DELETE' }),
   analyzeGithub: (canvasId: string, connId: string) =>
     req<RepoManifest>(`/api/canvases/${canvasId}/github/${connId}/analyze`, { method: 'POST' }),
-  importGithubScreens: (canvasId: string, connId: string, screens: RepoScreen[]) =>
+  importGithubScreens: (canvasId: string, connId: string, screens: RepoScreen[], designSystem = true) =>
     req<GithubImportResult>(`/api/canvases/${canvasId}/github/${connId}/import`, {
       method: 'POST',
-      body: JSON.stringify({ screens }),
+      body: JSON.stringify({ screens, design_system: designSystem }),
     }),
   guidelineHistory: (canvasId: string, name: string) =>
     req<{ markdown: string; savedAt: number; savedBy: string }[]>(

--- a/src/pages/CanvasPage.tsx
+++ b/src/pages/CanvasPage.tsx
@@ -554,6 +554,7 @@ function ImportModal({
     null,
   )
   const [repoSelected, setRepoSelected] = useState<Set<string>>(new Set())
+  const [extractSystem, setExtractSystem] = useState(true)
 
   function errorMessage(caught: unknown, fallback: string) {
     if (caught instanceof ApiError) return String(caught.body.error ?? fallback)
@@ -657,7 +658,7 @@ function ImportModal({
     setError(null)
     const screens = repoReview.manifest.screens.filter((s) => repoSelected.has(screenKey(s)))
     try {
-      const result = await api.importGithubScreens(canvasId, repoReview.connection.id, screens)
+      const result = await api.importGithubScreens(canvasId, repoReview.connection.id, screens, extractSystem)
       if (!result.frames.length) {
         const reason = result.failures[0]?.error
         setError(reason ? `No screens could be imported — ${reason}` : 'No screens could be imported')
@@ -684,6 +685,8 @@ function ImportModal({
     static: 'from repo',
     placeholder: 'agent sketch',
   }
+  const kindLabel = (s: RepoScreen) =>
+    s.kind === 'component' ? 'component' : s.kind === 'story' ? 'story' : laneLabel[s.source]
 
   return (
     <Modal size="lg" onClose={() => !busy && onClose()}>
@@ -763,11 +766,18 @@ function ImportModal({
                       screen.source === 'placeholder' ? 'bg-paper-deep text-ink-faint' : 'bg-brand/10 text-accent-ink',
                     )}
                   >
-                    {laneLabel[screen.source]}
+                    {kindLabel(screen)}
                   </span>
                 </label>
               ))}
             </div>
+            <CheckboxCard
+              checked={extractSystem}
+              disabled={!!busy}
+              onChange={setExtractSystem}
+              title="Extract the design system into a style guide"
+              description="Palette, type and spacing from the repo's theme — pinned to the canvas, followed by every agent."
+            />
             {repoReview.manifest.truncated && (
               <p className={importNoteCls}>The repository listing was cut short — very large repos show a subset.</p>
             )}

--- a/tests/github.test.ts
+++ b/tests/github.test.ts
@@ -62,6 +62,21 @@ describe('screen enumeration', () => {
     expect(screens.map((s) => s.route)).toEqual(['/', '/settings'])
   })
 
+  it('detects PascalCase component modules under components/ui dirs', () => {
+    const screens = detectScreens(
+      [
+        'src/components/Button.tsx',
+        'src/components/nav/NavBar.tsx',
+        'src/ui/Card.jsx',
+        'src/components/Button.test.tsx',
+        'src/components/helpers.ts',
+        'src/utils/Format.tsx',
+      ],
+      nextPkg,
+    )
+    expect(screens.filter((s) => s.kind === 'component').map((s) => s.title)).toEqual(['Button', 'NavBar', 'Card'])
+  })
+
   it('sweeps storybook stories and plain html regardless of framework', () => {
     const screens = detectScreens(
       ['src/Button.stories.tsx', 'public/landing.html', 'dist/index.html', 'node_modules/x/y.html'],


### PR DESCRIPTION
The import's primary output shifts: the extracted components and design system lead, with reconstructed screens supporting them rather than the other way around.

Ported from the upstream private repo (upstream #119).

🤖 Generated with [Claude Code](https://claude.com/claude-code)