### PR TITLE
fix(desktop): let the tab strip drag the window on macOS

### DIFF
--- a/desktop/src-tauri/capabilities/default.json
+++ b/desktop/src-tauri/capabilities/default.json
@@ -1,13 +1,14 @@
 {
   "$schema": "gen/schemas/desktop-schema.json",
   "identifier": "shell",
-  "description": "Lets the hosted app use the shell's IPC: window dragging for the custom tab strip (core:default) and opening external links in the system browser (opener). Remote IPC is scoped to the production origin; self-hosters overriding DOOP_APP_URL must add their origin here. In dev the devUrl origin counts as local, so no entry is needed for it.",
+  "description": "Lets the hosted app use the shell's IPC: window dragging for the custom tab strip (core:default covers the double-click zoom but not start_dragging, which data-tauri-drag-region invokes on mousedown, so that one is granted explicitly) and opening external links in the system browser (opener). Remote IPC is scoped to the production origin; self-hosters overriding DOOP_APP_URL must add their origin here. In dev the devUrl origin counts as local, so no entry is needed for it.",
   "windows": ["main"],
   "remote": {
     "urls": ["https://doop.design", "https://www.doop.design"]
   },
   "permissions": [
     "core:default",
+    "core:window:allow-start-dragging",
     {
       "identifier": "opener:allow-open-url",
       "allow": [{ "url": "https://**" }, { "url": "http://**" }]


### PR DESCRIPTION
Fixes #95.

The macOS shell's tab strip carries `data-tauri-drag-region`, and Tauri's drag script invokes `plugin:window|start_dragging` on mousedown. The shell capability only granted `core:default`, whose window subset includes `internal-toggle-maximize` (the double-click zoom) but not `start-dragging`, so every drag was silently denied. This grants `core:window:allow-start-dragging` explicitly.

Behaviour stays scoped the way it was designed: the bare attribute only fires on the strip itself and the traffic-light spacer, and tabs are `role="tab"`, which the drag script treats as clickable. So only the empty space next to the tabs drags the window.

Not built locally (no Rust toolchain on this machine); the desktop CI workflow compiles the shell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QKddmE3NXKYm2x4D6ABWgr