### PR TITLE
style: format tauri.conf.json and ignore release-please-written files

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -3,3 +3,5 @@ node_modules/
 package-lock.json
 bun.lock
 CHANGELOG.md
+desktop/src-tauri/tauri.conf.json
+desktop/CHANGELOG.md

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -16,17 +16,8 @@
   },
   "bundle": {
     "active": true,
-    "targets": [
-      "app",
-      "dmg"
-    ],
+    "targets": ["app", "dmg"],
     "category": "Productivity",
-    "icon": [
-      "icons/32x32.png",
-      "icons/128x128.png",
-      "icons/128x128@2x.png",
-      "icons/icon.icns",
-      "icons/icon.ico"
-    ]
+    "icon": ["icons/32x32.png", "icons/128x128.png", "icons/128x128@2x.png", "icons/icon.icns", "icons/icon.ico"]
   }
 }


### PR DESCRIPTION
CI on main failed after the v0.2.0 / desktop 0.1.4 release merge (#102): release-please rewrites `desktop/src-tauri/tauri.conf.json` in its own JSON layout, which fails `format:check`. This formats the file once and adds it plus `desktop/CHANGELOG.md` to `.prettierignore` (root `CHANGELOG.md` was already ignored) so the next bump does not break main again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WhraE9SrNdHURijbz6yznC