### PR TITLE
chore(desktop): bump to 0.1.3 for the Disc-D icon release

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "doop-desktop",
   "private": true,
-  "version": "0.1.2",
+  "version": "0.1.3",
   "scripts": {
     "tauri": "tauri",
     "dev": "tauri dev",

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "doop",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "identifier": "design.doop.desktop",
   "build": {
     "devUrl": "http://localhost:4300",


### PR DESCRIPTION
Version bump so the next `desktop-v0.1.3` tag ships the Disc-D app icon that landed in #81.

🤖 Generated with [Claude Code](https://claude.com/claude-code)