### PR TITLE
fix: disable vertical tab bar scrolling

### DIFF
--- a/src/components/DesktopTabs.tsx
+++ b/src/components/DesktopTabs.tsx
@@ -50,7 +50,7 @@ export function DesktopTabs({ path }: { path: string }) {
       <div
         role="tablist"
         aria-label="Open canvases"
-        className="flex min-w-0 items-end overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+        className="flex min-w-0 items-end overflow-x-auto overflow-y-hidden [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
       >
         {tabs.map((tab) => {
           const on = tab.id === activeId


### PR DESCRIPTION
## Summary

- prevent vertical wheel gestures from scrolling the macOS desktop tab strip
- preserve horizontal overflow for canvases that do not fit

Fixes #84.

## Validation

- `bun x eslint src/components/DesktopTabs.tsx`
- `bun x prettier --check src/components/DesktopTabs.tsx`
- `bun run typecheck`
- `bun run build`

## Risk

This only changes the tab list's vertical overflow behavior. Horizontal scrolling and tab layout are unchanged.
