### PR TITLE
feat(canvas): marquee selection, shift-click multi-select and space-to-pan

### DIFF
--- a/src/components/FrameContextMenu.tsx
+++ b/src/components/FrameContextMenu.tsx
@@ -2,7 +2,8 @@ import type { MutableRefObject } from 'react'
 import type { Frame } from '../../shared/types'
 import { api } from '../lib/api'
 import { copyFrame, duplicateFrame, hasFrameClip, pasteFrameAtScreen } from '../lib/frameClipboard'
-import { deleteFrameTracked } from '../lib/history'
+import { deleteFramesTracked } from '../lib/history'
+import { useStore } from '../lib/store'
 import { MOD_KEY } from '../lib/keys'
 import { ContextMenuContent, ContextMenuItem, ContextMenuSeparator } from './ui/context-menu'
 import { MenuHint } from './ui/menu'
@@ -10,6 +11,13 @@ import { MenuHint } from './ui/menu'
 /** Right-click menu for a frame. FrameView owns the trigger, and passes the
  *  point the right-click happened at — Paste lands there. */
 export function FrameContextMenu({ frame, at }: { frame: Frame; at: MutableRefObject<{ x: number; y: number }> }) {
+  /* a right-click inside a multi-selection acts on the whole group */
+  const groupSize = useStore((s) => (s.selectedIds.includes(frame.id) ? s.selectedIds.length : 1))
+  function deleteSelection() {
+    const s = useStore.getState()
+    const ids = s.selectedIds.includes(frame.id) ? s.selectedIds : [frame.id]
+    deleteFramesTracked(s.canvas?.frames.filter((f) => ids.includes(f.id)) ?? [frame])
+  }
   return (
     <ContextMenuContent>
       <ContextMenuItem onSelect={() => copyFrame(frame)}>
@@ -50,8 +58,8 @@ export function FrameContextMenu({ frame, at }: { frame: Frame; at: MutableRefOb
         Add to design memory
       </ContextMenuItem>
       <ContextMenuSeparator />
-      <ContextMenuItem tone="danger" onSelect={() => deleteFrameTracked(frame)}>
-        Delete frame
+      <ContextMenuItem tone="danger" onSelect={deleteSelection}>
+        {groupSize > 1 ? `Delete ${groupSize} frames` : 'Delete frame'}
         <MenuHint>⌫</MenuHint>
       </ContextMenuItem>
     </ContextMenuContent>

--- a/src/components/FrameView.tsx
+++ b/src/components/FrameView.tsx
@@ -7,7 +7,7 @@ import { sendWs } from '../lib/ws'
 import { throttle } from '../lib/throttle'
 import { getIdentity } from '../lib/identity'
 import { FRAME_BOOTSTRAP } from '../lib/frameRuntime'
-import { recordCreate, recordUpdate } from '../lib/history'
+import { recordCreate, recordUpdate, recordUpdates } from '../lib/history'
 import { snapFrame } from '../lib/snap'
 import { FrameContextMenu } from './FrameContextMenu'
 import { ContextMenu, ContextMenuTrigger } from './ui/context-menu'
@@ -79,6 +79,8 @@ interface ProbeHit {
   rect: { x: number; y: number; width: number; height: number }
 }
 
+type DragRect = { id: string; x: number; y: number; width: number; height: number }
+
 interface HoverHit {
   tag: string
   rect: { x: number; y: number; width: number; height: number }
@@ -88,7 +90,7 @@ interface HoverHit {
    `--zoom` CSS variable the Stage sets, so a viewport change never re-renders
    this component — memo holds as long as the frame and raster are unchanged. */
 export const FrameView = memo(function FrameView({ frame, raster }: { frame: Frame; raster: number }) {
-  const selected = useStore((s) => s.selectedId === frame.id)
+  const selected = useStore((s) => s.selectedIds.includes(frame.id))
   const select = useStore((s) => s.select)
   const flash = useStore((s) => s.flashes[frame.id])
   const stream = useStore((s) => s.streams[frame.id])
@@ -108,41 +110,71 @@ export const FrameView = memo(function FrameView({ frame, raster }: { frame: Fra
      lands in the store — otherwise a stale post would morph the edit away */
   const [suspendPost, setSuspendPost] = useState(false)
 
-  const sendDrag = useRef(
-    throttle((f: { id: string; x: number; y: number; width: number; height: number }) => {
-      sendWs({ type: 'frame:drag', frameId: f.id, x: f.x, y: f.y, width: f.width, height: f.height })
-    }, 50),
-  ).current
+  /* one throttle per frame, so a group drag broadcasts every member —
+     a single throttle would keep only the last frame written each tick */
+  const dragSenders = useRef(new Map<string, (f: DragRect) => void>()).current
+  function sendDrag(id: string, f: DragRect) {
+    let send = dragSenders.get(id)
+    if (!send) {
+      send = throttle((r: DragRect) => {
+        sendWs({ type: 'frame:drag', frameId: r.id, x: r.x, y: r.y, width: r.width, height: r.height })
+      }, 50)
+      dragSenders.set(id, send)
+    }
+    send(f)
+  }
 
   function startDrag(e: React.PointerEvent, mode: 'move' | 'resize', probeOnClick = false, panelOnClick = false) {
     if (e.button !== 0) return
+    /* space held: let the event reach the Stage, which pans */
+    if (useStore.getState().panMode) return
     e.stopPropagation()
     e.preventDefault()
-    select(frame.id)
+    /* ⌥⇧-drag duplicates: the moment the drag is real, leave a copy of the
+       frame at its origin and keep dragging this one — same net effect as
+       Figma's "drag off a duplicate", without retargeting the drag */
+    const duplicating = mode === 'move' && e.altKey && e.shiftKey
+    /* plain ⇧-click adds to (or drops from) the selection; a dropped frame
+       does not start a drag */
+    if (mode === 'move' && e.shiftKey && !e.altKey) {
+      useStore.getState().toggleSelect(frame.id)
+      if (!useStore.getState().selectedIds.includes(frame.id)) return
+    } else if (!useStore.getState().selectedIds.includes(frame.id)) {
+      /* clicking a frame already in a group keeps the group — the drag
+         moves all of them */
+      select(frame.id)
+    }
     setDragging(true)
     clearHover()
     const start = { x: e.clientX, y: e.clientY }
     const off = { x: e.nativeEvent.offsetX, y: e.nativeEvent.offsetY }
     const orig = { x: frame.x, y: frame.y, width: frame.width, height: frame.height }
     let moved = false
-    /* ⌥⇧-drag duplicates: the moment the drag is real, leave a copy of the
-       frame at its origin and keep dragging this one — same net effect as
-       Figma's "drag off a duplicate", without retargeting the drag */
-    const duplicating = mode === 'move' && e.altKey && e.shiftKey
     let dupDropped = false
     if (duplicating) setDuping(true)
+    /* a move carries every selected frame along; a resize is this frame only */
+    const frames = useStore.getState().canvas?.frames ?? []
+    const selectedIds = mode === 'move' ? useStore.getState().selectedIds : [frame.id]
+    const group = frames
+      .filter((f) => selectedIds.includes(f.id))
+      .map((f) => ({ id: f.id, orig: { x: f.x, y: f.y, width: f.width, height: f.height } }))
+    const groupIds = new Set(group.map((g) => g.id))
 
     function onMove(ev: PointerEvent) {
       if (Math.abs(ev.clientX - start.x) + Math.abs(ev.clientY - start.y) > 4) moved = true
       if (duplicating && moved && !dupDropped) {
         dupDropped = true
-        api
-          .createFrame(frame.canvasId, { name: frame.name, html: frame.html, ...orig })
-          .then((f) => {
-            posthog.capture('frame_duplicated', { via: 'drag' })
-            recordCreate(f)
-          })
-          .catch(console.error)
+        for (const g of group) {
+          const src = frames.find((f) => f.id === g.id)
+          if (!src) continue
+          api
+            .createFrame(src.canvasId, { name: src.name, html: src.html, ...g.orig })
+            .then((f) => {
+              posthog.capture('frame_duplicated', { via: 'drag' })
+              recordCreate(f)
+            })
+            .catch(console.error)
+        }
       }
       const zoom = useStore.getState().viewport.zoom
       const dx = (ev.clientX - start.x) / zoom
@@ -155,14 +187,26 @@ export const FrameView = memo(function FrameView({ frame, raster }: { frame: Fra
               width: Math.max(120, Math.round(orig.width + dx)),
               height: Math.max(80, Math.round(orig.height + dy)),
             }
-      /* edges pull onto neighbouring frames' edges/centers; ⌥ drags free */
-      const others = useStore.getState().canvas?.frames.filter((f) => f.id !== frame.id) ?? []
+      /* edges pull onto neighbouring frames' edges/centers; ⌥ drags free.
+         Frames riding along in the group are not neighbours. */
+      const others = useStore.getState().canvas?.frames.filter((f) => !groupIds.has(f.id)) ?? []
       const snapped = ev.altKey ? { ...raw, guides: [] } : snapFrame(mode, raw, others, zoom)
       useStore.getState().setSnapGuides(snapped.guides)
-      const patch = mode === 'move' ? { x: snapped.x, y: snapped.y } : { width: snapped.width, height: snapped.height }
-      useStore.getState().patchFrameLocal(frame.id, patch)
-      const f = useStore.getState().canvas?.frames.find((x) => x.id === frame.id)
-      if (f) sendDrag({ id: f.id, x: f.x, y: f.y, width: f.width, height: f.height })
+      if (mode === 'move') {
+        /* the snapped delta of the dragged frame moves the whole group */
+        const sdx = snapped.x - orig.x
+        const sdy = snapped.y - orig.y
+        for (const g of group) {
+          useStore.getState().patchFrameLocal(g.id, { x: g.orig.x + sdx, y: g.orig.y + sdy })
+        }
+      } else {
+        useStore.getState().patchFrameLocal(frame.id, { width: snapped.width, height: snapped.height })
+      }
+      const live = useStore.getState().canvas?.frames ?? []
+      for (const g of group) {
+        const f = live.find((x) => x.id === g.id)
+        if (f) sendDrag(f.id, { id: f.id, x: f.x, y: f.y, width: f.width, height: f.height })
+      }
     }
     function onUp() {
       window.removeEventListener('pointermove', onMove)
@@ -170,11 +214,17 @@ export const FrameView = memo(function FrameView({ frame, raster }: { frame: Fra
       setDragging(false)
       if (duplicating) setDuping(false)
       useStore.getState().setSnapGuides([])
-      const f = useStore.getState().canvas?.frames.find((x) => x.id === frame.id)
-      if (f) {
-        api.updateFrame(f.id, { x: f.x, y: f.y, width: f.width, height: f.height }).catch(console.error)
-        recordUpdate(f.id, orig, { x: f.x, y: f.y, width: f.width, height: f.height })
+      const live = useStore.getState().canvas?.frames ?? []
+      const updates: { frameId: string; before: typeof orig; after: typeof orig }[] = []
+      for (const g of group) {
+        const f = live.find((x) => x.id === g.id)
+        if (!f) continue
+        const after = { x: f.x, y: f.y, width: f.width, height: f.height }
+        api.updateFrame(f.id, after).catch(console.error)
+        updates.push({ frameId: f.id, before: g.orig, after })
       }
+      if (updates.length === 1) recordUpdate(updates[0].frameId, updates[0].before, updates[0].after)
+      else recordUpdates(updates)
       /* a click (no drag) on the frame surface targets the element under
          the cursor: probe it and show the element toolbar */
       if (!moved && probeOnClick) probeAt(off.x, off.y)
@@ -417,8 +467,9 @@ export const FrameView = memo(function FrameView({ frame, raster }: { frame: Fra
         /* deferPanel: when this right-click is what selects the frame, the
            Inspector waits until the menu closes — it must not slide in
            underneath the menu the user just opened */
-        const alreadySelected = store.selectedId === frame.id
-        select(frame.id)
+        const alreadySelected = store.selectedIds.includes(frame.id)
+        /* a right-click inside a group keeps the group, so Delete takes all */
+        if (!alreadySelected) select(frame.id)
         closePopovers()
         store.openCtxMenu({ frameId: frame.id, deferPanel: !alreadySelected })
       }}

--- a/src/components/FrameView.tsx
+++ b/src/components/FrameView.tsx
@@ -7,7 +7,7 @@ import { sendWs } from '../lib/ws'
 import { throttle } from '../lib/throttle'
 import { getIdentity } from '../lib/identity'
 import { FRAME_BOOTSTRAP } from '../lib/frameRuntime'
-import { recordCreate, recordUpdate, recordUpdates } from '../lib/history'
+import { recordCreate, recordUpdate, recordUpdates, trackSave } from '../lib/history'
 import { snapFrame } from '../lib/snap'
 import { FrameContextMenu } from './FrameContextMenu'
 import { ContextMenu, ContextMenuTrigger } from './ui/context-menu'
@@ -220,7 +220,7 @@ export const FrameView = memo(function FrameView({ frame, raster }: { frame: Fra
         const f = live.find((x) => x.id === g.id)
         if (!f) continue
         const after = { x: f.x, y: f.y, width: f.width, height: f.height }
-        api.updateFrame(f.id, after).catch(console.error)
+        trackSave(api.updateFrame(f.id, after).catch(console.error))
         updates.push({ frameId: f.id, before: g.orig, after })
       }
       if (updates.length === 1) recordUpdate(updates[0].frameId, updates[0].before, updates[0].after)

--- a/src/components/FrameView.tsx
+++ b/src/components/FrameView.tsx
@@ -91,6 +91,9 @@ interface HoverHit {
    this component — memo holds as long as the frame and raster are unchanged. */
 export const FrameView = memo(function FrameView({ frame, raster }: { frame: Frame; raster: number }) {
   const selected = useStore((s) => s.selectedIds.includes(frame.id))
+  /* space held: the shield stays up even in edit mode, so the press reaches
+     the Stage and pans instead of vanishing into the editable iframe */
+  const panMode = useStore((s) => s.panMode)
   const select = useStore((s) => s.select)
   const flash = useStore((s) => s.flashes[frame.id])
   const stream = useStore((s) => s.streams[frame.id])
@@ -596,7 +599,7 @@ export const FrameView = memo(function FrameView({ frame, raster }: { frame: Fra
             )}
             {/* shield keeps pointer events on the canvas, not the iframe;
             lifted while editing so clicks land in the editable document */}
-            {!editing && <div className="absolute inset-0" />}
+            {(!editing || panMode) && <div className="absolute inset-0" />}
             {hover && !editing && !dragging && (
               <div
                 className="pointer-events-none absolute z-[3] bg-[rgba(60,130,246,0.06)] shadow-[inset_0_0_0_calc(1.5px/var(--zoom,1))_#3c82f6]"

--- a/src/components/Stage.tsx
+++ b/src/components/Stage.tsx
@@ -27,7 +27,10 @@ export function Stage({ onAddFrame }: { onAddFrame: () => void }) {
   const setViewport = useStore((s) => s.setViewport)
   const canvas = useStore((s) => s.canvas)
   const select = useStore((s) => s.select)
+  const panMode = useStore((s) => s.panMode)
   const [panning, setPanning] = useState(false)
+  /* the selection rectangle being dragged out, in world coordinates */
+  const [marquee, setMarquee] = useState<{ x: number; y: number; width: number; height: number } | null>(null)
   /* where the background menu opened, so Paste drops the frame there */
   const bgAt = useRef({ x: 0, y: 0 })
   /* iframe oversampling factor — bumped only once the zoom settles */
@@ -260,11 +263,47 @@ export function Stage({ onAddFrame }: { onAddFrame: () => void }) {
     }
   }
 
+  /* space bar → pan mode: the stage drags the viewport instead of drawing a
+     marquee, and frames let the press fall through to it. Held-space repeats
+     must not re-trigger, and typing in a field is never a pan. */
+  useEffect(() => {
+    function isTyping(e: KeyboardEvent) {
+      const t = e.target as HTMLElement
+      return t.tagName === 'INPUT' || t.tagName === 'TEXTAREA' || t.isContentEditable
+    }
+    function onDown(e: KeyboardEvent) {
+      if (e.key !== ' ' || isTyping(e)) return
+      e.preventDefault()
+      if (!useStore.getState().panMode) useStore.getState().setPanMode(true)
+    }
+    function onUp(e: KeyboardEvent) {
+      if (e.key === ' ') useStore.getState().setPanMode(false)
+    }
+    const reset = () => useStore.getState().setPanMode(false)
+    window.addEventListener('keydown', onDown)
+    window.addEventListener('keyup', onUp)
+    window.addEventListener('blur', reset)
+    return () => {
+      window.removeEventListener('keydown', onDown)
+      window.removeEventListener('keyup', onUp)
+      window.removeEventListener('blur', reset)
+      reset()
+    }
+  }, [])
+
   function onPointerDown(e: React.PointerEvent) {
-    /* pan on background drag or middle mouse anywhere */
     const isBackground = e.target === e.currentTarget || (e.target as HTMLElement).classList.contains('world')
-    if (!isBackground && e.button !== 1) return
-    if (e.button !== 0 && e.button !== 1) return
+    /* pan: middle mouse anywhere, space-drag anywhere, or a finger on the
+       background (touch has no space bar, and one-finger pan is how phones
+       move around) */
+    const pan = e.button === 1 || (e.button === 0 && (useStore.getState().panMode || e.pointerType === 'touch'))
+    if (pan) return startPan(e, isBackground)
+    /* left drag on the background draws a selection marquee */
+    if (e.button !== 0 || !isBackground) return
+    startMarquee(e)
+  }
+
+  function startPan(e: React.PointerEvent, isBackground: boolean) {
     e.currentTarget.setPointerCapture(e.pointerId)
     setPanning(true)
     let last = { x: e.clientX, y: e.clientY }
@@ -282,7 +321,49 @@ export function Stage({ onAddFrame }: { onAddFrame: () => void }) {
       window.removeEventListener('pointermove', onMove)
       window.removeEventListener('pointerup', onUp)
       setPanning(false)
-      if (!moved) select(null)
+      if (!moved && isBackground) select(null)
+    }
+    window.addEventListener('pointermove', onMove)
+    window.addEventListener('pointerup', onUp)
+  }
+
+  function startMarquee(e: React.PointerEvent) {
+    e.currentTarget.setPointerCapture(e.pointerId)
+    const origin = toWorld(e.clientX, e.clientY)
+    /* ⇧-marquee adds to what is already selected */
+    const keep = e.shiftKey ? useStore.getState().selectedIds : []
+    let moved = false
+
+    function onMove(ev: PointerEvent) {
+      const cur = toWorld(ev.clientX, ev.clientY)
+      const zoom = useStore.getState().viewport.zoom
+      if (Math.abs(cur.x - origin.x) * zoom + Math.abs(cur.y - origin.y) * zoom > 3) moved = true
+      if (!moved) return
+      const rect = {
+        x: Math.min(origin.x, cur.x),
+        y: Math.min(origin.y, cur.y),
+        width: Math.abs(cur.x - origin.x),
+        height: Math.abs(cur.y - origin.y),
+      }
+      setMarquee(rect)
+      const frames = useStore.getState().canvas?.frames ?? []
+      const hits = frames
+        .filter(
+          (f) =>
+            f.x < rect.x + rect.width &&
+            f.x + f.width > rect.x &&
+            f.y < rect.y + rect.height &&
+            f.y + f.height > rect.y,
+        )
+        .map((f) => f.id)
+      useStore.getState().selectMany([...keep, ...hits.filter((id) => !keep.includes(id))])
+    }
+    function onUp() {
+      window.removeEventListener('pointermove', onMove)
+      window.removeEventListener('pointerup', onUp)
+      setMarquee(null)
+      /* a plain click on empty canvas clears the selection */
+      if (!moved && !e.shiftKey) select(null)
     }
     window.addEventListener('pointermove', onMove)
     window.addEventListener('pointerup', onUp)
@@ -302,7 +383,14 @@ export function Stage({ onAddFrame }: { onAddFrame: () => void }) {
             /* `stage` is a behaviour hook, not a style: frameClipboard.ts queries
            `.stage` to map screen coordinates into the canvas. No CSS is
            attached to it — everything visual is in the utilities beside it. */
-            className={cn('stage absolute inset-0 touch-none', panning ? 'cursor-grabbing' : 'cursor-default')}
+            className={cn(
+              'stage absolute inset-0 touch-none',
+              panning
+                ? 'cursor-grabbing! [&_*]:cursor-grabbing!'
+                : panMode
+                  ? 'cursor-grab! [&_*]:cursor-grab!'
+                  : 'cursor-default',
+            )}
             onPointerDown={onPointerDown}
             onPointerMove={onPointerMove}
             onContextMenu={(e) => {
@@ -333,6 +421,12 @@ export function Stage({ onAddFrame }: { onAddFrame: () => void }) {
               <FlowOverlay />
               <SnapGuides />
               <Cursors />
+              {marquee && (
+                <div
+                  className="pointer-events-none absolute bg-brand/10 [box-shadow:inset_0_0_0_calc(1px/var(--zoom,1))_var(--brand)]"
+                  style={{ left: marquee.x, top: marquee.y, width: marquee.width, height: marquee.height }}
+                />
+              )}
             </div>
           </div>
         </ContextMenuTrigger>

--- a/src/lib/history.ts
+++ b/src/lib/history.ts
@@ -14,6 +14,9 @@ type Entry =
   | { type: 'update'; frameId: string; before: Patch; after: Patch; at: number }
   | { type: 'create'; frameId: string; snapshot: Snapshot }
   | { type: 'delete'; frameId: string; snapshot: Snapshot }
+  /* one multi-frame action (a group move, a group delete): undone and
+     redone as a unit */
+  | { type: 'group'; entries: Entry[] }
 
 const MAX = 100
 /* consecutive edits to the same fields land as one entry within this window
@@ -39,15 +42,24 @@ function snapshot(f: Frame): Snapshot {
   return { canvasId: f.canvasId, name: f.name, html: f.html, x: f.x, y: f.y, width: f.width, height: f.height }
 }
 
-export function recordUpdate(frameId: string, before: Patch, after: Patch) {
+type UpdateEntry = Extract<Entry, { type: 'update' }>
+
+function updateEntry(frameId: string, before: Patch, after: Patch): UpdateEntry | null {
   const keys = (Object.keys(after) as (keyof Patch)[]).filter((k) => before[k] !== after[k])
-  if (!keys.length) return
+  if (!keys.length) return null
   const b: Patch = {}
   const a: Patch = {}
   for (const k of keys) {
     b[k] = before[k] as never
     a[k] = after[k] as never
   }
+  return { type: 'update', frameId, before: b, after: a, at: Date.now() }
+}
+
+export function recordUpdate(frameId: string, before: Patch, after: Patch) {
+  const entry = updateEntry(frameId, before, after)
+  if (!entry) return
+  const keys = Object.keys(entry.after) as (keyof Patch)[]
   const top = undoStack[undoStack.length - 1]
   if (
     top?.type === 'update' &&
@@ -56,12 +68,19 @@ export function recordUpdate(frameId: string, before: Patch, after: Patch) {
     keys.every((k) => k in top.after)
   ) {
     /* merge a burst of saves: keep the oldest before, the newest after */
-    top.after = { ...top.after, ...a }
+    top.after = { ...top.after, ...entry.after }
     top.at = Date.now()
     redoStack = []
     return
   }
-  push({ type: 'update', frameId, before: b, after: a, at: Date.now() })
+  push(entry)
+}
+
+/** Several frames moved together (a group drag): one undo step. */
+export function recordUpdates(items: { frameId: string; before: Patch; after: Patch }[]) {
+  const entries = items.map((i) => updateEntry(i.frameId, i.before, i.after)).filter((e): e is UpdateEntry => !!e)
+  if (entries.length === 1) push(entries[0])
+  else if (entries.length) push({ type: 'group', entries })
 }
 
 export function recordCreate(frame: Frame) {
@@ -70,16 +89,25 @@ export function recordCreate(frame: Frame) {
 
 /** Delete a frame through the API, remembering enough to bring it back. */
 export function deleteFrameTracked(frame: Frame) {
-  push({ type: 'delete', frameId: frame.id, snapshot: snapshot(frame) })
-  api.deleteFrame(frame.id).catch(console.error)
+  deleteFramesTracked([frame])
+}
+
+/** Delete several frames as one undo step. */
+export function deleteFramesTracked(frames: Frame[]) {
+  if (!frames.length) return
+  const entries: Entry[] = frames.map((f) => ({ type: 'delete', frameId: f.id, snapshot: snapshot(f) }))
+  push(entries.length === 1 ? entries[0] : { type: 'group', entries })
+  for (const f of frames) api.deleteFrame(f.id).catch(console.error)
 }
 
 /* undoing a delete recreates the frame under a fresh server id — every
    other entry that pointed at the old id must follow it */
 function remapId(oldId: string, newId: string) {
-  for (const e of [...undoStack, ...redoStack]) {
-    if (e.frameId === oldId) e.frameId = newId
+  const visit = (e: Entry) => {
+    if (e.type === 'group') e.entries.forEach(visit)
+    else if (e.frameId === oldId) e.frameId = newId
   }
+  for (const e of [...undoStack, ...redoStack]) visit(e)
 }
 
 async function recreate(e: { frameId: string; snapshot: Snapshot }) {
@@ -90,20 +118,39 @@ async function recreate(e: { frameId: string; snapshot: Snapshot }) {
   useStore.getState().select(f.id)
 }
 
+async function applyUndo(e: Entry): Promise<void> {
+  if (e.type === 'group') {
+    for (const child of [...e.entries].reverse()) await applyUndo(child)
+  } else if (e.type === 'update') {
+    useStore.getState().patchFrameLocal(e.frameId, e.before)
+    await api.updateFrame(e.frameId, e.before)
+  } else if (e.type === 'create') {
+    await api.deleteFrame(e.frameId)
+  } else {
+    await recreate(e)
+  }
+}
+
+async function applyRedo(e: Entry): Promise<void> {
+  if (e.type === 'group') {
+    for (const child of e.entries) await applyRedo(child)
+  } else if (e.type === 'update') {
+    useStore.getState().patchFrameLocal(e.frameId, e.after)
+    await api.updateFrame(e.frameId, e.after)
+  } else if (e.type === 'create') {
+    await recreate(e)
+  } else {
+    await api.deleteFrame(e.frameId)
+  }
+}
+
 export async function undo() {
   if (busy) return
   const e = undoStack.pop()
   if (!e) return
   busy = true
   try {
-    if (e.type === 'update') {
-      useStore.getState().patchFrameLocal(e.frameId, e.before)
-      await api.updateFrame(e.frameId, e.before)
-    } else if (e.type === 'create') {
-      await api.deleteFrame(e.frameId)
-    } else {
-      await recreate(e)
-    }
+    await applyUndo(e)
     redoStack.push(e)
     posthog.capture('canvas_undo')
   } catch (err) {
@@ -120,14 +167,7 @@ export async function redo() {
   if (!e) return
   busy = true
   try {
-    if (e.type === 'update') {
-      useStore.getState().patchFrameLocal(e.frameId, e.after)
-      await api.updateFrame(e.frameId, e.after)
-    } else if (e.type === 'create') {
-      await recreate(e)
-    } else {
-      await api.deleteFrame(e.frameId)
-    }
+    await applyRedo(e)
     undoStack.push(e)
     posthog.capture('canvas_redo')
   } catch (err) {

--- a/src/lib/history.ts
+++ b/src/lib/history.ts
@@ -142,7 +142,14 @@ async function apply(e: Entry, direction: 'undo' | 'redo'): Promise<Entry | null
   if (e.type === 'update') {
     const patch = forward ? e.after : e.before
     useStore.getState().patchFrameLocal(e.frameId, patch)
-    await api.updateFrame(e.frameId, patch)
+    try {
+      await api.updateFrame(e.frameId, patch)
+    } catch (err) {
+      /* the server kept the old value — put the local copy back in step
+         with it rather than leave a client-only position behind */
+      useStore.getState().patchFrameLocal(e.frameId, forward ? e.before : e.after)
+      throw err
+    }
   } else if ((e.type === 'create') === forward) {
     await recreate(e)
   } else {

--- a/src/lib/history.ts
+++ b/src/lib/history.ts
@@ -125,71 +125,57 @@ async function recreate(e: { frameId: string; snapshot: Snapshot }) {
   useStore.getState().select(f.id)
 }
 
-/* every member of a group is attempted even if one fails — the frames are
-   independent, so a single bad request should not strand the rest */
-async function applyAll(entries: Entry[], apply: (e: Entry) => Promise<void>) {
-  const results = await Promise.allSettled(entries.map(apply))
-  const failed = results.find((r): r is PromiseRejectedResult => r.status === 'rejected')
-  if (failed) throw failed.reason
-}
-
-async function applyUndo(e: Entry): Promise<void> {
+/* Apply an entry and report which of its members took effect. A group's
+   frames are independent, so every member is attempted even if one fails;
+   the survivors are what the opposite stack gets, so a partially failed
+   group can still be reversed. Failed members are dropped, exactly as a
+   failed single entry is: the frame is gone or the canvas moved on. */
+async function apply(e: Entry, direction: 'undo' | 'redo'): Promise<Entry | null> {
   if (e.type === 'group') {
-    await applyAll(e.entries, applyUndo)
-  } else if (e.type === 'update') {
-    useStore.getState().patchFrameLocal(e.frameId, e.before)
-    await api.updateFrame(e.frameId, e.before)
-  } else if (e.type === 'create') {
-    await api.deleteFrame(e.frameId)
-  } else {
-    await recreate(e)
+    const results = await Promise.allSettled(e.entries.map((child) => apply(child, direction)))
+    const ok = results.flatMap((r) => (r.status === 'fulfilled' && r.value ? [r.value] : []))
+    const failed = results.find((r): r is PromiseRejectedResult => r.status === 'rejected')
+    if (failed) console.error(`${direction} failed for ${e.entries.length - ok.length} frame(s)`, failed.reason)
+    return ok.length === 0 ? null : ok.length === 1 ? ok[0] : { type: 'group', entries: ok }
   }
-}
-
-async function applyRedo(e: Entry): Promise<void> {
-  if (e.type === 'group') {
-    await applyAll(e.entries, applyRedo)
-  } else if (e.type === 'update') {
-    useStore.getState().patchFrameLocal(e.frameId, e.after)
-    await api.updateFrame(e.frameId, e.after)
-  } else if (e.type === 'create') {
+  const forward = direction === 'redo'
+  if (e.type === 'update') {
+    const patch = forward ? e.after : e.before
+    useStore.getState().patchFrameLocal(e.frameId, patch)
+    await api.updateFrame(e.frameId, patch)
+  } else if ((e.type === 'create') === forward) {
     await recreate(e)
   } else {
     await api.deleteFrame(e.frameId)
   }
+  return e
 }
 
-export async function undo() {
+async function step(direction: 'undo' | 'redo') {
   if (busy) return
-  const e = undoStack.pop()
+  const [from, to] = direction === 'undo' ? [undoStack, redoStack] : [redoStack, undoStack]
+  const e = from.pop()
   if (!e) return
   busy = true
   try {
     await inflight
-    await applyUndo(e)
-    redoStack.push(e)
-    posthog.capture('canvas_undo')
+    const applied = await apply(e, direction)
+    if (applied) {
+      to.push(applied)
+      posthog.capture(direction === 'undo' ? 'canvas_undo' : 'canvas_redo')
+    }
   } catch (err) {
     /* the frame is gone or the canvas moved on — drop the entry */
-    console.error('undo failed', err)
+    console.error(`${direction} failed`, err)
   } finally {
     busy = false
   }
 }
 
-export async function redo() {
-  if (busy) return
-  const e = redoStack.pop()
-  if (!e) return
-  busy = true
-  try {
-    await inflight
-    await applyRedo(e)
-    undoStack.push(e)
-    posthog.capture('canvas_redo')
-  } catch (err) {
-    console.error('redo failed', err)
-  } finally {
-    busy = false
-  }
+export function undo() {
+  return step('undo')
+}
+
+export function redo() {
+  return step('redo')
 }

--- a/src/lib/history.ts
+++ b/src/lib/history.ts
@@ -26,6 +26,13 @@ const COALESCE_MS = 1500
 let undoStack: Entry[] = []
 let redoStack: Entry[] = []
 let busy = false
+/* saves still in flight from a drag: undo/redo wait for them so the inverse
+   write never lands before (and gets overwritten by) the original */
+let inflight: Promise<unknown> = Promise.resolve()
+
+export function trackSave(p: Promise<unknown>) {
+  inflight = inflight.then(() => p.catch(() => undefined))
+}
 
 export function clearHistory() {
   undoStack = []
@@ -118,9 +125,17 @@ async function recreate(e: { frameId: string; snapshot: Snapshot }) {
   useStore.getState().select(f.id)
 }
 
+/* every member of a group is attempted even if one fails — the frames are
+   independent, so a single bad request should not strand the rest */
+async function applyAll(entries: Entry[], apply: (e: Entry) => Promise<void>) {
+  const results = await Promise.allSettled(entries.map(apply))
+  const failed = results.find((r): r is PromiseRejectedResult => r.status === 'rejected')
+  if (failed) throw failed.reason
+}
+
 async function applyUndo(e: Entry): Promise<void> {
   if (e.type === 'group') {
-    for (const child of [...e.entries].reverse()) await applyUndo(child)
+    await applyAll(e.entries, applyUndo)
   } else if (e.type === 'update') {
     useStore.getState().patchFrameLocal(e.frameId, e.before)
     await api.updateFrame(e.frameId, e.before)
@@ -133,7 +148,7 @@ async function applyUndo(e: Entry): Promise<void> {
 
 async function applyRedo(e: Entry): Promise<void> {
   if (e.type === 'group') {
-    for (const child of e.entries) await applyRedo(child)
+    await applyAll(e.entries, applyRedo)
   } else if (e.type === 'update') {
     useStore.getState().patchFrameLocal(e.frameId, e.after)
     await api.updateFrame(e.frameId, e.after)
@@ -150,6 +165,7 @@ export async function undo() {
   if (!e) return
   busy = true
   try {
+    await inflight
     await applyUndo(e)
     redoStack.push(e)
     posthog.capture('canvas_undo')
@@ -167,6 +183,7 @@ export async function redo() {
   if (!e) return
   busy = true
   try {
+    await inflight
     await applyRedo(e)
     undoStack.push(e)
     posthog.capture('canvas_redo')

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -227,6 +227,8 @@ export const useStore = create<State>((set, get) => ({
         /* losing the primary promotes the last surviving member, so a group
            never sits selected with nothing driving the Inspector/presence */
         selectedId: s.selectedId === frameId ? (selectedIds[selectedIds.length - 1] ?? null) : s.selectedId,
+        /* an open Inspector must not silently retarget onto the promoted frame */
+        inspectorOpen: s.selectedId === frameId ? false : s.inspectorOpen,
         ctxMenu: s.ctxMenu?.frameId === frameId ? null : s.ctxMenu,
       }
     }),

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -38,7 +38,14 @@ interface State {
   /** which tab the side panel shows — in the store so a Memory-suggestion
    *  toast anywhere in the app can jump straight to the Memory tab */
   panelTab: 'tasks' | 'activity' | 'memory'
+  /** every selected frame, in selection order — marquee and ⇧-click build
+   *  this up; a plain click collapses it to one */
+  selectedIds: string[]
+  /** the primary selection (the last frame added) — what the Inspector,
+   *  presence, and the flow overlay follow */
   selectedId: string | null
+  /** space bar held: the stage pans on drag instead of drawing a marquee */
+  panMode: boolean
   /** the Inspector panel is showing — opened by clicking a frame's name, not
    *  by mere selection, so clicking around a frame doesn't slide the panel in */
   inspectorOpen: boolean
@@ -99,6 +106,11 @@ interface State {
   allowanceChanged(): void
   requestFlyTo(frameId: string): void
   select(id: string | null): void
+  /** ⇧-click: add the frame to the selection, or drop it if already in */
+  toggleSelect(id: string): void
+  /** marquee: replace the selection with these frames */
+  selectMany(ids: string[]): void
+  setPanMode(v: boolean): void
   setInspectorOpen(v: boolean): void
   openCtxMenu(menu: { frameId: string; deferPanel: boolean }): void
   closeCtxMenu(): void
@@ -122,7 +134,9 @@ export const useStore = create<State>((set, get) => ({
   limitWall: false,
   allowanceVersion: 0,
   flyTo: null,
+  selectedIds: [],
   selectedId: null,
+  panMode: false,
   inspectorOpen: false,
   ctxMenu: null,
   viewport: { x: 0, y: 0, zoom: 1 },
@@ -208,6 +222,7 @@ export const useStore = create<State>((set, get) => ({
       if (!s.canvas) return {}
       return {
         canvas: { ...s.canvas, frames: s.canvas.frames.filter((f) => f.id !== frameId) },
+        selectedIds: s.selectedIds.filter((id) => id !== frameId),
         selectedId: s.selectedId === frameId ? null : s.selectedId,
         ctxMenu: s.ctxMenu?.frameId === frameId ? null : s.ctxMenu,
       }
@@ -256,7 +271,24 @@ export const useStore = create<State>((set, get) => ({
      panel must not follow surface clicks, paste, or undo onto another frame.
      Re-selecting the same frame keeps an open panel open. */
   select: (selectedId) =>
-    set((s) => (s.selectedId === selectedId ? { selectedId } : { selectedId, inspectorOpen: false })),
+    set((s) => {
+      const selectedIds = selectedId ? [selectedId] : []
+      return s.selectedId === selectedId
+        ? { selectedId, selectedIds }
+        : { selectedId, selectedIds, inspectorOpen: false }
+    }),
+  toggleSelect: (id) =>
+    set((s) => {
+      const selectedIds = s.selectedIds.includes(id) ? s.selectedIds.filter((x) => x !== id) : [...s.selectedIds, id]
+      const selectedId = selectedIds[selectedIds.length - 1] ?? null
+      return selectedId === s.selectedId ? { selectedIds } : { selectedIds, selectedId, inspectorOpen: false }
+    }),
+  selectMany: (ids) =>
+    set((s) => {
+      const selectedId = ids[ids.length - 1] ?? null
+      return selectedId === s.selectedId ? { selectedIds: ids } : { selectedIds: ids, selectedId, inspectorOpen: false }
+    }),
+  setPanMode: (panMode) => set({ panMode }),
   setInspectorOpen: (inspectorOpen) => set({ inspectorOpen }),
   openCtxMenu: (ctxMenu) => set({ ctxMenu }),
   closeCtxMenu: () => set({ ctxMenu: null }),

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -220,10 +220,13 @@ export const useStore = create<State>((set, get) => ({
   removeFrame: (frameId) =>
     set((s) => {
       if (!s.canvas) return {}
+      const selectedIds = s.selectedIds.filter((id) => id !== frameId)
       return {
         canvas: { ...s.canvas, frames: s.canvas.frames.filter((f) => f.id !== frameId) },
-        selectedIds: s.selectedIds.filter((id) => id !== frameId),
-        selectedId: s.selectedId === frameId ? null : s.selectedId,
+        selectedIds,
+        /* losing the primary promotes the last surviving member, so a group
+           never sits selected with nothing driving the Inspector/presence */
+        selectedId: s.selectedId === frameId ? (selectedIds[selectedIds.length - 1] ?? null) : s.selectedId,
         ctxMenu: s.ctxMenu?.frameId === frameId ? null : s.ctxMenu,
       }
     }),

--- a/src/pages/CanvasPage.tsx
+++ b/src/pages/CanvasPage.tsx
@@ -27,7 +27,7 @@ import { ShareModal } from '../components/ShareModal'
 import { BrainIcon } from '../components/BrainIcon'
 import { getIdentity, setName } from '../lib/identity'
 import { copyFrame, duplicateFrame, hasFrameClip, pasteFrameCentered, pasteImagesCentered } from '../lib/frameClipboard'
-import { clearHistory, deleteFrameTracked, recordCreate, redo, undo } from '../lib/history'
+import { clearHistory, deleteFramesTracked, recordCreate, redo, undo } from '../lib/history'
 import { authClient } from '../lib/auth'
 import { posthog } from '../lib/posthog'
 import { useIsMobile } from '../hooks/use-mobile'
@@ -132,10 +132,11 @@ export function CanvasPage({ canvasId }: { canvasId: string }) {
       const t = e.target as HTMLElement
       if (t.tagName === 'INPUT' || t.tagName === 'TEXTAREA' || t.isContentEditable) return
       const sel = useStore.getState().selectedId
-      if ((e.key === 'Delete' || e.key === 'Backspace') && sel) {
+      const selectedIds = useStore.getState().selectedIds
+      if ((e.key === 'Delete' || e.key === 'Backspace') && selectedIds.length) {
         e.preventDefault()
-        const frame = useStore.getState().canvas?.frames.find((f) => f.id === sel)
-        if (frame) deleteFrameTracked(frame)
+        const frames = useStore.getState().canvas?.frames.filter((f) => selectedIds.includes(f.id)) ?? []
+        deleteFramesTracked(frames)
       }
       if (e.key === 'Escape') select(null)
       if ((e.metaKey || e.ctrlKey) && !e.altKey && e.key.toLowerCase() === 'z') {

--- a/tests/selection.test.ts
+++ b/tests/selection.test.ts
@@ -1,0 +1,105 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Canvas, Frame } from '../shared/types'
+
+/* the history module talks to the server and analytics — stub both so the
+   undo stack can be exercised as pure bookkeeping */
+const api = {
+  updateFrame: vi.fn(async () => ({})),
+  deleteFrame: vi.fn(async () => ({})),
+  createFrame: vi.fn(async (_canvasId: string, rest: Partial<Frame>) => ({ ...frame('new'), ...rest, id: 'new' })),
+}
+vi.mock('../src/lib/api', () => ({ api }))
+vi.mock('../src/lib/posthog', () => ({ posthog: { capture: vi.fn() } }))
+
+const { useStore } = await import('../src/lib/store')
+const history = await import('../src/lib/history')
+
+function frame(id: string, x = 0, y = 0): Frame {
+  return {
+    id,
+    canvasId: 'c1',
+    name: id,
+    html: '',
+    x,
+    y,
+    width: 100,
+    height: 100,
+  } as Frame
+}
+
+function seed(...frames: Frame[]) {
+  useStore.getState().setCanvas({ id: 'c1', name: 'c', frames } as unknown as Canvas)
+}
+
+beforeEach(() => {
+  seed(frame('a'), frame('b'), frame('c'))
+  useStore.getState().select(null)
+  history.clearHistory()
+  vi.clearAllMocks()
+})
+
+describe('multi-selection in the store', () => {
+  it('a plain select collapses to one frame and makes it primary', () => {
+    useStore.getState().selectMany(['a', 'b'])
+    useStore.getState().select('c')
+    expect(useStore.getState().selectedIds).toEqual(['c'])
+    expect(useStore.getState().selectedId).toBe('c')
+  })
+
+  it('toggleSelect adds, then drops, keeping the last-added frame primary', () => {
+    const s = useStore.getState()
+    s.select('a')
+    s.toggleSelect('b')
+    expect(useStore.getState().selectedIds).toEqual(['a', 'b'])
+    expect(useStore.getState().selectedId).toBe('b')
+    useStore.getState().toggleSelect('b')
+    expect(useStore.getState().selectedIds).toEqual(['a'])
+    expect(useStore.getState().selectedId).toBe('a')
+    useStore.getState().toggleSelect('a')
+    expect(useStore.getState().selectedId).toBeNull()
+  })
+
+  it('removing a frame drops it from the selection', () => {
+    useStore.getState().selectMany(['a', 'b'])
+    useStore.getState().removeFrame('b')
+    expect(useStore.getState().selectedIds).toEqual(['a'])
+    expect(useStore.getState().selectedId).toBeNull()
+  })
+
+  it('changing the primary frame closes the inspector, re-selecting keeps it', () => {
+    useStore.getState().select('a')
+    useStore.getState().setInspectorOpen(true)
+    useStore.getState().selectMany(['b', 'a'])
+    expect(useStore.getState().inspectorOpen).toBe(true)
+    useStore.getState().toggleSelect('c')
+    expect(useStore.getState().inspectorOpen).toBe(false)
+  })
+})
+
+describe('grouped history', () => {
+  it('a group move undoes and redoes as one step', async () => {
+    history.recordUpdates([
+      { frameId: 'a', before: { x: 0, y: 0 }, after: { x: 10, y: 10 } },
+      { frameId: 'b', before: { x: 0, y: 0 }, after: { x: 10, y: 10 } },
+    ])
+    await history.undo()
+    expect(api.updateFrame).toHaveBeenCalledTimes(2)
+    expect(api.updateFrame).toHaveBeenCalledWith('a', { x: 0, y: 0 })
+    expect(api.updateFrame).toHaveBeenCalledWith('b', { x: 0, y: 0 })
+    await history.undo()
+    expect(api.updateFrame).toHaveBeenCalledTimes(2)
+    await history.redo()
+    expect(api.updateFrame).toHaveBeenCalledTimes(4)
+    expect(api.updateFrame).toHaveBeenLastCalledWith('b', { x: 10, y: 10 })
+  })
+
+  it('a group delete removes every frame and one undo brings them all back', async () => {
+    const frames = useStore.getState().canvas!.frames
+    history.deleteFramesTracked(frames.slice(0, 2))
+    expect(api.deleteFrame).toHaveBeenCalledTimes(2)
+    await history.undo()
+    expect(api.createFrame).toHaveBeenCalledTimes(2)
+    expect(api.createFrame).toHaveBeenCalledWith('c1', expect.objectContaining({ name: 'a' }))
+    expect(api.createFrame).toHaveBeenCalledWith('c1', expect.objectContaining({ name: 'b' }))
+  })
+})

--- a/tests/selection.test.ts
+++ b/tests/selection.test.ts
@@ -4,7 +4,7 @@ import type { Canvas, Frame } from '../shared/types'
 /* the history module talks to the server and analytics — stub both so the
    undo stack can be exercised as pure bookkeeping */
 const api = {
-  updateFrame: vi.fn(async () => ({})),
+  updateFrame: vi.fn(async (_id: string, _patch: object) => ({})),
   deleteFrame: vi.fn(async () => ({})),
   createFrame: vi.fn(async (_canvasId: string, rest: Partial<Frame>) => ({ ...frame('new'), ...rest, id: 'new' })),
 }
@@ -132,13 +132,23 @@ describe('review follow-ups', () => {
     expect(order).toEqual(['save', 'undo'])
   })
 
-  it('a failing member of a group does not stop the others', async () => {
+  it('a failing member of a group does not stop the others, and the survivors stay redoable', async () => {
     history.recordUpdates([
       { frameId: 'a', before: { x: 0 }, after: { x: 1 } },
       { frameId: 'b', before: { x: 0 }, after: { x: 1 } },
     ])
-    api.updateFrame.mockRejectedValueOnce(new Error('boom'))
+    api.updateFrame.mockImplementationOnce(async (id: string) => {
+      if (id === 'a') throw new Error('boom')
+      return {}
+    })
     await history.undo()
     expect(api.updateFrame).toHaveBeenCalledTimes(2)
+    /* only b was undone, so only b comes back on redo */
+    await history.redo()
+    expect(api.updateFrame).toHaveBeenCalledTimes(3)
+    expect(api.updateFrame).toHaveBeenLastCalledWith('b', { x: 1 })
+    /* and that redo is itself undoable */
+    await history.undo()
+    expect(api.updateFrame).toHaveBeenLastCalledWith('b', { x: 0 })
   })
 })

--- a/tests/selection.test.ts
+++ b/tests/selection.test.ts
@@ -59,10 +59,12 @@ describe('multi-selection in the store', () => {
     expect(useStore.getState().selectedId).toBeNull()
   })
 
-  it('removing a frame drops it from the selection', () => {
+  it('removing a frame drops it from the selection and promotes a survivor', () => {
     useStore.getState().selectMany(['a', 'b'])
     useStore.getState().removeFrame('b')
     expect(useStore.getState().selectedIds).toEqual(['a'])
+    expect(useStore.getState().selectedId).toBe('a')
+    useStore.getState().removeFrame('a')
     expect(useStore.getState().selectedId).toBeNull()
   })
 
@@ -101,5 +103,42 @@ describe('grouped history', () => {
     expect(api.createFrame).toHaveBeenCalledTimes(2)
     expect(api.createFrame).toHaveBeenCalledWith('c1', expect.objectContaining({ name: 'a' }))
     expect(api.createFrame).toHaveBeenCalledWith('c1', expect.objectContaining({ name: 'b' }))
+  })
+})
+
+describe('review follow-ups', () => {
+  it('deleting the primary frame promotes the last surviving member', () => {
+    useStore.getState().selectMany(['a', 'b', 'c'])
+    useStore.getState().removeFrame('c')
+    expect(useStore.getState().selectedIds).toEqual(['a', 'b'])
+    expect(useStore.getState().selectedId).toBe('b')
+  })
+
+  it('undo waits for in-flight drag saves before writing the inverse', async () => {
+    const order: string[] = []
+    let release!: () => void
+    const pending = new Promise<void>((r) => (release = r)).then(() => order.push('save'))
+    history.trackSave(pending)
+    history.recordUpdate('a', { x: 0 }, { x: 10 })
+    api.updateFrame.mockImplementationOnce(async () => {
+      order.push('undo')
+      return {}
+    })
+    const undone = history.undo()
+    await Promise.resolve()
+    expect(order).toEqual([])
+    release()
+    await undone
+    expect(order).toEqual(['save', 'undo'])
+  })
+
+  it('a failing member of a group does not stop the others', async () => {
+    history.recordUpdates([
+      { frameId: 'a', before: { x: 0 }, after: { x: 1 } },
+      { frameId: 'b', before: { x: 0 }, after: { x: 1 } },
+    ])
+    api.updateFrame.mockRejectedValueOnce(new Error('boom'))
+    await history.undo()
+    expect(api.updateFrame).toHaveBeenCalledTimes(2)
   })
 })

--- a/tests/selection.test.ts
+++ b/tests/selection.test.ts
@@ -114,6 +114,14 @@ describe('review follow-ups', () => {
     expect(useStore.getState().selectedId).toBe('b')
   })
 
+  it('an open Inspector closes when its frame is deleted out from under it', () => {
+    useStore.getState().selectMany(['a', 'b'])
+    useStore.getState().setInspectorOpen(true)
+    useStore.getState().removeFrame('b')
+    expect(useStore.getState().selectedId).toBe('a')
+    expect(useStore.getState().inspectorOpen).toBe(false)
+  })
+
   it('undo waits for in-flight drag saves before writing the inverse', async () => {
     const order: string[] = []
     let release!: () => void

--- a/tests/selection.test.ts
+++ b/tests/selection.test.ts
@@ -151,6 +151,10 @@ describe('review follow-ups', () => {
     })
     await history.undo()
     expect(api.updateFrame).toHaveBeenCalledTimes(2)
+    /* a's rejected undo is rolled back locally so it matches the server */
+    const frames = useStore.getState().canvas!.frames
+    expect(frames.find((f) => f.id === 'a')!.x).toBe(1)
+    expect(frames.find((f) => f.id === 'b')!.x).toBe(0)
     /* only b was undone, so only b comes back on redo */
     await history.redo()
     expect(api.updateFrame).toHaveBeenCalledTimes(3)


### PR DESCRIPTION
Closes #89

## What changes

- **Marquee is the default tool.** Left-drag on empty canvas draws a selection rectangle and selects every frame it touches. Shift-marquee adds to the selection; a plain click on empty canvas still clears it.
- **Space pans.** Hold space to drag the viewport anywhere, including over frames. Middle mouse and two-finger trackpad scrolling pan as before. One-finger touch on the background still pans (no space bar on phones).
- **Shift-click toggles frames** in and out of the selection. Alt-shift-drag still duplicates.
- **Dragging a selected frame moves the whole group**, snapping the dragged frame against non-selected neighbours and broadcasting every member's live position.
- **Delete acts on the group** from Backspace and the context menu ("Delete N frames"), as one undo step. History gained a `group` entry so multi-frame moves and deletes undo/redo together.
- Store gains `selectedIds`; `selectedId` stays the primary (last-added) frame so the Inspector, presence broadcast and flow overlay are unchanged.

## Verification

- typecheck clean; new `tests/selection.test.ts` covers the store and grouped undo. Full suite passes on the private mirror of this change.
- Not yet clicked through in a browser — worth a manual pass: marquee drag, shift-click + group drag, space-drag over a frame, Backspace then Cmd-Z on a multi-selection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012wo923qzfEk6KLt2jHZ7QW