### PR TITLE
feat: add canvas actions and duplication

### DIFF
--- a/server/db/persist.ts
+++ b/server/db/persist.ts
@@ -48,6 +48,76 @@ export function saveCanvas(c: Canvas) {
   )
 }
 
+/** Persist a newly duplicated canvas as one unit. Unlike ordinary live edits,
+ * duplication must not report success until every copied row is durable. */
+export async function saveCanvasCopy(c: Canvas): Promise<void> {
+  await db.transaction(async (tx) => {
+    await tx.insert(t.canvases).values({
+      id: c.id,
+      name: c.name,
+      ownerId: c.ownerId ?? null,
+      linkAccess: c.linkAccess ?? null,
+      createdAt: c.createdAt,
+      updatedAt: c.updatedAt,
+    })
+
+    if (c.frames.length) {
+      await tx.insert(t.frames).values(
+        c.frames.map((frame) => ({
+          id: frame.id,
+          canvasId: frame.canvasId,
+          name: frame.name,
+          x: frame.x,
+          y: frame.y,
+          width: frame.width,
+          height: frame.height,
+          html: frame.html,
+          createdAt: frame.createdAt,
+          updatedAt: frame.updatedAt,
+          updatedBy: frame.updatedBy,
+          demo: frame.demo ?? null,
+        })),
+      )
+    }
+
+    if (c.guidelines?.length) {
+      await tx.insert(t.guidelines).values(
+        c.guidelines.map((doc) => ({
+          canvasId: c.id,
+          name: doc.name,
+          markdown: doc.markdown,
+          title: doc.title ?? null,
+          updatedAt: doc.updatedAt,
+          updatedBy: doc.updatedBy,
+          x: doc.x ?? null,
+          y: doc.y ?? null,
+        })),
+      )
+    }
+
+    if (c.references?.length) {
+      await tx.insert(t.memoryReferences).values(
+        c.references.map((ref) => ({
+          id: ref.id,
+          canvasId: c.id,
+          frameId: ref.frameId,
+          title: ref.title,
+          html: ref.html,
+          width: ref.width,
+          height: ref.height,
+          pinnedBy: ref.pinnedBy,
+          pinnedAt: ref.pinnedAt,
+        })),
+      )
+    }
+
+    const refs = c.frames.flatMap((frame) =>
+      [...extractAssetIds(frame.html)].map((assetId) => ({ assetId, frameId: frame.id })),
+    )
+    if (refs.length) await tx.insert(t.assetRefs).values(refs)
+  })
+}
+
 export function saveMember(canvasId: string, userId: string, addedBy: string, addedAt: number) {
   swallow(db.insert(t.canvasMembers).values({ canvasId, userId, addedBy, addedAt }).onConflictDoNothing())
 }

--- a/server/index.ts
+++ b/server/index.ts
@@ -687,6 +687,19 @@ app.post('/api/canvases', (req, res) => {
   res.json(store.createCanvas(name, req.user!.id))
 })
 
+app.post('/api/canvases/:id/duplicate', async (req, res) => {
+  const source = store.getCanvas(req.params.id)
+  if (!source) return res.status(404).json({ error: 'not found' })
+  if (!hasDurableCanvasAccess(req.user!.id, source)) return res.status(403).json({ error: 'access denied' })
+  try {
+    const copy = await store.duplicateCanvas(source.id, req.user!.id, req.user!.name)
+    res.json(copy)
+  } catch (error) {
+    console.error('[canvas] duplicate failed', error)
+    res.status(500).json({ error: 'could not duplicate canvas' })
+  }
+})
+
 app.get('/api/canvases/:id', (req, res) => {
   const c = requireCanvas(req, res, req.params.id)
   if (c) res.json(c)

--- a/server/store.ts
+++ b/server/store.ts
@@ -72,6 +72,46 @@ class Store {
     return canvas
   }
 
+  /** Copy reusable design content into a new private canvas. Collaboration,
+   * activity, tasks and external connections belong to the source only. */
+  async duplicateCanvas(id: string, ownerId: string, by: string): Promise<Canvas | undefined> {
+    const source = this.canvases.get(id)
+    if (!source) return undefined
+    const now = Date.now()
+    const canvasId = nanoid(10)
+    const frameIds = new Map(source.frames.map((frame) => [frame.id, nanoid(10)]))
+    const frames = source.frames.map((frame) => ({
+      ...frame,
+      id: frameIds.get(frame.id)!,
+      canvasId,
+      createdAt: now,
+      updatedAt: now,
+      updatedBy: by,
+    }))
+    const guidelines = source.guidelines?.map((doc) => ({ ...doc, updatedAt: now, updatedBy: by }))
+    const references = source.references?.map((ref) => ({
+      ...ref,
+      id: nanoid(10),
+      frameId: frameIds.get(ref.frameId) ?? ref.frameId,
+      pinnedBy: by,
+      pinnedAt: now,
+    }))
+    const canvas: Canvas = {
+      id: canvasId,
+      name: `${source.name} copy`,
+      ownerId,
+      createdAt: now,
+      updatedAt: now,
+      frames,
+      ...(guidelines?.length ? { guidelines } : {}),
+      ...(references?.length ? { references } : {}),
+    }
+    await persist.saveCanvasCopy(canvas)
+    this.canvases.set(canvas.id, canvas)
+    for (const frame of frames) this.frameIndex.set(frame.id, canvas.id)
+    return canvas
+  }
+
   getCanvas(id: string) {
     return this.canvases.get(id)
   }

--- a/src/components/ShareModal.tsx
+++ b/src/components/ShareModal.tsx
@@ -1,0 +1,201 @@
+import { useEffect, useState } from 'react'
+import type { Canvas } from '../../shared/types'
+import { navigate } from '../App'
+import { api, ApiError, type CanvasMember } from '../lib/api'
+import { authClient } from '../lib/auth'
+import { posthog } from '../lib/posthog'
+import { Avatar } from './ui/avatar'
+import { Button } from './ui/button'
+import { Checkbox } from './ui/checkbox'
+import { XIcon } from './ui/icons'
+import { Input } from './ui/input'
+import { Modal, ModalTitle } from './ui/modal'
+
+type ShareableCanvas = Pick<Canvas, 'id' | 'name' | 'ownerId' | 'linkAccess' | 'memberIds'>
+type SharePatch = Partial<Pick<ShareableCanvas, 'linkAccess' | 'memberIds'>>
+
+/* One sharing surface for the canvas and dashboard. The caller owns canvas
+   state; this component reports optimistic access changes back to it. */
+export function ShareModal({
+  canvas,
+  onChange,
+  onClose,
+  onCopied,
+}: {
+  canvas: ShareableCanvas
+  onChange: (patch: SharePatch) => void
+  onClose: () => void
+  onCopied: () => void
+}) {
+  const { data: session } = authClient.useSession()
+  const meId = session?.user?.id
+  const isOwner = !!canvas.ownerId && canvas.ownerId === meId
+  const linkEdits = canvas.linkAccess === 'edit'
+  const [people, setPeople] = useState<CanvasMember[] | null>(null)
+  const [email, setEmail] = useState('')
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let active = true
+    api
+      .listMembers(canvas.id)
+      .then((members) => active && setPeople(members))
+      .catch(() => active && setPeople([]))
+    return () => {
+      active = false
+    }
+  }, [canvas.id])
+
+  async function invite() {
+    const clean = email.trim()
+    if (!clean || busy || people === null) return
+    setBusy(true)
+    setError(null)
+    try {
+      const member = await api.inviteMember(canvas.id, clean)
+      setPeople((current) =>
+        current?.some((person) => person.userId === member.userId) ? current : [...(current ?? []), member],
+      )
+      if (!canvas.memberIds?.includes(member.userId)) {
+        onChange({ memberIds: [...(canvas.memberIds ?? []), member.userId] })
+      }
+      setEmail('')
+    } catch (caught) {
+      setError(caught instanceof ApiError ? String(caught.body.error ?? 'invite failed') : 'invite failed')
+    }
+    setBusy(false)
+  }
+
+  async function remove(userId: string) {
+    if (busy) return
+    setBusy(true)
+    setError(null)
+    try {
+      await api.removeMember(canvas.id, userId)
+      setPeople((current) => current?.filter((person) => person.userId !== userId) ?? null)
+      onChange({ memberIds: canvas.memberIds?.filter((id) => id !== userId) })
+      if (userId === meId && !isOwner) navigate('/')
+    } catch (caught) {
+      setError(caught instanceof ApiError ? String(caught.body.error ?? 'removal failed') : 'removal failed')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  async function toggleLink(next: boolean) {
+    if (busy) return
+    const linkAccess = next ? 'edit' : 'none'
+    setBusy(true)
+    setError(null)
+    try {
+      await api.setLinkAccess(canvas.id, linkAccess)
+      onChange({ linkAccess })
+    } catch (caught) {
+      setError(
+        caught instanceof ApiError ? String(caught.body.error ?? 'access update failed') : 'access update failed',
+      )
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  async function copy() {
+    setError(null)
+    try {
+      await navigator.clipboard.writeText(`${location.origin}/c/${canvas.id}`)
+      posthog.capture('canvas_link_shared')
+      onCopied()
+    } catch {
+      setError('Couldn’t copy the link. Copy the URL from your browser instead.')
+    }
+  }
+
+  return (
+    <Modal size="sm" onClose={onClose}>
+      <>
+        <div className="flex items-start justify-between gap-3">
+          <ModalTitle className="min-w-0">Share “{canvas.name}”</ModalTitle>
+          <Button variant="ghost" size="icon" className="size-10" aria-label="Close sharing" onClick={onClose}>
+            <XIcon />
+          </Button>
+        </div>
+        {isOwner && (
+          <>
+            <div className="mt-4 flex flex-col items-stretch gap-2 sm:flex-row">
+              <Input
+                className="flex-1 rounded-[10px] bg-paper focus:ring-0"
+                autoFocus
+                placeholder="Invite by email (doop account)"
+                value={email}
+                disabled={busy}
+                onChange={(event) => setEmail(event.target.value)}
+                onKeyDown={(event) => event.key === 'Enter' && invite()}
+              />
+              <Button
+                variant="primary"
+                className="justify-center"
+                disabled={busy || people === null || !email.trim()}
+                onClick={invite}
+              >
+                Invite
+              </Button>
+            </div>
+          </>
+        )}
+        {error && <p className="mx-[2px] mt-2 text-[12px] text-accent-ink">{error}</p>}
+        <div className="mt-[14px] mb-1 flex max-h-[40vh] flex-col gap-[2px] overflow-y-auto">
+          {(people ?? []).map((person) => (
+            <div key={person.userId} className="flex items-center gap-2.5 px-[2px] py-1.5">
+              <Avatar name={person.name} className="size-7 flex-none border-0 text-xs" />
+              <span className="flex min-w-0 flex-1 flex-col leading-[1.3]">
+                <b className="overflow-hidden whitespace-nowrap text-ellipsis text-[13px] font-semibold">
+                  {person.name}
+                  {person.userId === meId ? ' (you)' : ''}
+                </b>
+                <span className="overflow-hidden whitespace-nowrap text-ellipsis text-[12px] text-ink-faint">
+                  {person.email}
+                </span>
+              </span>
+              {person.owner ? (
+                <span className="flex-none text-[12px] text-ink-faint">Owner</span>
+              ) : isOwner || person.userId === meId ? (
+                <Button
+                  variant="bare"
+                  size="icon-sm"
+                  className="flex-none text-[13px] hover:bg-accent-ink/10 hover:text-accent-ink"
+                  title={person.userId === meId ? 'Leave this canvas' : 'Remove'}
+                  disabled={busy}
+                  onClick={() => remove(person.userId)}
+                >
+                  ✕
+                </Button>
+              ) : (
+                <span className="flex-none text-[12px] text-ink-faint">Can edit</span>
+              )}
+            </div>
+          ))}
+          {people === null && <p className="text-[12px] text-ink-faint">Loading…</p>}
+        </div>
+        <div className="mt-2.5 flex flex-col items-stretch justify-between gap-2.5 border-t border-line-soft pt-3.5 sm:flex-row sm:items-center">
+          {isOwner ? (
+            <label
+              className="relative flex cursor-pointer items-center gap-2 text-[13px] font-medium text-ink"
+              title="Off = only you and invited people can open this canvas"
+            >
+              <Checkbox checked={linkEdits} disabled={busy} onChange={(event) => toggleLink(event.target.checked)} />
+              Anyone with the link can edit
+            </label>
+          ) : (
+            <span className="text-xs text-ink-faint">
+              {linkEdits ? 'Anyone with the link can edit' : 'Invite-only canvas'}
+            </span>
+          )}
+          <Button className="justify-center" onClick={copy}>
+            ⧉ Copy link
+          </Button>
+        </div>
+      </>
+    </Modal>
+  )
+}

--- a/src/components/ui/icons.tsx
+++ b/src/components/ui/icons.tsx
@@ -19,6 +19,44 @@ export function XIcon(props: SVGProps<SVGSVGElement>) {
   )
 }
 
+export function MoreHorizontalIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg {...iconProps} {...props}>
+      <circle cx="5" cy="12" r="1" fill="currentColor" stroke="none" />
+      <circle cx="12" cy="12" r="1" fill="currentColor" stroke="none" />
+      <circle cx="19" cy="12" r="1" fill="currentColor" stroke="none" />
+    </svg>
+  )
+}
+
+export function ShareIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg {...iconProps} {...props}>
+      <circle cx="18" cy="5" r="3" />
+      <circle cx="6" cy="12" r="3" />
+      <circle cx="18" cy="19" r="3" />
+      <path d="m8.6 10.5 6.8-4M8.6 13.5l6.8 4" />
+    </svg>
+  )
+}
+
+export function CopyIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg {...iconProps} {...props}>
+      <rect width="13" height="13" x="8" y="8" rx="2" />
+      <path d="M16 8V5a2 2 0 0 0-2-2H5a2 2 0 0 0-2 2v9a2 2 0 0 0 2 2h3" />
+    </svg>
+  )
+}
+
+export function TrashIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg {...iconProps} {...props}>
+      <path d="M3 6h18M8 6V4h8v2M19 6l-1 15H6L5 6M10 11v5M14 11v5" />
+    </svg>
+  )
+}
+
 export function CheckIcon(props: SVGProps<SVGSVGElement>) {
   return (
     <svg {...iconProps} {...props}>

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -171,9 +171,11 @@ async function req<T>(url: string, init?: RequestInit): Promise<T> {
 
 export const api = {
   listCanvases: () => req<CanvasMeta[]>('/api/canvases'),
+  getCanvas: (id: string) => req<Canvas>(`/api/canvases/${id}`),
   deleteCanvas: (id: string) => req(`/api/canvases/${id}`, { method: 'DELETE' }),
   homeActivity: () => req<HomeActivity[]>('/api/home/activity'),
   createCanvas: (name: string) => req<Canvas>('/api/canvases', { method: 'POST', body: JSON.stringify({ name }) }),
+  duplicateCanvas: (id: string) => req<Canvas>(`/api/canvases/${id}/duplicate`, { method: 'POST' }),
   claimCanvas: (id: string) => req(`/api/canvases/${id}/claim`, { method: 'POST' }),
   renameCanvas: (id: string, name: string) =>
     req('/api/canvases/' + id, { method: 'PATCH', body: JSON.stringify({ name, actor: actor() }) }),

--- a/src/pages/CanvasPage.tsx
+++ b/src/pages/CanvasPage.tsx
@@ -4,7 +4,6 @@ import { connect, disconnect, sendWs } from '../lib/ws'
 import {
   api,
   ApiError,
-  type CanvasMember,
   type DiscoveredSite,
   type GithubConnectionInfo,
   type InstallationRepo,
@@ -24,6 +23,7 @@ import { LimitWall } from '../components/TeamAllowance'
 import { PromptBar } from '../components/PromptBar'
 import { WorkingNow } from '../components/WorkingNow'
 import { Onboarding } from '../components/Onboarding'
+import { ShareModal } from '../components/ShareModal'
 import { BrainIcon } from '../components/BrainIcon'
 import { getIdentity, setName } from '../lib/identity'
 import { copyFrame, duplicateFrame, hasFrameClip, pasteFrameCentered, pasteImagesCentered } from '../lib/frameClipboard'
@@ -34,7 +34,7 @@ import { useIsMobile } from '../hooks/use-mobile'
 import { cn } from '@/lib/utils'
 import { Button } from '../components/ui/button'
 import { Sheet, SheetContent, SheetDescription, SheetTitle } from '../components/ui/sheet'
-import { GithubIcon, XIcon } from '../components/ui/icons'
+import { GithubIcon } from '../components/ui/icons'
 import { Badge } from '../components/ui/badge'
 import { Input } from '../components/ui/input'
 import { Field } from '../components/ui/field'
@@ -479,9 +479,14 @@ export function CanvasPage({ canvasId }: { canvasId: string }) {
 
       {renaming && <RenameSelfModal current={me.name} onClose={() => setRenaming(false)} />}
       {showConnect && <ConnectModal canvasId={canvasId} onClose={() => setShowConnect(false)} />}
-      {showShare && (
+      {showShare && canvas && (
         <ShareModal
-          canvasId={canvasId}
+          key={canvas.id}
+          canvas={canvas}
+          onChange={(patch) => {
+            const current = useStore.getState().canvas
+            if (current?.id === canvasId) useStore.getState().setCanvas({ ...current, ...patch })
+          }}
           onClose={() => setShowShare(false)}
           onCopied={() => {
             setShowShare(false)
@@ -1083,151 +1088,6 @@ function RenameSelfModal({ current, onClose }: { current: string; onClose: () =>
             {busy ? 'Saving…' : 'Save name'}
           </Button>
         </ModalActions>
-      </>
-    </Modal>
-  )
-}
-
-/* Share modal, Figma-style: invite doop accounts to collaborate, or turn on
-   link sharing. Canvases are private by default — only the owner and invited
-   members get in until the link toggle is flipped. */
-function ShareModal({ canvasId, onClose, onCopied }: { canvasId: string; onClose: () => void; onCopied: () => void }) {
-  const canvas = useStore((s) => s.canvas)
-  const { data: session } = authClient.useSession()
-  const meId = session?.user?.id
-  const isOwner = !!canvas?.ownerId && canvas.ownerId === meId
-  const linkEdits = canvas?.linkAccess === 'edit'
-  const [people, setPeople] = useState<CanvasMember[] | null>(null)
-  const [email, setEmail] = useState('')
-  const [busy, setBusy] = useState(false)
-  const [error, setError] = useState<string | null>(null)
-
-  useEffect(() => {
-    api
-      .listMembers(canvasId)
-      .then(setPeople)
-      .catch(() => setPeople([]))
-  }, [canvasId])
-
-  async function invite() {
-    const clean = email.trim()
-    if (!clean || busy) return
-    setBusy(true)
-    setError(null)
-    try {
-      const m = await api.inviteMember(canvasId, clean)
-      setPeople((p) => (p?.some((x) => x.userId === m.userId) ? p : [...(p ?? []), m]))
-      if (canvas && !canvas.memberIds?.includes(m.userId)) {
-        useStore.getState().setCanvas({ ...canvas, memberIds: [...(canvas.memberIds ?? []), m.userId] })
-      }
-      setEmail('')
-    } catch (e) {
-      setError(e instanceof ApiError ? String(e.body.error ?? 'invite failed') : 'invite failed')
-    }
-    setBusy(false)
-  }
-
-  function remove(userId: string) {
-    api.removeMember(canvasId, userId).catch(console.error)
-    setPeople((p) => p?.filter((x) => x.userId !== userId) ?? null)
-    if (canvas) {
-      useStore.getState().setCanvas({ ...canvas, memberIds: canvas.memberIds?.filter((id) => id !== userId) })
-    }
-    /* removing yourself = leaving the canvas */
-    if (userId === meId && !isOwner) navigate('/')
-  }
-
-  function toggleLink(next: boolean) {
-    if (!canvas) return
-    const linkAccess = next ? 'edit' : 'none'
-    api.setLinkAccess(canvas.id, linkAccess).catch(console.error)
-    useStore.getState().setCanvas({ ...canvas, linkAccess })
-  }
-
-  async function copy() {
-    await navigator.clipboard.writeText(location.href)
-    posthog.capture('canvas_link_shared')
-    onCopied()
-  }
-
-  return (
-    <Modal size="sm" onClose={onClose}>
-      <>
-        <div className="flex items-start justify-between gap-3">
-          <ModalTitle className="min-w-0">Share “{canvas?.name ?? 'canvas'}”</ModalTitle>
-          <Button variant="ghost" size="icon" className="size-10" aria-label="Close sharing" onClick={onClose}>
-            <XIcon />
-          </Button>
-        </div>
-        {isOwner && (
-          <>
-            <div className="mt-4 flex flex-col items-stretch gap-2 sm:flex-row">
-              <Input
-                className="flex-1 rounded-[10px] bg-paper focus:ring-0"
-                autoFocus
-                placeholder="Invite by email (doop account)"
-                value={email}
-                disabled={busy}
-                onChange={(e) => setEmail(e.target.value)}
-                onKeyDown={(e) => e.key === 'Enter' && invite()}
-              />
-              <Button variant="primary" className="justify-center" disabled={busy || !email.trim()} onClick={invite}>
-                Invite
-              </Button>
-            </div>
-            {error && <p className="mx-[2px] mt-2 text-[12px] text-accent-ink">{error}</p>}
-          </>
-        )}
-        <div className="mt-[14px] mb-1 flex max-h-[40vh] flex-col gap-[2px] overflow-y-auto">
-          {(people ?? []).map((p) => (
-            <div key={p.userId} className="flex items-center gap-2.5 px-[2px] py-1.5">
-              <Avatar name={p.name} className="size-7 flex-none border-0 text-xs" />
-              <span className="flex min-w-0 flex-1 flex-col leading-[1.3]">
-                <b className="overflow-hidden whitespace-nowrap text-ellipsis text-[13px] font-semibold">
-                  {p.name}
-                  {p.userId === meId ? ' (you)' : ''}
-                </b>
-                <span className="overflow-hidden whitespace-nowrap text-ellipsis text-[12px] text-ink-faint">
-                  {p.email}
-                </span>
-              </span>
-              {p.owner ? (
-                <span className="flex-none text-[12px] text-ink-faint">Owner</span>
-              ) : isOwner || p.userId === meId ? (
-                <Button
-                  variant="bare"
-                  size="icon-sm"
-                  className="flex-none text-[13px] hover:bg-accent-ink/10 hover:text-accent-ink"
-                  title={p.userId === meId ? 'Leave this canvas' : 'Remove'}
-                  onClick={() => remove(p.userId)}
-                >
-                  ✕
-                </Button>
-              ) : (
-                <span className="flex-none text-[12px] text-ink-faint">Can edit</span>
-              )}
-            </div>
-          ))}
-          {people === null && <p className="text-[12px] text-ink-faint">Loading…</p>}
-        </div>
-        <div className="mt-2.5 flex flex-col items-stretch justify-between gap-2.5 border-t border-line-soft pt-3.5 sm:flex-row sm:items-center">
-          {isOwner ? (
-            <label
-              className="relative flex cursor-pointer items-center gap-2 text-[13px] font-medium text-ink"
-              title="Off = only you and invited people can open this canvas"
-            >
-              <Checkbox checked={linkEdits} onChange={(e) => toggleLink(e.target.checked)} />
-              Anyone with the link can edit
-            </label>
-          ) : (
-            <span className="text-xs text-ink-faint">
-              {linkEdits ? 'Anyone with the link can edit' : 'Invite-only canvas'}
-            </span>
-          )}
-          <Button className="justify-center" onClick={copy}>
-            ⧉ Copy link
-          </Button>
-        </div>
       </>
     </Modal>
   )

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
-import type { CanvasMeta } from '../../shared/types'
+import type { Canvas, CanvasMeta } from '../../shared/types'
 import { colorFor } from '../../shared/types'
 import { api, type HomeActivity } from '../lib/api'
 import { authClient } from '../lib/auth'
@@ -7,6 +7,7 @@ import { navigate } from '../App'
 import { Logo } from '../components/Logo'
 import { timeAgo } from '../lib/time'
 import { AgentIcon } from '../components/AgentIcon'
+import { ShareModal } from '../components/ShareModal'
 import { AccountMenu, ConnectCard, IconGrid, IconList, IconShare, IconUser } from '../components/DashShell'
 import { posthog } from '../lib/posthog'
 import { closeTab, openCanvasTab, pruneTabs } from '../lib/desktop'
@@ -19,6 +20,16 @@ import { Skeleton } from '../components/ui/skeleton'
 import { Dot } from '../components/ui/dot'
 import { Wordmark } from '../components/ui/wordmark'
 import { SegmentedIconItem, SegmentedIcons } from '../components/ui/segmented'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '../components/ui/dropdown-menu'
+import { CopyIcon, MoreHorizontalIcon, ShareIcon, TrashIcon } from '../components/ui/icons'
+import { ConfirmDialog } from '../components/ui/alert-dialog'
+import { Toast } from '../components/ui/toast'
 import {
   DashContent,
   DashHeader,
@@ -49,6 +60,10 @@ export function Home() {
   const [scope, setScope] = useState<Scope>('all')
   const [query, setQuery] = useState('')
   const [view, setView] = useState<'grid' | 'list'>('grid')
+  const [shareCanvas, setShareCanvas] = useState<Canvas | null>(null)
+  const [deleteCanvas, setDeleteCanvas] = useState<CanvasMeta | null>(null)
+  const [duplicatingId, setDuplicatingId] = useState<string | null>(null)
+  const [toast, setToast] = useState<string | null>(null)
   /* a clock the render can read: an agent that just worked shows as live, and
      the relative times stay honest without a reload */
   const [now, setNow] = useState(0)
@@ -85,6 +100,36 @@ export function Home() {
     const canvas = await api.createCanvas('Untitled canvas')
     posthog.capture('canvas_created')
     open(canvas.id, canvas.name)
+  }
+
+  async function duplicate(canvas: CanvasMeta) {
+    if (duplicatingId) return
+    setDuplicatingId(canvas.id)
+    try {
+      const copy = await api.duplicateCanvas(canvas.id)
+      posthog.capture('canvas_duplicated')
+      reload()
+      open(copy.id, copy.name)
+    } catch (error) {
+      console.error(error)
+      showToast('Couldn’t duplicate canvas')
+    } finally {
+      setDuplicatingId(null)
+    }
+  }
+
+  async function share(canvas: CanvasMeta) {
+    try {
+      setShareCanvas(await api.getCanvas(canvas.id))
+    } catch (error) {
+      console.error(error)
+      showToast('Couldn’t open sharing')
+    }
+  }
+
+  function showToast(message: string) {
+    setToast(message)
+    window.setTimeout(() => setToast(null), 2400)
   }
 
   /* Figma-style in the desktop shell: the canvas gets its own tab and Home
@@ -352,47 +397,74 @@ export function Home() {
                       <Skeleton key={i} index={i} className={cn(cardCls, 'min-h-[230px] border-solid')} />
                     ))}
                   {visible.map((c) => (
-                    <button key={c.id} className={cn(cardCls, 'group')} onClick={() => open(c.id, c.name)}>
-                      <div className="relative grid aspect-[16/10] place-items-center overflow-hidden border-b border-line-soft [background:radial-gradient(circle,var(--dot)_1px,transparent_1px)_0_0/18px_18px,var(--paper-deep)]">
-                        <Preview canvas={c} />
-                        <AgentStack canvas={c} />
-                        {c.ownerId && !c.shared && <DeleteButton onDelete={() => remove(c.id, reload)} />}
-                      </div>
-                      <div className="px-3 pb-3 pt-2.5">
-                        <div className="truncate font-display text-[13.5px] font-semibold">{c.name}</div>
-                        <div className="mt-[5px] flex items-center gap-1.5 text-[11.5px] text-ink-faint">
-                          <Meta canvas={c} onClaim={reload} />
+                    <div key={c.id} className={cn(cardCls, 'group relative')}>
+                      <button
+                        className="block w-full border-0 bg-transparent text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-brand"
+                        onClick={() => open(c.id, c.name)}
+                      >
+                        <div className="relative grid aspect-[16/10] place-items-center overflow-hidden border-b border-line-soft [background:radial-gradient(circle,var(--dot)_1px,transparent_1px)_0_0/18px_18px,var(--paper-deep)]">
+                          <Preview canvas={c} />
+                          <AgentStack canvas={c} />
                         </div>
-                      </div>
-                    </button>
+                        <div className="px-3 pb-3 pt-2.5">
+                          <div className="truncate font-display text-[13.5px] font-semibold">{c.name}</div>
+                          <div className="mt-[5px] flex items-center gap-1.5 text-[11.5px] text-ink-faint">
+                            <Meta canvas={c} onClaim={reload} />
+                          </div>
+                        </div>
+                      </button>
+                      <CanvasActions
+                        canvas={c}
+                        duplicating={duplicatingId === c.id}
+                        onShare={() => share(c)}
+                        onDuplicate={() => duplicate(c)}
+                        onDelete={c.ownerId && !c.shared ? () => setDeleteCanvas(c) : undefined}
+                      />
+                    </div>
                   ))}
                 </div>
               ) : (
                 <div className="mt-4 overflow-hidden rounded-[14px] border border-line bg-surface shadow-card">
                   {visible.map((c) => (
-                    <button
+                    <div
                       key={c.id}
-                      className="flex w-full items-center gap-2.5 border-0 border-b border-line-soft bg-transparent px-3 py-2.5 text-left transition-colors last:border-b-0 hover:bg-paper md:gap-[13px] md:px-3.5 md:py-[9px]"
-                      onClick={() => open(c.id, c.name)}
+                      className="group flex w-full items-center border-b border-line-soft transition-colors last:border-b-0 hover:bg-paper"
                     >
-                      <span className="grid h-9 w-[58px] flex-none place-items-center overflow-hidden rounded-[7px] border border-line-soft bg-paper-deep">
-                        <Preview canvas={c} blankSize="text-[9px]" />
-                      </span>
-                      <span className="min-w-0 flex-1 truncate font-display text-[13.5px] font-semibold">{c.name}</span>
-                      <span className="hidden w-[82px] flex-none text-xs text-ink-faint sm:block">
-                        {c.frameCount} frame{c.frameCount === 1 ? '' : 's'}
-                      </span>
-                      <span className="hidden w-[62px] flex-none gap-[3px] xs:flex">
-                        {(c.agents ?? []).slice(0, 3).map((a) => (
-                          <i key={a.name} style={{ color: colorFor(a.name) }}>
-                            <AgentIcon name={a.name} size={11} />
-                          </i>
-                        ))}
-                      </span>
-                      <span className="w-auto flex-none text-right text-xs text-ink-faint md:w-[66px]">
-                        {timeAgo(c.updatedAt)}
-                      </span>
-                    </button>
+                      <button
+                        className="flex min-w-0 flex-1 items-center gap-2.5 border-0 bg-transparent px-3 py-2.5 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-brand md:gap-[13px] md:px-3.5 md:py-[9px]"
+                        onClick={() => open(c.id, c.name)}
+                      >
+                        <span className="grid h-9 w-[58px] flex-none place-items-center overflow-hidden rounded-[7px] border border-line-soft bg-paper-deep">
+                          <Preview canvas={c} blankSize="text-[9px]" />
+                        </span>
+                        <span className="min-w-0 flex-1 truncate font-display text-[13.5px] font-semibold">
+                          {c.name}
+                        </span>
+                        <span className="hidden w-[82px] flex-none text-xs text-ink-faint sm:block">
+                          {c.frameCount} frame{c.frameCount === 1 ? '' : 's'}
+                        </span>
+                        <span className="hidden w-[62px] flex-none gap-[3px] xs:flex">
+                          {(c.agents ?? []).slice(0, 3).map((a) => (
+                            <i key={a.name} style={{ color: colorFor(a.name) }}>
+                              <AgentIcon name={a.name} size={11} />
+                            </i>
+                          ))}
+                        </span>
+                        <span className="w-auto flex-none text-right text-xs text-ink-faint md:w-[66px]">
+                          {timeAgo(c.updatedAt)}
+                        </span>
+                      </button>
+                      <div className="mr-3 flex-none md:mr-3.5">
+                        <CanvasActions
+                          canvas={c}
+                          compact
+                          duplicating={duplicatingId === c.id}
+                          onShare={() => share(c)}
+                          onDuplicate={() => duplicate(c)}
+                          onDelete={c.ownerId && !c.shared ? () => setDeleteCanvas(c) : undefined}
+                        />
+                      </div>
+                    </div>
                   ))}
                 </div>
               )}
@@ -400,6 +472,31 @@ export function Home() {
           )}
         </DashContent>
       </DashMain>
+      {shareCanvas && (
+        <ShareModal
+          key={shareCanvas.id}
+          canvas={shareCanvas}
+          onChange={(patch) => setShareCanvas((current) => (current ? { ...current, ...patch } : null))}
+          onClose={() => setShareCanvas(null)}
+          onCopied={() => {
+            setShareCanvas(null)
+            showToast('Canvas link copied')
+          }}
+        />
+      )}
+      <ConfirmDialog
+        open={!!deleteCanvas}
+        onOpenChange={(open) => !open && setDeleteCanvas(null)}
+        title={`Delete “${deleteCanvas?.name ?? 'canvas'}”?`}
+        description="This permanently deletes the canvas and everything in it. This can’t be undone."
+        confirmLabel="Delete canvas"
+        destructive
+        onConfirm={() => {
+          if (deleteCanvas) remove(deleteCanvas.id, reload)
+          setDeleteCanvas(null)
+        }}
+      />
+      {toast && <Toast>{toast}</Toast>}
     </DashLayout>
   )
 }
@@ -514,28 +611,53 @@ function NavItem({
   )
 }
 
-function DeleteButton({ onDelete }: { onDelete: () => void }) {
-  const [armed, setArmed] = useState(false)
-  useEffect(() => {
-    if (!armed) return
-    const t = window.setTimeout(() => setArmed(false), 2600)
-    return () => window.clearTimeout(t)
-  }, [armed])
+function CanvasActions({
+  canvas,
+  compact = false,
+  duplicating,
+  onShare,
+  onDuplicate,
+  onDelete,
+}: {
+  canvas: CanvasMeta
+  compact?: boolean
+  duplicating: boolean
+  onShare: () => void
+  onDuplicate: () => void
+  onDelete?: () => void
+}) {
   return (
-    <span
-      role="button"
-      className={cn(
-        'absolute right-2 top-2 grid h-10 min-w-10 cursor-pointer place-items-center rounded-full bg-ink/75 px-[7px] text-xs font-bold text-white opacity-100 transition-[opacity,background] md:h-6 md:min-w-6 md:opacity-0 md:group-hover:opacity-100',
-        armed ? 'bg-brand text-[11px] opacity-100' : 'hover:bg-ink',
-      )}
-      title={armed ? 'Click again to permanently delete this canvas' : 'Delete canvas'}
-      onClick={(e) => {
-        e.stopPropagation()
-        if (armed) onDelete()
-        else setArmed(true)
-      }}
-    >
-      {armed ? 'Delete?' : '✕'}
-    </span>
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          type="button"
+          aria-label={`Actions for ${canvas.name}`}
+          className={cn(
+            'grid cursor-pointer place-items-center rounded-full transition-[opacity,background,color] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand',
+            compact
+              ? 'size-8 flex-none text-ink-faint hover:bg-paper-deep hover:text-ink'
+              : 'absolute right-2 top-2 size-10 bg-ink/75 text-white opacity-100 hover:bg-ink md:size-7 md:opacity-0 md:group-hover:opacity-100 md:data-[state=open]:opacity-100',
+          )}
+        >
+          <MoreHorizontalIcon className="size-4" />
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent className="w-[190px]">
+        <DropdownMenuItem onSelect={onShare}>
+          <ShareIcon className="size-4" /> Share
+        </DropdownMenuItem>
+        <DropdownMenuItem disabled={duplicating} onSelect={onDuplicate}>
+          <CopyIcon className="size-4" /> {duplicating ? 'Duplicating…' : 'Duplicate'}
+        </DropdownMenuItem>
+        {onDelete && (
+          <>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem tone="danger" onSelect={onDelete}>
+              <TrashIcon className="size-4" /> Delete
+            </DropdownMenuItem>
+          </>
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
   )
 }

--- a/tests/access.test.ts
+++ b/tests/access.test.ts
@@ -14,7 +14,7 @@ let server: Server
 let BASE: string
 
 beforeAll(async () => {
-  server = await startServer(PORT)
+  server = await startServer(PORT, { BETTER_AUTH_URL: `http://localhost:${PORT}` })
   BASE = server.base
 }, 70_000)
 
@@ -51,6 +51,34 @@ describe('canvas access model', () => {
     canvasId = canvas.id
     const frame = await (await owner.post(`/api/canvases/${canvasId}/frames`, { name: 'F1' })).json()
     frameId = frame.id
+
+    const png = Buffer.from(
+      'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=',
+      'base64',
+    )
+    const upload = await owner.req(`/api/canvases/${canvasId}/assets`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'image/png' },
+      body: png,
+    })
+    const asset = await upload.json()
+    expect(upload.status, JSON.stringify(asset)).toBe(200)
+    expect(
+      (
+        await owner.patch(`/api/frames/${frameId}`, {
+          html: `<img src="${asset.url}" alt="duplication test">`,
+        })
+      ).status,
+    ).toBe(200)
+    expect(
+      (
+        await owner.req(`/api/canvases/${canvasId}/guidelines/brand`, {
+          method: 'PUT',
+          body: JSON.stringify({ markdown: 'Use the brand blue.', title: 'Brand' }),
+        })
+      ).status,
+    ).toBe(200)
+    expect((await owner.post(`/api/canvases/${canvasId}/references`, { frameId })).status).toBe(200)
   })
 
   it('is private by default: non-owners are blocked everywhere', async () => {
@@ -99,6 +127,34 @@ describe('canvas access model', () => {
 
     expect((await owner.patch(`/api/canvases/${canvasId}`, { linkAccess: 'none' })).status).toBe(200)
     expect((await stranger.get(`/api/canvases/${canvasId}`)).status).toBe(403)
+  })
+
+  it('lets durable collaborators duplicate design content into a private canvas of their own', async () => {
+    expect((await stranger.post(`/api/canvases/${canvasId}/duplicate`)).status).toBe(403)
+
+    const res = await invited.post(`/api/canvases/${canvasId}/duplicate`)
+    const copy = await res.json()
+    expect(res.status, JSON.stringify(copy)).toBe(200)
+    expect(copy.name).toBe('ACL copy')
+    expect(copy.ownerId).toBe(invitedId)
+    expect(copy.linkAccess).toBeUndefined()
+    expect(copy.memberIds).toBeUndefined()
+    expect(copy.frames).toHaveLength(2)
+    expect(copy.frames.map((frame: { canvasId: string }) => frame.canvasId)).toEqual([copy.id, copy.id])
+    expect(copy.frames.map((frame: { id: string }) => frame.id)).not.toContain(frameId)
+    expect(copy.guidelines).toMatchObject([{ name: 'brand', markdown: 'Use the brand blue.', title: 'Brand' }])
+    expect(copy.references).toHaveLength(1)
+    expect(copy.references[0].id).not.toBe(
+      (await (await owner.get(`/api/canvases/${canvasId}`)).json()).references[0].id,
+    )
+    expect(copy.references[0].frameId).toBe(copy.frames.find((frame: { name: string }) => frame.name === 'F1').id)
+    const copiedImage = copy.frames.find((frame: { name: string }) => frame.name === 'F1')
+    expect(copiedImage.html).toMatch(/<img src="http:\/\/localhost:\d+\/a\/[A-Za-z0-9_-]+\.png"/)
+    const copiedAsset = await fetch(copiedImage.html.match(/src="([^"]+)"/)![1])
+    expect(copiedAsset.status).toBe(200)
+    expect(copiedAsset.headers.get('content-type')).toBe('image/png')
+    expect((await stranger.get(`/api/canvases/${copy.id}`)).status).toBe(403)
+    expect((await invited.delete(`/api/canvases/${copy.id}`)).status).toBe(200)
   })
 
   it('a member who leaves loses access', async () => {

--- a/tests/duplicatePersistence.test.ts
+++ b/tests/duplicatePersistence.test.ts
@@ -1,0 +1,81 @@
+import { expect, it } from 'vitest'
+import { Client, startServer, type Server } from './harness.ts'
+
+const PORT = 4981
+
+it('persists a complete canvas duplicate across a server restart', async () => {
+  let server: Server = await startServer(PORT, { BETTER_AUTH_URL: `http://localhost:${PORT}` })
+  try {
+    const owner = new Client(server)
+    await owner.signUp('duplicate@test.dev', 'Duplicate Owner')
+
+    const source = await (await owner.post('/api/canvases', { name: 'Persistent design' })).json()
+    const sourceFrame = await (await owner.post(`/api/canvases/${source.id}/frames`, { name: 'Image frame' })).json()
+    const png = Buffer.from(
+      'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=',
+      'base64',
+    )
+    const upload = await owner.req(`/api/canvases/${source.id}/assets`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'image/png' },
+      body: png,
+    })
+    const asset = await upload.json()
+    expect(upload.status, JSON.stringify(asset)).toBe(200)
+    expect(
+      (
+        await owner.patch(`/api/frames/${sourceFrame.id}`, {
+          html: `<img src="${asset.url}" alt="persistent duplicate">`,
+        })
+      ).status,
+    ).toBe(200)
+    expect(
+      (
+        await owner.req(`/api/canvases/${source.id}/guidelines/brand`, {
+          method: 'PUT',
+          body: JSON.stringify({ markdown: 'Use the brand blue.', title: 'Brand' }),
+        })
+      ).status,
+    ).toBe(200)
+    const sourceReference = await (
+      await owner.post(`/api/canvases/${source.id}/references`, { frameId: sourceFrame.id })
+    ).json()
+
+    const duplicateResponse = await owner.post(`/api/canvases/${source.id}/duplicate`)
+    const duplicate = await duplicateResponse.json()
+    expect(duplicateResponse.status, JSON.stringify(duplicate)).toBe(200)
+
+    const dataDir = server.dataDir
+    server.stop({ keepData: true })
+    await server.stopped
+    server = await startServer(PORT + 1, { BETTER_AUTH_URL: `http://localhost:${PORT + 1}` }, dataDir)
+
+    const signedIn = new Client(server)
+    expect(
+      (
+        await signedIn.post('/api/auth/sign-in/email', {
+          email: 'duplicate@test.dev',
+          password: 'password12345',
+        })
+      ).status,
+    ).toBe(200)
+    const response = await signedIn.get(`/api/canvases/${duplicate.id}`)
+    const restored = await response.json()
+    expect(response.status, JSON.stringify(restored)).toBe(200)
+    expect(restored.linkAccess).toBeUndefined()
+    expect(restored.memberIds).toBeUndefined()
+    expect(restored.frames).toHaveLength(1)
+    expect(restored.frames[0].id).not.toBe(sourceFrame.id)
+    expect(restored.guidelines).toMatchObject([{ name: 'brand', markdown: 'Use the brand blue.', title: 'Brand' }])
+    expect(restored.references).toHaveLength(1)
+    expect(restored.references[0].id).not.toBe(sourceReference.id)
+    expect(restored.references[0].frameId).toBe(restored.frames[0].id)
+
+    const assetPath = new URL(restored.frames[0].html.match(/src="([^"]+)"/)![1]).pathname
+    const copiedAsset = await fetch(`${server.base}${assetPath}`)
+    expect(copiedAsset.status).toBe(200)
+    expect(copiedAsset.headers.get('content-type')).toBe('image/png')
+  } finally {
+    server.stop()
+  }
+}, 70_000)

--- a/tests/harness.ts
+++ b/tests/harness.ts
@@ -18,6 +18,8 @@ export interface Server {
   port: number
   /** PGlite lives here; pass it back to startServer to reboot the same database */
   dataDir: string
+  /** Resolves after the child process exits; useful before reopening its data directory. */
+  stopped: Promise<void>
   stop(opts?: { keepData?: boolean }): void
 }
 
@@ -33,6 +35,7 @@ export async function startServer(port: number, env: Record<string, string> = {}
     },
   )
   const base = `http://localhost:${port}`
+  const stopped = new Promise<void>((resolve) => proc.once('exit', () => resolve()))
   const deadline = Date.now() + 60_000
   for (;;) {
     try {
@@ -48,6 +51,7 @@ export async function startServer(port: number, env: Record<string, string> = {}
     base,
     port,
     dataDir,
+    stopped,
     stop({ keepData }: { keepData?: boolean } = {}) {
       proc.kill()
       if (!keepData) rmSync(dataDir, { recursive: true, force: true })


### PR DESCRIPTION
## Summary

Replace the delete button on dashboard canvas cards with a three-dot action menu.

The menu lets users:

- Open the existing canvas sharing dialog
- Duplicate a canvas
- Delete canvases they own, with confirmation

The menu is available in both grid and list views and works at desktop and mobile sizes.

## Duplication behavior

Duplicating creates a new private canvas owned by the user who made the copy.

The copy includes:

- Frames with fresh IDs
- Design guidelines
- Pinned memory references with fresh IDs
- Uploaded image references

It does not inherit:

- Members or link access
- Activity, tasks, feedback, or comments
- Sync keys
- GitHub connections or other external configuration

Owners and invited collaborators can duplicate a canvas. Visitors who only have link access cannot.

## Sharing

The existing canvas sharing dialog has been moved into a reusable component. Opening Share from the dashboard now uses the same dialog as an open canvas.

## Deletion

The previous two-click delete control has been replaced with the project's standard confirmation dialog. Delete remains available only for canvases owned by the current user.

## Testing

- `bun run test` (216 tests passed)
- `bun run typecheck`
- `bun run lint` (0 errors, 9 existing warnings)
- `bun run format:check`
- `bun run build`

The action menu and sharing dialog were checked in the browser at desktop and mobile widths. Canvas duplication was also tested with an uploaded image, with an integration regression test covering the asset URL in the copy.
