### PR TITLE
feat(comments): reply inside an element comment thread

### DIFF
--- a/server/actions.ts
+++ b/server/actions.ts
@@ -499,6 +499,10 @@ function postComment(
   if (!clean) return undefined
   /* @Doop, @brand, @a11y… — whichever resident agent is mentioned picks it up */
   const mentioned = mentionedRole(clean)
+  const list = commentLog.get(frame.canvasId) ?? []
+  /* strictly increasing per canvas: thread order is reconstructed from `at`
+     after a restart, so two messages must never share a timestamp */
+  const at = Math.max(Date.now(), (list[0]?.at ?? 0) + 1)
   const comment: ElementComment = {
     id: nanoid(8),
     canvasId: frame.canvasId,
@@ -508,11 +512,10 @@ function postComment(
     from,
     ...(fromUserId ? { fromUserId } : {}),
     text: clean,
-    at: Date.now(),
+    at,
     ...(mentioned ? { forAgent: true, targetAgent: mentioned.name } : {}),
     ...(anchor.parentId ? { parentId: anchor.parentId } : {}),
   }
-  const list = commentLog.get(frame.canvasId) ?? []
   list.unshift(comment)
   if (list.length > 100) list.length = 100
   commentLog.set(frame.canvasId, list)

--- a/server/actions.ts
+++ b/server/actions.ts
@@ -444,23 +444,63 @@ export function addElementComment(
   from: string,
   fromUserId?: string,
 ): ElementComment | undefined {
-  const clean = input.text.trim()
-  if (!clean) return undefined
   const frame = store.getFrame(frameId)
   if (!frame) return undefined
+  return postComment(
+    frame,
+    { selector: String(input.selector ?? '').slice(0, 300), snippet: String(input.snippet ?? '').slice(0, 400) },
+    input.text,
+    from,
+    fromUserId,
+  )
+}
+
+/** Reply inside a thread: the reply inherits the root comment's element so an
+ *  @mention in it gives the agent the same anchor the conversation is about. */
+export function replyToComment(
+  commentId: string,
+  text: string,
+  from: string,
+  fromUserId?: string,
+): ElementComment | undefined {
+  const parent = findComment(commentId)
+  if (!parent) return undefined
+  const root = parent.parentId ? findComment(parent.parentId) : parent
+  if (!root || root.resolvedAt) return undefined
+  const frame = store.getFrame(root.frameId)
+  if (!frame) return undefined
+  return postComment(
+    frame,
+    { selector: root.selector, snippet: root.snippet, parentId: root.id },
+    text,
+    from,
+    fromUserId,
+  )
+}
+
+function postComment(
+  frame: Frame,
+  anchor: { selector: string; snippet: string; parentId?: string },
+  text: string,
+  from: string,
+  fromUserId?: string,
+): ElementComment | undefined {
+  const clean = text.trim()
+  if (!clean) return undefined
   /* @Doop, @brand, @a11y… — whichever resident agent is mentioned picks it up */
   const mentioned = mentionedRole(clean)
   const comment: ElementComment = {
     id: nanoid(8),
     canvasId: frame.canvasId,
-    frameId,
-    selector: String(input.selector ?? '').slice(0, 300),
-    snippet: String(input.snippet ?? '').slice(0, 400),
+    frameId: frame.id,
+    selector: anchor.selector,
+    snippet: anchor.snippet,
     from,
     ...(fromUserId ? { fromUserId } : {}),
     text: clean,
     at: Date.now(),
     ...(mentioned ? { forAgent: true, targetAgent: mentioned.name } : {}),
+    ...(anchor.parentId ? { parentId: anchor.parentId } : {}),
   }
   const list = commentLog.get(frame.canvasId) ?? []
   list.unshift(comment)
@@ -468,11 +508,14 @@ export function addElementComment(
   commentLog.set(frame.canvasId, list)
   persist.saveComment(comment)
   broadcast(frame.canvasId, { type: 'comment', comment })
+  const excerpt = clean.length > 80 ? clean.slice(0, 77) + '…' : clean
   logActivity(
     frame.canvasId,
     resolveActor({ name: from, kind: 'user' }),
-    `commented on an element in “${frame.name}”: “${clean.length > 80 ? clean.slice(0, 77) + '…' : clean}”`,
-    frameId,
+    anchor.parentId
+      ? `replied to a comment in “${frame.name}”: “${excerpt}”`
+      : `commented on an element in “${frame.name}”: “${excerpt}”`,
+    frame.id,
   )
   if (comment.forAgent) {
     /* @Doop mention: the resident agent picks it up instantly (no-op without
@@ -480,6 +523,17 @@ export function addElementComment(
     import('./resident.ts').then((r) => r.onFeedback(frame.canvasId)).catch(() => {})
   }
   return comment
+}
+
+/** The whole conversation a comment belongs to, oldest first. */
+export function commentThread(comment: ElementComment): ElementComment[] {
+  const rootId = comment.parentId ?? comment.id
+  /* the log is newest-first; reverse before the (stable) sort so replies
+     posted within the same millisecond keep their arrival order */
+  return [...(commentLog.get(comment.canvasId) ?? [])]
+    .reverse()
+    .filter((c) => c.id === rootId || c.parentId === rootId)
+    .sort((a, b) => a.at - b.at)
 }
 
 /** Open comments @mentioning this agent, claimed by it. */
@@ -538,20 +592,25 @@ export function resolveComment(commentId: string, by: string): ElementComment | 
     const c = list.find((x) => x.id === commentId)
     if (!c) continue
     if (c.resolvedAt) return c
-    c.resolvedBy = by
-    c.resolvedAt = Date.now()
-    persist.saveComment(c)
-    broadcast(canvasId, { type: 'comment', comment: c })
-    /* a resolved @agent comment was an instruction that got carried out —
-       capture it as a decision (plain human-to-human notes are not) */
-    if (c.forAgent) {
-      captureDecision(canvasId, {
-        text: c.text,
-        source: 'comment',
-        frameId: c.frameId,
-        from: c.from,
-        agentName: c.claimedBy ?? (by !== c.from ? by : undefined),
-      })
+    /* resolving the root closes its whole thread: an open reply under a
+       resolved pin would be invisible yet still queued for an agent */
+    const closing = c.parentId ? [c] : list.filter((x) => x.id === c.id || (x.parentId === c.id && !x.resolvedAt))
+    for (const item of closing) {
+      item.resolvedBy = by
+      item.resolvedAt = Date.now()
+      persist.saveComment(item)
+      broadcast(canvasId, { type: 'comment', comment: item })
+      /* a resolved @agent comment was an instruction that got carried out —
+         capture it as a decision (plain human-to-human notes are not) */
+      if (item.forAgent) {
+        captureDecision(canvasId, {
+          text: item.text,
+          source: 'comment',
+          frameId: item.frameId,
+          from: item.from,
+          agentName: item.claimedBy ?? (by !== item.from ? by : undefined),
+        })
+      }
     }
     return c
   }

--- a/server/actions.ts
+++ b/server/actions.ts
@@ -463,12 +463,9 @@ export function replyToComment(
   from: string,
   fromUserId?: string,
 ): ElementComment | undefined {
-  const parent = findComment(commentId)
-  if (!parent) return undefined
-  const root = parent.parentId ? findComment(parent.parentId) : parent
-  if (!root || root.resolvedAt) return undefined
-  const frame = store.getFrame(root.frameId)
-  if (!frame) return undefined
+  const open = openThread(commentId)
+  if (!open) return undefined
+  const { root, frame } = open
   return postComment(
     frame,
     { selector: root.selector, snippet: root.snippet, parentId: root.id },
@@ -476,6 +473,19 @@ export function replyToComment(
     from,
     fromUserId,
   )
+}
+
+/** The root and frame a reply to this comment would land on, or undefined
+ *  when the thread is resolved or its frame is gone — checked before any
+ *  metering so a rejected reply never costs a resident task. */
+export function openThread(commentId: string): { root: ElementComment; frame: Frame } | undefined {
+  const parent = findComment(commentId)
+  if (!parent) return undefined
+  const root = parent.parentId ? findComment(parent.parentId) : parent
+  if (!root || root.resolvedAt) return undefined
+  const frame = store.getFrame(root.frameId)
+  if (!frame) return undefined
+  return { root, frame }
 }
 
 function postComment(

--- a/server/allowance.ts
+++ b/server/allowance.ts
@@ -98,3 +98,14 @@ export async function consumeResidentTask(userId: string): Promise<Allowance & {
   if (!applied) return { ...current, used: current.limit, ok: false }
   return { ...current, used: applied.used, ok: true }
 }
+
+/** Give back a task that was spent but never turned into work — the thread
+ *  closed or its frame vanished between metering and the write. Only a
+ *  metered spend (not a byo-model pass) is returned, never below zero. */
+export async function refundResidentTask(gate: Allowance & { ok: boolean }, userId: string): Promise<void> {
+  if (!gate.ok || gate.byoModel) return
+  await db
+    .update(residentUsage)
+    .set({ used: sql`greatest(${residentUsage.used} - 1, 0)`, updatedAt: Date.now() })
+    .where(eq(residentUsage.userId, userId))
+}

--- a/server/db/migrations/0008_comment_replies.sql
+++ b/server/db/migrations/0008_comment_replies.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "comments" ADD COLUMN "parent_id" text;

--- a/server/db/migrations/meta/0008_snapshot.json
+++ b/server/db/migrations/meta/0008_snapshot.json
@@ -1,0 +1,2187 @@
+{
+  "id": "017121ef-bfa5-4daf-ac8e-163bf9140caa",
+  "prevId": "ab4fb165-fe80-4701-ad38-2b9a4c25d94d",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.activity": {
+      "name": "activity",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "canvas_id": {
+          "name": "canvas_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_kind": {
+          "name": "actor_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_color": {
+          "name": "actor_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frame_id": {
+          "name": "frame_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "at": {
+          "name": "at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "activity_canvas_idx": {
+          "name": "activity_canvas_idx",
+          "columns": [
+            {
+              "expression": "canvas_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.asset_refs": {
+      "name": "asset_refs",
+      "schema": "",
+      "columns": {
+        "asset_id": {
+          "name": "asset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frame_id": {
+          "name": "frame_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "asset_refs_frame_idx": {
+          "name": "asset_refs_frame_idx",
+          "columns": [
+            {
+              "expression": "frame_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "asset_refs_asset_id_frame_id_pk": {
+          "name": "asset_refs_asset_id_frame_id_pk",
+          "columns": ["asset_id", "frame_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.assets": {
+      "name": "assets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "canvas_id": {
+          "name": "canvas_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mime": {
+          "name": "mime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ext": {
+          "name": "ext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "assets_canvas_idx": {
+          "name": "assets_canvas_idx",
+          "columns": [
+            {
+              "expression": "canvas_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.canvas_members": {
+      "name": "canvas_members",
+      "schema": "",
+      "columns": {
+        "canvas_id": {
+          "name": "canvas_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "added_by": {
+          "name": "added_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "canvas_members_canvas_id_user_id_pk": {
+          "name": "canvas_members_canvas_id_user_id_pk",
+          "columns": ["canvas_id", "user_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.canvases": {
+      "name": "canvases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_access": {
+          "name": "link_access",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.comments": {
+      "name": "comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "canvas_id": {
+          "name": "canvas_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frame_id": {
+          "name": "frame_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "selector": {
+          "name": "selector",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snippet": {
+          "name": "snippet",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_name": {
+          "name": "from_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_user_id": {
+          "name": "from_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "at": {
+          "name": "at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "for_agent": {
+          "name": "for_agent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "target_agent": {
+          "name": "target_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_by": {
+          "name": "claimed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failed_at": {
+          "name": "failed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "comments_canvas_idx": {
+          "name": "comments_canvas_idx",
+          "columns": [
+            {
+              "expression": "canvas_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.decisions": {
+      "name": "decisions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "canvas_id": {
+          "name": "canvas_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frame_id": {
+          "name": "frame_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_name": {
+          "name": "from_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "at": {
+          "name": "at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "distilled_at": {
+          "name": "distilled_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "decisions_canvas_idx": {
+          "name": "decisions_canvas_idx",
+          "columns": [
+            {
+              "expression": "canvas_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feedback": {
+      "name": "feedback",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canvas_id": {
+          "name": "canvas_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_agent": {
+          "name": "target_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_name": {
+          "name": "from_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_user_id": {
+          "name": "from_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "at": {
+          "name": "at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_by": {
+          "name": "claimed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failed_at": {
+          "name": "failed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "feedback_canvas_idx": {
+          "name": "feedback_canvas_idx",
+          "columns": [
+            {
+              "expression": "canvas_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.frames": {
+      "name": "frames",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "canvas_id": {
+          "name": "canvas_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "x": {
+          "name": "x",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "y": {
+          "name": "y",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "width": {
+          "name": "width",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "height": {
+          "name": "height",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "html": {
+          "name": "html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "demo": {
+          "name": "demo",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "frames_canvas_idx": {
+          "name": "frames_canvas_idx",
+          "columns": [
+            {
+              "expression": "canvas_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_connections": {
+      "name": "github_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "canvas_id": {
+          "name": "canvas_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo": {
+          "name": "repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deploy_url": {
+          "name": "deploy_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "github_connections_canvas_idx": {
+          "name": "github_connections_canvas_idx",
+          "columns": [
+            {
+              "expression": "canvas_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.guideline_versions": {
+      "name": "guideline_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "canvas_id": {
+          "name": "canvas_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "markdown": {
+          "name": "markdown",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "saved_at": {
+          "name": "saved_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "saved_by": {
+          "name": "saved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "guideline_versions_doc_idx": {
+          "name": "guideline_versions_doc_idx",
+          "columns": [
+            {
+              "expression": "canvas_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.guidelines": {
+      "name": "guidelines",
+      "schema": "",
+      "columns": {
+        "canvas_id": {
+          "name": "canvas_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "markdown": {
+          "name": "markdown",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "x": {
+          "name": "x",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "y": {
+          "name": "y",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "guidelines_canvas_id_name_pk": {
+          "name": "guidelines_canvas_id_name_pk",
+          "columns": ["canvas_id", "name"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.memory_proposals": {
+      "name": "memory_proposals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "canvas_id": {
+          "name": "canvas_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guide_name": {
+          "name": "guide_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guide_title": {
+          "name": "guide_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rule": {
+          "name": "rule",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rationale": {
+          "name": "rationale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "based_on": {
+          "name": "based_on",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "at": {
+          "name": "at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "memory_proposals_canvas_idx": {
+          "name": "memory_proposals_canvas_idx",
+          "columns": [
+            {
+              "expression": "canvas_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.memory_references": {
+      "name": "memory_references",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "canvas_id": {
+          "name": "canvas_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frame_id": {
+          "name": "frame_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "html": {
+          "name": "html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "width": {
+          "name": "width",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "height": {
+          "name": "height",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pinned_by": {
+          "name": "pinned_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pinned_at": {
+          "name": "pinned_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "memory_references_canvas_idx": {
+          "name": "memory_references_canvas_idx",
+          "columns": [
+            {
+              "expression": "canvas_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.model_accounts": {
+      "name": "model_accounts",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan": {
+          "name": "plan",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connected_at": {
+          "name": "connected_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.resident_usage": {
+      "name": "resident_usage",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "used": {
+          "name": "used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sync_edges": {
+      "name": "sync_edges",
+      "schema": "",
+      "columns": {
+        "key_id": {
+          "name": "key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_page": {
+          "name": "from_page",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_page": {
+          "name": "to_page",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_at": {
+          "name": "last_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "sync_edges_key_id_from_page_to_page_pk": {
+          "name": "sync_edges_key_id_from_page_to_page_pk",
+          "columns": ["key_id", "from_page", "to_page"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sync_keys": {
+      "name": "sync_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canvas_id": {
+          "name": "canvas_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "sync_keys_canvas_idx": {
+          "name": "sync_keys_canvas_idx",
+          "columns": [
+            {
+              "expression": "canvas_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sync_keys_secret_idx": {
+          "name": "sync_keys_secret_idx",
+          "columns": [
+            {
+              "expression": "secret",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sync_links": {
+      "name": "sync_links",
+      "schema": "",
+      "columns": {
+        "key_id": {
+          "name": "key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "page": {
+          "name": "page",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_page": {
+          "name": "to_page",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "x": {
+          "name": "x",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "y": {
+          "name": "y",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "width": {
+          "name": "width",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "height": {
+          "name": "height",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "sync_links_page_idx": {
+          "name": "sync_links_page_idx",
+          "columns": [
+            {
+              "expression": "key_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "page",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tasks": {
+      "name": "tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "canvas_id": {
+          "name": "canvas_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto": {
+          "name": "auto",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "queued_by": {
+          "name": "queued_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failed_at": {
+          "name": "failed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pipeline": {
+          "name": "pipeline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stage": {
+          "name": "stage",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attachments": {
+          "name": "attachments",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "queued_by_user_id": {
+          "name": "queued_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "tasks_canvas_idx": {
+          "name": "tasks_canvas_idx",
+          "columns": [
+            {
+              "expression": "canvas_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_access_token": {
+      "name": "oauth_access_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_access_token_access_token_unique": {
+          "name": "oauth_access_token_access_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["access_token"]
+        },
+        "oauth_access_token_refresh_token_unique": {
+          "name": "oauth_access_token_refresh_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["refresh_token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_application": {
+      "name": "oauth_application",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_urls": {
+          "name": "redirect_urls",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_application_client_id_unique": {
+          "name": "oauth_application_client_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["client_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_consent": {
+      "name": "oauth_consent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "consent_given": {
+          "name": "consent_given",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/server/db/migrations/meta/_journal.json
+++ b/server/db/migrations/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1788139127832,
       "tag": "0007_colorful_firedrake",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1788470786816,
+      "tag": "0008_comment_replies",
+      "breakpoints": true
     }
   ]
 }

--- a/server/db/persist.ts
+++ b/server/db/persist.ts
@@ -452,6 +452,7 @@ export function saveComment(c: ElementComment) {
     failureReason: c.failureReason ?? null,
     resolvedBy: c.resolvedBy ?? null,
     resolvedAt: c.resolvedAt ?? null,
+    parentId: c.parentId ?? null,
   }
   swallow(
     db
@@ -684,6 +685,7 @@ export async function hydrate(): Promise<Hydrated> {
       ...(failureReason !== undefined ? { failureReason } : {}),
       ...(row.resolvedBy != null ? { resolvedBy: row.resolvedBy } : {}),
       ...(row.resolvedAt != null ? { resolvedAt: row.resolvedAt } : {}),
+      ...(row.parentId != null ? { parentId: row.parentId } : {}),
     })
     comments.set(row.canvasId, list)
   }

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -201,6 +201,7 @@ export const comments = pgTable(
     failureReason: text('failure_reason'),
     resolvedBy: text('resolved_by'),
     resolvedAt: bigint('resolved_at', { mode: 'number' }),
+    parentId: text('parent_id'),
   },
   (t) => [index('comments_canvas_idx').on(t.canvasId)],
 )

--- a/server/index.ts
+++ b/server/index.ts
@@ -1181,14 +1181,19 @@ app.post('/api/comments/:id/replies', async (req, res) => {
     return res.status(404).json({ error: 'thread resolved or empty text' })
   }
   /* same rule as a fresh comment: only an @mention costs a resident task */
+  let gate: Awaited<ReturnType<typeof allowance.consumeResidentTask>> | undefined
   if (mentionedRole(text)) {
-    const gate = await allowance.consumeResidentTask(req.user!.id)
+    gate = await allowance.consumeResidentTask(req.user!.id)
     if (!gate.ok) {
       return res.status(403).json({ error: 'resident_limit', used: gate.used, limit: gate.limit })
     }
   }
   const reply = actions.replyToComment(req.params.id, text, req.user!.name, req.user!.id)
-  if (!reply) return res.status(409).json({ error: 'thread resolved meanwhile' })
+  if (!reply) {
+    /* the thread closed while the meter was being written: give the task back */
+    if (gate) await allowance.refundResidentTask(gate, req.user!.id)
+    return res.status(409).json({ error: 'thread resolved meanwhile' })
+  }
   res.json(reply)
 })
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -1190,8 +1190,13 @@ app.post('/api/comments/:id/replies', async (req, res) => {
   }
   const reply = actions.replyToComment(req.params.id, text, req.user!.name, req.user!.id)
   if (!reply) {
-    /* the thread closed while the meter was being written: give the task back */
-    if (gate) await allowance.refundResidentTask(gate, req.user!.id)
+    /* the thread closed while the meter was being written: give the task
+       back — a failed refund is logged, never turned into a 500 */
+    if (gate) {
+      await allowance.refundResidentTask(gate, req.user!.id).catch((err) => {
+        console.error(`[comments] could not refund a resident task for ${req.user!.id}:`, err)
+      })
+    }
     return res.status(409).json({ error: 'thread resolved meanwhile' })
   }
   res.json(reply)

--- a/server/index.ts
+++ b/server/index.ts
@@ -1172,6 +1172,23 @@ app.post('/api/frames/:id/comments', async (req, res) => {
   res.json(comment)
 })
 
+app.post('/api/comments/:id/replies', async (req, res) => {
+  const found = actions.findComment(req.params.id)
+  if (!found) return res.status(404).json({ error: 'comment not found' })
+  if (!requireCanvas(req, res, found.canvasId)) return
+  const text = String(req.body?.text ?? '')
+  /* same rule as a fresh comment: only an @mention costs a resident task */
+  if (mentionedRole(text)) {
+    const gate = await allowance.consumeResidentTask(req.user!.id)
+    if (!gate.ok) {
+      return res.status(403).json({ error: 'resident_limit', used: gate.used, limit: gate.limit })
+    }
+  }
+  const reply = actions.replyToComment(req.params.id, text, req.user!.name, req.user!.id)
+  if (!reply) return res.status(404).json({ error: 'thread resolved or empty text' })
+  res.json(reply)
+})
+
 app.post('/api/comments/:id/resolve', (req, res) => {
   const found = actions.findComment(req.params.id)
   if (!found) return res.status(404).json({ error: 'comment not found' })

--- a/server/index.ts
+++ b/server/index.ts
@@ -1177,6 +1177,9 @@ app.post('/api/comments/:id/replies', async (req, res) => {
   if (!found) return res.status(404).json({ error: 'comment not found' })
   if (!requireCanvas(req, res, found.canvasId)) return
   const text = String(req.body?.text ?? '')
+  if (!text.trim() || !actions.openThread(req.params.id)) {
+    return res.status(404).json({ error: 'thread resolved or empty text' })
+  }
   /* same rule as a fresh comment: only an @mention costs a resident task */
   if (mentionedRole(text)) {
     const gate = await allowance.consumeResidentTask(req.user!.id)
@@ -1185,7 +1188,7 @@ app.post('/api/comments/:id/replies', async (req, res) => {
     }
   }
   const reply = actions.replyToComment(req.params.id, text, req.user!.name, req.user!.id)
-  if (!reply) return res.status(404).json({ error: 'thread resolved or empty text' })
+  if (!reply) return res.status(409).json({ error: 'thread resolved meanwhile' })
   res.json(reply)
 })
 

--- a/server/resident.ts
+++ b/server/resident.ts
@@ -316,7 +316,15 @@ async function runAgent(canvasId: string, agentName: string, stalled: Set<string
           comments
             .map((c) => {
               const fname = store.getFrame(c.frameId)?.name ?? 'unknown frame'
-              return `- ${c.from} on frame ${c.frameId} "${fname}", element ${c.selector}\n  element HTML at comment time: ${c.snippet}\n  comment: "${c.text}"`
+              /* a reply carries the conversation it answers, so "make it
+                 bigger" reads against what was said before */
+              const earlier = actions
+                .commentThread(c)
+                .filter((x) => x.at < c.at)
+                .map((x) => `    ${x.from}: "${x.text}"`)
+                .join('\n')
+              const thread = earlier ? `\n  earlier in this thread:\n${earlier}` : ''
+              return `- ${c.from} on frame ${c.frameId} "${fname}", element ${c.selector}\n  element HTML at comment time: ${c.snippet}${thread}\n  comment: "${c.text}"`
             })
             .join('\n'),
       )

--- a/server/resident.ts
+++ b/server/resident.ts
@@ -318,9 +318,12 @@ async function runAgent(canvasId: string, agentName: string, stalled: Set<string
               const fname = store.getFrame(c.frameId)?.name ?? 'unknown frame'
               /* a reply carries the conversation it answers, so "make it
                  bigger" reads against what was said before */
-              const earlier = actions
-                .commentThread(c)
-                .filter((x) => x.at < c.at)
+              const history = actions.commentThread(c)
+              const earlier = history
+                .slice(
+                  0,
+                  history.findIndex((x) => x.id === c.id),
+                )
                 .map((x) => `    ${x.from}: "${x.text}"`)
                 .join('\n')
               const thread = earlier ? `\n  earlier in this thread:\n${earlier}` : ''

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -236,6 +236,9 @@ export interface ElementComment {
   failureReason?: string
   resolvedBy?: string
   resolvedAt?: number
+  /** set on a reply: the root comment of its thread. Replies inherit the
+   *  root's anchor and are listed under its pin instead of getting their own */
+  parentId?: string
 }
 
 export interface ActivityItem {

--- a/src/components/FrameView.tsx
+++ b/src/components/FrameView.tsx
@@ -212,7 +212,9 @@ export const FrameView = memo(function FrameView({ frame, raster }: { frame: Fra
   }, [runtimeReady, html, editing, suspendPost])
 
   /* ---- element comments ---- */
-  const comments = useStore((s) => s.comments).filter((c) => c.frameId === frame.id && !c.resolvedAt)
+  const frameComments = useStore((s) => s.comments).filter((c) => c.frameId === frame.id)
+  /* only thread roots get a pin; replies live inside the root's popover */
+  const comments = frameComments.filter((c) => !c.parentId && !c.resolvedAt)
   const [probe, setProbe] = useState<ProbeHit | null>(null)
   /* element selected for text editing inside the iframe (edit mode only) */
   const [activeHit, setActiveHit] = useState<ProbeHit | null>(null)
@@ -609,17 +611,20 @@ export const FrameView = memo(function FrameView({ frame, raster }: { frame: Fra
                   const pos = pinPos[c.id]
                   if (!pos) return null
                   const open = openThread === c.id
+                  const replies = frameComments.filter((r) => r.parentId === c.id).reverse() // store is newest-first
+                  const thread = [c, ...replies.sort((a, b) => a.at - b.at)]
+                  /* the pin reflects the newest agent request in the thread */
+                  const agentItem = [...thread].reverse().find((x) => x.forAgent && !x.resolvedAt)
+                  const working = agentItem?.claimedBy && !agentItem.failedAt
                   return (
                     <div
                       key={c.id}
                       className={cn(
                         'pointer-events-auto absolute z-[4] grid h-[26px] w-[26px] cursor-pointer place-items-center rounded-[50%_50%_50%_4px] border-2 border-white text-[13px] text-white [transform:translate(-50%,-50%)_scale(min(calc(1/var(--zoom,1)),2.4))] animate-[chip-in_0.25s_ease]',
-                        c.failedAt
+                        agentItem?.failedAt
                           ? 'bg-accent-ink! font-extrabold shadow-[0_0_0_3px_rgba(208,52,31,0.2),var(--shadow-card)]'
                           : 'shadow-card',
-                        !c.failedAt &&
-                          c.claimedBy &&
-                          !c.resolvedAt &&
+                        working &&
                           "after:absolute after:-inset-1.5 after:rounded-[inherit] after:border-2 after:border-current after:opacity-50 after:content-[''] after:[animation:stream-pulse_1.1s_ease-in-out_infinite]",
                       )}
                       style={{
@@ -633,12 +638,21 @@ export const FrameView = memo(function FrameView({ frame, raster }: { frame: Fra
                         setComposing(false)
                         setOpenThread(open ? null : c.id)
                       }}
-                      title={`${c.from}: ${c.text}`}
+                      title={`${c.from}: ${c.text}${thread.length > 1 ? ` (${thread.length - 1} replies)` : ''}`}
                     >
-                      {c.failedAt ? '!' : c.claimedBy && !c.resolvedAt ? '✦' : '💬'}
+                      {agentItem?.failedAt ? '!' : working ? '✦' : '💬'}
                       {open && (
                         <CommentThread
-                          comment={c}
+                          thread={thread}
+                          onReply={(text) =>
+                            api
+                              .replyComment(c.id, text)
+                              .then(() => posthog.capture('element_comment_replied'))
+                              .catch((err) => {
+                                if (isResidentLimit(err)) useStore.getState().setLimitWall(true)
+                                else console.error(err)
+                              })
+                          }
                           onResolve={() => {
                             api
                               .resolveComment(c.id)
@@ -646,8 +660,8 @@ export const FrameView = memo(function FrameView({ frame, raster }: { frame: Fra
                               .catch(console.error)
                             setOpenThread(null)
                           }}
-                          onRetry={() =>
-                            api.retryComment(c.id).catch((err) => {
+                          onRetry={(id) =>
+                            api.retryComment(id).catch((err) => {
                               if (isResidentLimit(err)) useStore.getState().setLimitWall(true)
                               else console.error(err)
                             })
@@ -828,44 +842,82 @@ function CommentComposer({
   )
 }
 
+/** Where an @agent request in the thread stands, or null for a human note. */
+function agentStatus(c: ElementComment): string | null {
+  const target = c.targetAgent ?? roleName(DEFAULT_ROLE_ID)
+  if (c.failedAt) return `${target} stopped`
+  if (c.resolvedAt) return c.forAgent ? `✓ ${c.resolvedBy ?? target}` : null
+  if (c.claimedBy) return `✦ ${c.claimedBy} is on it`
+  return c.forAgent ? `✦ waiting for ${target}` : null
+}
+
 function CommentThread({
-  comment,
+  thread,
+  onReply,
   onResolve,
   onRetry,
 }: {
-  comment: ElementComment
+  /** root comment first, then its replies oldest → newest */
+  thread: ElementComment[]
+  onReply: (text: string) => void
   onResolve: () => void
-  onRetry: () => void
+  onRetry: (commentId: string) => void
 }) {
-  const target = comment.targetAgent ?? roleName(DEFAULT_ROLE_ID)
-  const status = comment.failedAt
-    ? `${target} stopped`
-    : comment.claimedBy && !comment.resolvedAt
-      ? `✦ ${comment.claimedBy} is on it`
-      : comment.forAgent
-        ? `✦ waiting for ${target}`
-        : null
+  const [reply, setReply] = useState('')
+  const listRef = useRef<HTMLDivElement>(null)
+  /* a long conversation opens (and grows) scrolled to its newest message */
+  useEffect(() => {
+    listRef.current?.scrollTo({ top: listRef.current.scrollHeight })
+  }, [thread.length])
+  const send = () => {
+    if (!reply.trim()) return
+    onReply(reply)
+    setReply('')
+  }
+  const mentioned = mentionedRole(reply)
   return (
     <div
-      className="absolute top-[calc(100%_+_8px)] left-1/2 w-[230px] -translate-x-1/2 cursor-default rounded-[10px] border border-line bg-surface p-2.5 text-left shadow-pop animate-[chip-in_0.18s_ease]"
+      className="absolute top-[calc(100%_+_8px)] left-1/2 w-[250px] -translate-x-1/2 cursor-default rounded-[10px] border border-line bg-surface p-2.5 text-left shadow-pop animate-[chip-in_0.18s_ease]"
       onClick={(e) => e.stopPropagation()}
     >
-      <div className="flex items-center justify-between gap-2 text-[12px]">
-        <b style={{ color: colorFor(comment.from) }}>{comment.from}</b>
-        {status && <span className="whitespace-nowrap text-[11px] font-semibold text-brand">{status}</span>}
+      <div ref={listRef} className="-mx-1 max-h-[240px] overflow-y-auto px-1">
+        {thread.map((c, i) => {
+          const status = agentStatus(c)
+          return (
+            <div key={c.id} className={cn(i > 0 && 'mt-2 border-t border-line-soft pt-2')}>
+              <div className="flex items-center justify-between gap-2 text-[12px]">
+                <b style={{ color: colorFor(c.from) }}>{c.from}</b>
+                {status && <span className="whitespace-nowrap text-[11px] font-semibold text-brand">{status}</span>}
+              </div>
+              <div className="mt-1 break-words text-[13px] leading-[1.45] text-ink">{c.text}</div>
+              {c.failedAt ? (
+                <div className="mt-1 flex items-center gap-2 text-[11px] leading-[1.4] text-accent-ink">
+                  <span>{c.failureReason ?? 'The agent did not finish.'}</span>
+                  <Button
+                    variant="danger-solid"
+                    size="pill"
+                    className="shrink-0 px-[9px] py-[3px] text-[11px]"
+                    onClick={() => onRetry(c.id)}
+                  >
+                    ↻ Retry
+                  </Button>
+                </div>
+              ) : null}
+            </div>
+          )
+        })}
       </div>
-      <div className="mt-1.5 mb-2 break-words text-[13px] leading-[1.45] text-ink">{comment.text}</div>
-      {comment.failedAt ? (
-        <div className="-mt-0.5 mb-2 text-[11px] leading-[1.4] text-accent-ink">
-          {comment.failureReason ?? 'The agent did not finish.'}
-        </div>
-      ) : null}
-      <div className="flex items-center gap-1.5">
-        {comment.failedAt ? (
-          <Button variant="danger-solid" size="pill" className="px-[11px] py-[5px]" onClick={onRetry}>
-            ↻ Retry
-          </Button>
-        ) : null}
+      <Textarea
+        variant="bare"
+        className="mt-2 min-h-[38px] md:text-[13px]"
+        value={reply}
+        placeholder="Reply… (@doop to ask the agent)"
+        onChange={(e) => setReply(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) send()
+        }}
+      />
+      <div className="mt-1.5 flex items-center gap-1.5">
         <Button
           variant="ghost"
           size="pill"
@@ -873,6 +925,23 @@ function CommentThread({
           onClick={onResolve}
         >
           ✓ Resolve
+        </Button>
+        {mentioned && (
+          <span
+            className="ml-auto truncate text-[11px] font-semibold text-brand"
+            title={`${mentioned.name} will pick this up`}
+          >
+            {mentioned.emoji} {mentioned.name}
+          </span>
+        )}
+        <Button
+          variant="solid"
+          size="pill"
+          className={cn('px-3 py-[4px] text-xs', !mentioned && 'ml-auto')}
+          disabled={!reply.trim()}
+          onClick={send}
+        >
+          Reply
         </Button>
       </div>
     </div>

--- a/src/components/FrameView.tsx
+++ b/src/components/FrameView.tsx
@@ -649,8 +649,10 @@ export const FrameView = memo(function FrameView({ frame, raster }: { frame: Fra
                               .replyComment(c.id, text)
                               .then(() => posthog.capture('element_comment_replied'))
                               .catch((err) => {
+                                /* the wall explains a hit limit; anything else
+                                   surfaces in the thread so the draft survives */
                                 if (isResidentLimit(err)) useStore.getState().setLimitWall(true)
-                                else console.error(err)
+                                throw err
                               })
                           }
                           onResolve={() => {
@@ -859,20 +861,27 @@ function CommentThread({
 }: {
   /** root comment first, then its replies oldest → newest */
   thread: ElementComment[]
-  onReply: (text: string) => void
+  /** rejects when the reply did not land — the draft is kept for a retry */
+  onReply: (text: string) => Promise<unknown>
   onResolve: () => void
   onRetry: (commentId: string) => void
 }) {
   const [reply, setReply] = useState('')
+  const [sending, setSending] = useState(false)
+  const [failed, setFailed] = useState(false)
   const listRef = useRef<HTMLDivElement>(null)
   /* a long conversation opens (and grows) scrolled to its newest message */
   useEffect(() => {
     listRef.current?.scrollTo({ top: listRef.current.scrollHeight })
   }, [thread.length])
   const send = () => {
-    if (!reply.trim()) return
+    if (!reply.trim() || sending) return
+    setSending(true)
+    setFailed(false)
     onReply(reply)
-    setReply('')
+      .then(() => setReply(''))
+      .catch(() => setFailed(true))
+      .finally(() => setSending(false))
   }
   const mentioned = mentionedRole(reply)
   return (
@@ -917,6 +926,11 @@ function CommentThread({
           if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) send()
         }}
       />
+      {failed && (
+        <div className="mt-1 text-[11px] leading-[1.4] text-accent-ink">
+          That reply did not go through — it may be resolved already. Try again.
+        </div>
+      )}
       <div className="mt-1.5 flex items-center gap-1.5">
         <Button
           variant="ghost"
@@ -938,10 +952,10 @@ function CommentThread({
           variant="solid"
           size="pill"
           className={cn('px-3 py-[4px] text-xs', !mentioned && 'ml-auto')}
-          disabled={!reply.trim()}
+          disabled={!reply.trim() || sending}
           onClick={send}
         >
-          Reply
+          {sending ? 'Posting…' : 'Reply'}
         </Button>
       </div>
     </div>

--- a/src/components/FrameView.tsx
+++ b/src/components/FrameView.tsx
@@ -876,10 +876,12 @@ function CommentThread({
   }, [thread.length])
   const send = () => {
     if (!reply.trim() || sending) return
+    const submitted = reply
     setSending(true)
     setFailed(false)
-    onReply(reply)
-      .then(() => setReply(''))
+    onReply(submitted)
+      /* only clear what was sent — text typed meanwhile is a new draft */
+      .then(() => setReply((current) => (current === submitted ? '' : current)))
       .catch(() => setFailed(true))
       .finally(() => setSending(false))
   }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -295,6 +295,8 @@ export const api = {
     req(`/api/canvases/${canvasId}/cards/${cardId}/retry`, { method: 'POST' }),
   addComment: (frameId: string, input: { selector: string; snippet: string; text: string }) =>
     req(`/api/frames/${frameId}/comments`, { method: 'POST', body: JSON.stringify(input) }),
+  replyComment: (commentId: string, text: string) =>
+    req(`/api/comments/${commentId}/replies`, { method: 'POST', body: JSON.stringify({ text }) }),
   resolveComment: (commentId: string) => req(`/api/comments/${commentId}/resolve`, { method: 'POST' }),
   retryComment: (commentId: string) => req(`/api/comments/${commentId}/retry`, { method: 'POST' }),
   retryTaskFeedback: (feedbackId: string) => req(`/api/feedback/${feedbackId}/retry`, { method: 'POST' }),

--- a/tests/commentReplies.test.ts
+++ b/tests/commentReplies.test.ts
@@ -66,6 +66,14 @@ describe('replying to a comment', () => {
     expect(actions.commentThread(reply).map((c) => c.text)).toEqual(['Too small', 'Agreed'])
   })
 
+  it('gives every message a distinct timestamp so order survives a reload', () => {
+    const parent = root()
+    const first = actions.replyToComment(parent.id, 'one', 'bob')!
+    const second = actions.replyToComment(parent.id, 'two', 'carol')!
+    expect(first.at).toBeGreaterThan(parent.at)
+    expect(second.at).toBeGreaterThan(first.at)
+  })
+
   it('re-roots a reply to a reply, keeping threads one level deep', () => {
     const parent = root()
     const first = actions.replyToComment(parent.id, 'Agreed', 'bob')!

--- a/tests/commentReplies.test.ts
+++ b/tests/commentReplies.test.ts
@@ -1,0 +1,107 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Frame } from '../shared/types.ts'
+
+/* Replies are persisted and broadcast like any comment; the unit tests only
+   care about how a thread is shaped, so both sides are stubbed. */
+vi.mock('../server/db/persist.ts', () => ({
+  saveTask: () => {},
+  saveFeedback: () => {},
+  saveComment: () => {},
+  saveActivity: () => {},
+  saveDecision: () => {},
+  saveProposal: () => {},
+}))
+
+const actions = await import('../server/actions.ts')
+const { store } = await import('../server/store.ts')
+const { DEFAULT_ROLE_ID, roleName } = await import('../shared/agents.ts')
+
+const AGENT = roleName(DEFAULT_ROLE_ID)
+const CANVAS = 'canvas-1'
+const FRAME: Frame = {
+  id: 'f1',
+  canvasId: CANVAS,
+  name: 'Hero',
+  html: '<p/>',
+  x: 0,
+  y: 0,
+  width: 10,
+  height: 10,
+  createdAt: 0,
+  updatedAt: 0,
+  updatedBy: 'alice',
+}
+
+beforeEach(() => {
+  actions.wire(
+    () => {},
+    () => {},
+  )
+  actions.hydrateLogs({
+    tasks: new Map(),
+    feedback: new Map(),
+    comments: new Map([[CANVAS, []]]),
+    activity: new Map(),
+    decisions: new Map(),
+    proposals: new Map(),
+  })
+  vi.spyOn(store, 'getFrame').mockImplementation((id) => (id === FRAME.id ? FRAME : undefined))
+})
+
+function root() {
+  return actions.addElementComment(
+    FRAME.id,
+    { selector: '.hero h1', snippet: '<h1>Hi</h1>', text: 'Too small' },
+    'alice',
+  )!
+}
+
+describe('replying to a comment', () => {
+  it('threads the reply under the root and inherits its element', () => {
+    const parent = root()
+    const reply = actions.replyToComment(parent.id, 'Agreed', 'bob')!
+    expect(reply.parentId).toBe(parent.id)
+    expect(reply.selector).toBe(parent.selector)
+    expect(reply.snippet).toBe(parent.snippet)
+    expect(actions.commentThread(reply).map((c) => c.text)).toEqual(['Too small', 'Agreed'])
+  })
+
+  it('re-roots a reply to a reply, keeping threads one level deep', () => {
+    const parent = root()
+    const first = actions.replyToComment(parent.id, 'Agreed', 'bob')!
+    const second = actions.replyToComment(first.id, 'Same', 'carol')!
+    expect(second.parentId).toBe(parent.id)
+    expect(actions.commentThread(parent).map((c) => c.from)).toEqual(['alice', 'bob', 'carol'])
+  })
+
+  it('routes an @mention in a reply to the agent with the thread anchor', () => {
+    const parent = root()
+    const reply = actions.replyToComment(parent.id, `@${DEFAULT_ROLE_ID} make it 48px`, 'alice', 'alice')!
+    expect(reply.forAgent).toBe(true)
+    expect(reply.targetAgent).toBe(AGENT)
+    expect(actions.takeAgentCommentsFor(CANVAS, AGENT, 'alice').map((c) => c.id)).toEqual([reply.id])
+  })
+
+  it('refuses replies on a resolved thread or with empty text', () => {
+    const parent = root()
+    expect(actions.replyToComment(parent.id, '   ', 'bob')).toBeUndefined()
+    actions.resolveComment(parent.id, 'alice')
+    expect(actions.replyToComment(parent.id, 'Late', 'bob')).toBeUndefined()
+    expect(actions.replyToComment('missing', 'Hello', 'bob')).toBeUndefined()
+  })
+
+  it('resolving the root closes every open reply so none stays queued for an agent', () => {
+    const parent = root()
+    const reply = actions.replyToComment(parent.id, `@${DEFAULT_ROLE_ID} bigger`, 'alice', 'alice')!
+    actions.resolveComment(parent.id, 'alice')
+    expect(actions.findComment(reply.id)?.resolvedAt).toBeDefined()
+    expect(actions.takeAgentCommentsFor(CANVAS, AGENT, 'alice')).toEqual([])
+  })
+
+  it('resolving a reply leaves the thread open', () => {
+    const parent = root()
+    const reply = actions.replyToComment(parent.id, `@${DEFAULT_ROLE_ID} bigger`, 'alice', 'alice')!
+    actions.resolveComment(reply.id, AGENT)
+    expect(actions.findComment(parent.id)?.resolvedAt).toBeUndefined()
+  })
+})

--- a/tests/commentReplies.test.ts
+++ b/tests/commentReplies.test.ts
@@ -82,6 +82,15 @@ describe('replying to a comment', () => {
     expect(actions.takeAgentCommentsFor(CANVAS, AGENT, 'alice').map((c) => c.id)).toEqual([reply.id])
   })
 
+  it('reports whether a thread can take a reply before anything is metered', () => {
+    const parent = root()
+    const reply = actions.replyToComment(parent.id, 'Agreed', 'bob')!
+    expect(actions.openThread(reply.id)?.root.id).toBe(parent.id)
+    actions.resolveComment(parent.id, 'alice')
+    expect(actions.openThread(reply.id)).toBeUndefined()
+    expect(actions.openThread('missing')).toBeUndefined()
+  })
+
   it('refuses replies on a resolved thread or with empty text', () => {
     const parent = root()
     expect(actions.replyToComment(parent.id, '   ', 'bob')).toBeUndefined()


### PR DESCRIPTION
Closes #83

Comments were single messages: the only actions on a pin were resolve and retry, so any back-and-forth had to happen as new pins on the same element. A reply now threads under the root comment and shows in the pin's popover with a reply box.

## What changed

- **Threads.** `ElementComment.parentId` marks a reply. Replies inherit the root's element anchor (selector + snippet) and never get their own pin; replying to a reply re-roots to the thread root so threads stay one level deep.
- **API.** `POST /api/comments/:id/replies { text }`. An `@mention` in a reply dispatches to the resident agent exactly like a fresh @comment (same metering); plain replies stay free. Replies on a resolved thread are rejected.
- **Agent context.** When the resident picks up an @mentioned reply, its prompt includes the earlier messages of the thread, so "make it bigger" reads against what was said before.
- **Resolve.** Resolving the root closes its open replies too, so nothing stays queued for an agent under a hidden pin. Resolving a single reply (what the agent does when it finishes) leaves the thread open.
- **UI.** The pin popover lists the thread (scrolls past ~240px), shows per-message agent status and retry, and has a reply textarea (⌘/Ctrl+Enter to send). The pin icon reflects the newest agent request in the thread.
- **DB.** `comments.parent_id text` via a new drizzle migration.

## Testing

- `tests/commentReplies.test.ts` covers threading, anchor inheritance, re-rooting, @mention routing, resolved/empty rejection, and resolve cascading.
- typecheck, lint, format:check and the full vitest suite pass.
- Smoke-tested the endpoint against a local dev server: comment → reply → empty reply (404) → resolve → late reply (404).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XZoxfAJ9WKNA8tGs1mFekN
