### PR TITLE
feat: marquee selection, comment replies, repo import cards, pinch zoom

### DIFF
--- a/server/actions.ts
+++ b/server/actions.ts
@@ -444,35 +444,91 @@ export function addElementComment(
   from: string,
   fromUserId?: string,
 ): ElementComment | undefined {
-  const clean = input.text.trim()
-  if (!clean) return undefined
   const frame = store.getFrame(frameId)
   if (!frame) return undefined
+  return postComment(
+    frame,
+    { selector: String(input.selector ?? '').slice(0, 300), snippet: String(input.snippet ?? '').slice(0, 400) },
+    input.text,
+    from,
+    fromUserId,
+  )
+}
+
+/** Reply inside a thread: the reply inherits the root comment's element so an
+ *  @mention in it gives the agent the same anchor the conversation is about. */
+export function replyToComment(
+  commentId: string,
+  text: string,
+  from: string,
+  fromUserId?: string,
+): ElementComment | undefined {
+  const open = openThread(commentId)
+  if (!open) return undefined
+  const { root, frame } = open
+  return postComment(
+    frame,
+    { selector: root.selector, snippet: root.snippet, parentId: root.id },
+    text,
+    from,
+    fromUserId,
+  )
+}
+
+/** The root and frame a reply to this comment would land on, or undefined
+ *  when the thread is resolved or its frame is gone — checked before any
+ *  metering so a rejected reply never costs a resident task. */
+export function openThread(commentId: string): { root: ElementComment; frame: Frame } | undefined {
+  const parent = findComment(commentId)
+  if (!parent) return undefined
+  const root = parent.parentId ? findComment(parent.parentId) : parent
+  if (!root || root.resolvedAt) return undefined
+  const frame = store.getFrame(root.frameId)
+  if (!frame) return undefined
+  return { root, frame }
+}
+
+function postComment(
+  frame: Frame,
+  anchor: { selector: string; snippet: string; parentId?: string },
+  text: string,
+  from: string,
+  fromUserId?: string,
+): ElementComment | undefined {
+  const clean = text.trim()
+  if (!clean) return undefined
   /* @Doop, @brand, @a11y… — whichever resident agent is mentioned picks it up */
   const mentioned = mentionedRole(clean)
+  const list = commentLog.get(frame.canvasId) ?? []
+  /* strictly increasing per canvas: thread order is reconstructed from `at`
+     after a restart, so two messages must never share a timestamp */
+  const at = Math.max(Date.now(), (list[0]?.at ?? 0) + 1)
   const comment: ElementComment = {
     id: nanoid(8),
     canvasId: frame.canvasId,
-    frameId,
-    selector: String(input.selector ?? '').slice(0, 300),
-    snippet: String(input.snippet ?? '').slice(0, 400),
+    frameId: frame.id,
+    selector: anchor.selector,
+    snippet: anchor.snippet,
     from,
     ...(fromUserId ? { fromUserId } : {}),
     text: clean,
-    at: Date.now(),
+    at,
     ...(mentioned ? { forAgent: true, targetAgent: mentioned.name } : {}),
+    ...(anchor.parentId ? { parentId: anchor.parentId } : {}),
   }
-  const list = commentLog.get(frame.canvasId) ?? []
   list.unshift(comment)
   if (list.length > 100) list.length = 100
   commentLog.set(frame.canvasId, list)
   persist.saveComment(comment)
   broadcast(frame.canvasId, { type: 'comment', comment })
+  const excerpt = clean.length > 80 ? clean.slice(0, 77) + '…' : clean
   logActivity(
     frame.canvasId,
     resolveActor({ name: from, kind: 'user' }),
-    `commented on an element in “${frame.name}”: “${clean.length > 80 ? clean.slice(0, 77) + '…' : clean}”`,
-    frameId,
+    anchor.parentId
+      ? `replied to a comment in “${frame.name}”: “${excerpt}”`
+      : `commented on an element in “${frame.name}”: “${excerpt}”`,
+    frame.id,
   )
   if (comment.forAgent) {
     /* @Doop mention: the resident agent picks it up instantly (no-op without
@@ -480,6 +536,17 @@ export function addElementComment(
     import('./resident.ts').then((r) => r.onFeedback(frame.canvasId)).catch(() => {})
   }
   return comment
+}
+
+/** The whole conversation a comment belongs to, oldest first. */
+export function commentThread(comment: ElementComment): ElementComment[] {
+  const rootId = comment.parentId ?? comment.id
+  /* the log is newest-first; reverse before the (stable) sort so replies
+     posted within the same millisecond keep their arrival order */
+  return [...(commentLog.get(comment.canvasId) ?? [])]
+    .reverse()
+    .filter((c) => c.id === rootId || c.parentId === rootId)
+    .sort((a, b) => a.at - b.at)
 }
 
 /** Open comments @mentioning this agent, claimed by it. */
@@ -538,20 +605,25 @@ export function resolveComment(commentId: string, by: string): ElementComment | 
     const c = list.find((x) => x.id === commentId)
     if (!c) continue
     if (c.resolvedAt) return c
-    c.resolvedBy = by
-    c.resolvedAt = Date.now()
-    persist.saveComment(c)
-    broadcast(canvasId, { type: 'comment', comment: c })
-    /* a resolved @agent comment was an instruction that got carried out —
-       capture it as a decision (plain human-to-human notes are not) */
-    if (c.forAgent) {
-      captureDecision(canvasId, {
-        text: c.text,
-        source: 'comment',
-        frameId: c.frameId,
-        from: c.from,
-        agentName: c.claimedBy ?? (by !== c.from ? by : undefined),
-      })
+    /* resolving the root closes its whole thread: an open reply under a
+       resolved pin would be invisible yet still queued for an agent */
+    const closing = c.parentId ? [c] : list.filter((x) => x.id === c.id || (x.parentId === c.id && !x.resolvedAt))
+    for (const item of closing) {
+      item.resolvedBy = by
+      item.resolvedAt = Date.now()
+      persist.saveComment(item)
+      broadcast(canvasId, { type: 'comment', comment: item })
+      /* a resolved @agent comment was an instruction that got carried out —
+         capture it as a decision (plain human-to-human notes are not) */
+      if (item.forAgent) {
+        captureDecision(canvasId, {
+          text: item.text,
+          source: 'comment',
+          frameId: item.frameId,
+          from: item.from,
+          agentName: item.claimedBy ?? (by !== item.from ? by : undefined),
+        })
+      }
     }
     return c
   }

--- a/server/actions.ts
+++ b/server/actions.ts
@@ -15,6 +15,9 @@ import type {
   GuidelineDoc,
   MemoryProposal,
   MemoryReference,
+  RepoCardKind,
+  RepoCardPayload,
+  RepoScreenRef,
   ServerMessage,
   TaskFeedback,
 } from '../shared/types.ts'
@@ -734,8 +737,7 @@ export function addQueuedCard(
     ...(refs.length > 0 ? { attachments: refs } : {}),
   }
   list.unshift(card)
-  if (list.length > 100) list.length = 100
-  taskLog.set(canvasId, list)
+  taskLog.set(canvasId, trimTaskLog(list))
   persist.saveTask(canvasId, card)
   broadcast(canvasId, { type: 'task', task: card })
   logActivity(
@@ -746,6 +748,111 @@ export function addQueuedCard(
   /* the resident agents pick queued cards up instantly (no-op without a key) */
   import('./resident.ts').then((r) => r.onFeedback(canvasId)).catch(() => {})
   return card
+}
+
+const TASK_LOG_CAP = 100
+
+/** Keep the task log at its cap without losing open work: the oldest FINISHED
+ *  tasks go first, so a bulk import can never push a queued, claimed or
+ *  failed card off the board. Open cards past the cap are kept as well. */
+export function trimTaskLog(list: AgentTask[]): AgentTask[] {
+  if (list.length <= TASK_LOG_CAP) return list
+  const isOpen = (t: AgentTask) => !!t.queuedBy && !t.endedAt
+  let room = TASK_LOG_CAP - list.filter(isOpen).length
+  const kept: AgentTask[] = []
+  for (const t of list) {
+    if (isOpen(t)) kept.push(t)
+    else if (room > 0) {
+      kept.push(t)
+      room--
+    }
+  }
+  list.length = 0
+  list.push(...kept)
+  return list
+}
+
+/** One repo import as board cards: the design-system extraction first (it
+ *  becomes the guide the sketches follow), then one sketch card per selected
+ *  screen. Structured cards — the resident runner dispatches them straight to
+ *  the GitHub sketch runner (server/githubRecon.ts) instead of the chat agent.
+ *  A screen already queued or in flight from the same connection is not
+ *  queued twice. Returns the cards, oldest first. */
+export interface RepoImportInput {
+  connectionId: string
+  repo: string
+  screens: RepoScreenRef[]
+  designSystem: boolean
+}
+
+/** What an import would queue, after removing screens already waiting or in
+ *  flight from the same connection. Pure — the route checks this BEFORE
+ *  spending the requester's allowance, so a no-op re-import costs nothing. */
+export function planRepoCards(
+  canvasId: string,
+  input: RepoImportInput,
+): { kind: RepoCardKind; title: string; payload: RepoCardPayload }[] {
+  if (!store.getCanvas(canvasId)) return []
+  const list = taskLog.get(canvasId) ?? []
+  const open = list.filter((t) => t.queuedBy && !t.endedAt && t.payload?.connectionId === input.connectionId)
+  const importId = nanoid(8)
+  const base = { connectionId: input.connectionId, repo: input.repo, importId }
+  const wanted: { kind: RepoCardKind; title: string; payload: RepoCardPayload }[] = []
+  if (input.designSystem && !open.some((t) => t.kind === 'design-system'))
+    wanted.push({ kind: 'design-system', title: `Design system of ${input.repo}`, payload: base })
+  for (const screen of input.screens) {
+    const queued = open.some(
+      (t) =>
+        t.kind === 'sketch' &&
+        t.payload?.screen?.sourcePath === screen.sourcePath &&
+        t.payload.screen.kind === screen.kind,
+    )
+    if (!queued) wanted.push({ kind: 'sketch', title: screen.title, payload: { ...base, screen } })
+  }
+  return wanted
+}
+
+export function addRepoCards(canvasId: string, input: RepoImportInput, from: string, fromUserId: string): AgentTask[] {
+  const wanted = planRepoCards(canvasId, input)
+  if (!wanted.length) return []
+  const list = taskLog.get(canvasId) ?? []
+  const actor = resolveActor({ name: from, kind: 'user' })
+  const cards: AgentTask[] = []
+  /* startedAt orders the queue (oldest first); a shared timestamp would leave
+     the order to Map iteration, so each card sits one tick after the last */
+  const at = Date.now()
+  wanted.forEach((w, i) => {
+    const card: AgentTask = {
+      id: nanoid(8),
+      agentName: '',
+      color: colorFor(from),
+      status: w.title.slice(0, 200),
+      startedAt: at + i,
+      queuedBy: from,
+      queuedByUserId: fromUserId,
+      pipeline: [DEFAULT_ROLE_ID],
+      stage: 0,
+      kind: w.kind,
+      payload: w.payload,
+    }
+    list.unshift(card)
+    persist.saveTask(canvasId, card)
+    broadcast(canvasId, { type: 'task', task: card })
+    cards.push(card)
+  })
+  taskLog.set(canvasId, trimTaskLog(list))
+  if (cards.length) {
+    const sketches = cards.filter((c) => c.kind === 'sketch').length
+    const what = [
+      cards.some((c) => c.kind === 'design-system') ? 'the design system' : '',
+      sketches ? `${sketches} ${sketches === 1 ? 'screen' : 'screens'}` : '',
+    ]
+      .filter(Boolean)
+      .join(' and ')
+    logActivity(canvasId, actor, `queued ${what} from ${input.repo} for ${roleName(DEFAULT_ROLE_ID)}`)
+    import('./resident.ts').then((r) => r.onFeedback(canvasId)).catch(() => {})
+  }
+  return cards
 }
 
 /** Cards waiting on THIS agent's stage, claimed by it. A card at another

--- a/server/allowance.ts
+++ b/server/allowance.ts
@@ -98,3 +98,14 @@ export async function consumeResidentTask(userId: string): Promise<Allowance & {
   if (!applied) return { ...current, used: current.limit, ok: false }
   return { ...current, used: applied.used, ok: true }
 }
+
+/** Give back a task that was spent but never turned into work — the thread
+ *  closed or its frame vanished between metering and the write. Only a
+ *  metered spend (not a byo-model pass) is returned, never below zero. */
+export async function refundResidentTask(gate: Allowance & { ok: boolean }, userId: string): Promise<void> {
+  if (!gate.ok || gate.byoModel) return
+  await db
+    .update(residentUsage)
+    .set({ used: sql`greatest(${residentUsage.used} - 1, 0)`, updatedAt: Date.now() })
+    .where(eq(residentUsage.userId, userId))
+}

--- a/server/db/migrations/0008_comment_replies.sql
+++ b/server/db/migrations/0008_comment_replies.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "comments" ADD COLUMN "parent_id" text;

--- a/server/db/migrations/0009_repo_cards.sql
+++ b/server/db/migrations/0009_repo_cards.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "tasks" ADD COLUMN "kind" text;--> statement-breakpoint
+ALTER TABLE "tasks" ADD COLUMN "payload" text;

--- a/server/db/migrations/meta/0006_snapshot.json
+++ b/server/db/migrations/meta/0006_snapshot.json
@@ -629,43 +629,6 @@
       "checkConstraints": {},
       "isRLSEnabled": false
     },
-    "public.founder_emails": {
-      "name": "founder_emails",
-      "schema": "",
-      "columns": {
-        "user_id": {
-          "name": "user_id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "scheduled_at": {
-          "name": "scheduled_at",
-          "type": "bigint",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "sent_at": {
-          "name": "sent_at",
-          "type": "bigint",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "skipped": {
-          "name": "skipped",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {},
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
     "public.frames": {
       "name": "frames",
       "schema": "",

--- a/server/db/migrations/meta/0008_snapshot.json
+++ b/server/db/migrations/meta/0008_snapshot.json
@@ -1,6 +1,6 @@
 {
-  "id": "ab4fb165-fe80-4701-ad38-2b9a4c25d94d",
-  "prevId": "aeded106-b024-4321-92fc-ab20dd5dfc07",
+  "id": "3949da29-5c25-46e8-beeb-9cda1cfdbb0f",
+  "prevId": "ab4fb165-fe80-4701-ad38-2b9a4c25d94d",
   "version": "7",
   "dialect": "postgresql",
   "tables": {
@@ -399,6 +399,12 @@
         "resolved_at": {
           "name": "resolved_at",
           "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
           "primaryKey": false,
           "notNull": false
         }

--- a/server/db/migrations/meta/0009_snapshot.json
+++ b/server/db/migrations/meta/0009_snapshot.json
@@ -1,0 +1,2199 @@
+{
+  "id": "a11c9849-2dd2-4674-968a-746f28f79a7d",
+  "prevId": "3949da29-5c25-46e8-beeb-9cda1cfdbb0f",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.activity": {
+      "name": "activity",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "canvas_id": {
+          "name": "canvas_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_kind": {
+          "name": "actor_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_color": {
+          "name": "actor_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frame_id": {
+          "name": "frame_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "at": {
+          "name": "at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "activity_canvas_idx": {
+          "name": "activity_canvas_idx",
+          "columns": [
+            {
+              "expression": "canvas_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.asset_refs": {
+      "name": "asset_refs",
+      "schema": "",
+      "columns": {
+        "asset_id": {
+          "name": "asset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frame_id": {
+          "name": "frame_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "asset_refs_frame_idx": {
+          "name": "asset_refs_frame_idx",
+          "columns": [
+            {
+              "expression": "frame_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "asset_refs_asset_id_frame_id_pk": {
+          "name": "asset_refs_asset_id_frame_id_pk",
+          "columns": ["asset_id", "frame_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.assets": {
+      "name": "assets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "canvas_id": {
+          "name": "canvas_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mime": {
+          "name": "mime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ext": {
+          "name": "ext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "assets_canvas_idx": {
+          "name": "assets_canvas_idx",
+          "columns": [
+            {
+              "expression": "canvas_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.canvas_members": {
+      "name": "canvas_members",
+      "schema": "",
+      "columns": {
+        "canvas_id": {
+          "name": "canvas_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "added_by": {
+          "name": "added_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "canvas_members_canvas_id_user_id_pk": {
+          "name": "canvas_members_canvas_id_user_id_pk",
+          "columns": ["canvas_id", "user_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.canvases": {
+      "name": "canvases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_access": {
+          "name": "link_access",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.comments": {
+      "name": "comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "canvas_id": {
+          "name": "canvas_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frame_id": {
+          "name": "frame_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "selector": {
+          "name": "selector",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snippet": {
+          "name": "snippet",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_name": {
+          "name": "from_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_user_id": {
+          "name": "from_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "at": {
+          "name": "at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "for_agent": {
+          "name": "for_agent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "target_agent": {
+          "name": "target_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_by": {
+          "name": "claimed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failed_at": {
+          "name": "failed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "comments_canvas_idx": {
+          "name": "comments_canvas_idx",
+          "columns": [
+            {
+              "expression": "canvas_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.decisions": {
+      "name": "decisions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "canvas_id": {
+          "name": "canvas_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frame_id": {
+          "name": "frame_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_name": {
+          "name": "from_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "at": {
+          "name": "at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "distilled_at": {
+          "name": "distilled_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "decisions_canvas_idx": {
+          "name": "decisions_canvas_idx",
+          "columns": [
+            {
+              "expression": "canvas_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feedback": {
+      "name": "feedback",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canvas_id": {
+          "name": "canvas_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_agent": {
+          "name": "target_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_name": {
+          "name": "from_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_user_id": {
+          "name": "from_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "at": {
+          "name": "at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_by": {
+          "name": "claimed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failed_at": {
+          "name": "failed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "feedback_canvas_idx": {
+          "name": "feedback_canvas_idx",
+          "columns": [
+            {
+              "expression": "canvas_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.frames": {
+      "name": "frames",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "canvas_id": {
+          "name": "canvas_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "x": {
+          "name": "x",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "y": {
+          "name": "y",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "width": {
+          "name": "width",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "height": {
+          "name": "height",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "html": {
+          "name": "html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "demo": {
+          "name": "demo",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "frames_canvas_idx": {
+          "name": "frames_canvas_idx",
+          "columns": [
+            {
+              "expression": "canvas_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_connections": {
+      "name": "github_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "canvas_id": {
+          "name": "canvas_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo": {
+          "name": "repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deploy_url": {
+          "name": "deploy_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "github_connections_canvas_idx": {
+          "name": "github_connections_canvas_idx",
+          "columns": [
+            {
+              "expression": "canvas_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.guideline_versions": {
+      "name": "guideline_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "canvas_id": {
+          "name": "canvas_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "markdown": {
+          "name": "markdown",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "saved_at": {
+          "name": "saved_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "saved_by": {
+          "name": "saved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "guideline_versions_doc_idx": {
+          "name": "guideline_versions_doc_idx",
+          "columns": [
+            {
+              "expression": "canvas_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.guidelines": {
+      "name": "guidelines",
+      "schema": "",
+      "columns": {
+        "canvas_id": {
+          "name": "canvas_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "markdown": {
+          "name": "markdown",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "x": {
+          "name": "x",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "y": {
+          "name": "y",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "guidelines_canvas_id_name_pk": {
+          "name": "guidelines_canvas_id_name_pk",
+          "columns": ["canvas_id", "name"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.memory_proposals": {
+      "name": "memory_proposals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "canvas_id": {
+          "name": "canvas_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guide_name": {
+          "name": "guide_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guide_title": {
+          "name": "guide_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rule": {
+          "name": "rule",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rationale": {
+          "name": "rationale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "based_on": {
+          "name": "based_on",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "at": {
+          "name": "at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "memory_proposals_canvas_idx": {
+          "name": "memory_proposals_canvas_idx",
+          "columns": [
+            {
+              "expression": "canvas_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.memory_references": {
+      "name": "memory_references",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "canvas_id": {
+          "name": "canvas_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frame_id": {
+          "name": "frame_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "html": {
+          "name": "html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "width": {
+          "name": "width",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "height": {
+          "name": "height",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pinned_by": {
+          "name": "pinned_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pinned_at": {
+          "name": "pinned_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "memory_references_canvas_idx": {
+          "name": "memory_references_canvas_idx",
+          "columns": [
+            {
+              "expression": "canvas_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.model_accounts": {
+      "name": "model_accounts",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan": {
+          "name": "plan",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connected_at": {
+          "name": "connected_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.resident_usage": {
+      "name": "resident_usage",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "used": {
+          "name": "used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sync_edges": {
+      "name": "sync_edges",
+      "schema": "",
+      "columns": {
+        "key_id": {
+          "name": "key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_page": {
+          "name": "from_page",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_page": {
+          "name": "to_page",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_at": {
+          "name": "last_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "sync_edges_key_id_from_page_to_page_pk": {
+          "name": "sync_edges_key_id_from_page_to_page_pk",
+          "columns": ["key_id", "from_page", "to_page"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sync_keys": {
+      "name": "sync_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canvas_id": {
+          "name": "canvas_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "sync_keys_canvas_idx": {
+          "name": "sync_keys_canvas_idx",
+          "columns": [
+            {
+              "expression": "canvas_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sync_keys_secret_idx": {
+          "name": "sync_keys_secret_idx",
+          "columns": [
+            {
+              "expression": "secret",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sync_links": {
+      "name": "sync_links",
+      "schema": "",
+      "columns": {
+        "key_id": {
+          "name": "key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "page": {
+          "name": "page",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_page": {
+          "name": "to_page",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "x": {
+          "name": "x",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "y": {
+          "name": "y",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "width": {
+          "name": "width",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "height": {
+          "name": "height",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "sync_links_page_idx": {
+          "name": "sync_links_page_idx",
+          "columns": [
+            {
+              "expression": "key_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "page",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tasks": {
+      "name": "tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "canvas_id": {
+          "name": "canvas_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto": {
+          "name": "auto",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "queued_by": {
+          "name": "queued_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failed_at": {
+          "name": "failed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pipeline": {
+          "name": "pipeline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stage": {
+          "name": "stage",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attachments": {
+          "name": "attachments",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "queued_by_user_id": {
+          "name": "queued_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "tasks_canvas_idx": {
+          "name": "tasks_canvas_idx",
+          "columns": [
+            {
+              "expression": "canvas_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_access_token": {
+      "name": "oauth_access_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_access_token_access_token_unique": {
+          "name": "oauth_access_token_access_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["access_token"]
+        },
+        "oauth_access_token_refresh_token_unique": {
+          "name": "oauth_access_token_refresh_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["refresh_token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_application": {
+      "name": "oauth_application",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_urls": {
+          "name": "redirect_urls",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_application_client_id_unique": {
+          "name": "oauth_application_client_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["client_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_consent": {
+      "name": "oauth_consent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "consent_given": {
+          "name": "consent_given",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/server/db/migrations/meta/_journal.json
+++ b/server/db/migrations/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1788139127832,
       "tag": "0007_colorful_firedrake",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1788474703764,
+      "tag": "0008_comment_replies",
+      "breakpoints": true
     }
   ]
 }

--- a/server/db/migrations/meta/_journal.json
+++ b/server/db/migrations/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1788474703764,
       "tag": "0008_comment_replies",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "7",
+      "when": 1788474725138,
+      "tag": "0009_repo_cards",
+      "breakpoints": true
     }
   ]
 }

--- a/server/db/persist.ts
+++ b/server/db/persist.ts
@@ -16,6 +16,8 @@ import type {
   GuidelineDoc,
   MemoryProposal,
   MemoryReference,
+  RepoCardKind,
+  RepoCardPayload,
   TaskFeedback,
 } from '../../shared/types.ts'
 
@@ -358,6 +360,17 @@ export function deleteFrame(frameId: string) {
   swallow(db.delete(t.assetRefs).where(eq(t.assetRefs.frameId, frameId)))
 }
 
+/** A structured card's kind + payload, or nothing when the row is a prompt
+ *  card or its payload no longer parses (the card then reads as a plain one). */
+function repoCardFields(kind: string | null, payload: string | null): Pick<AgentTask, 'kind' | 'payload'> {
+  if (!kind || !payload) return {}
+  try {
+    return { kind: kind as RepoCardKind, payload: JSON.parse(payload) as RepoCardPayload }
+  } catch {
+    return {}
+  }
+}
+
 export function saveTask(canvasId: string, task: AgentTask) {
   const row = {
     id: task.id,
@@ -377,6 +390,8 @@ export function saveTask(canvasId: string, task: AgentTask) {
     pipeline: task.pipeline?.join(',') ?? null,
     stage: task.stage ?? null,
     attachments: task.attachments?.join(',') ?? null,
+    kind: task.kind ?? null,
+    payload: task.payload ? JSON.stringify(task.payload) : null,
   }
   swallow(
     db
@@ -592,11 +607,14 @@ export async function hydrate(): Promise<Hydrated> {
   const tasks = new Map<string, AgentTask[]>()
   for (const row of taskRows) {
     const list = tasks.get(row.canvasId) ?? []
-    if (list.length >= LOG_CAP) continue
     /* A task still open across a restart belongs to an agent that's gone.
        Ordinary status tasks close; claimed board cards pause in a visible
        failed state and require a human retry. */
     const isOpenCard = row.queuedBy != null && row.endedAt == null
+    /* the cap bounds history, never open work: an unfinished card older than
+       the newest hundred rows still belongs on the board (same rule as
+       actions.trimTaskLog keeps in memory) */
+    if (list.length >= LOG_CAP && !isOpenCard) continue
     const endedAt = isOpenCard ? undefined : (row.endedAt ?? now)
     const interruptedCard = isOpenCard && !!row.agentName
     const failedAt = row.failedAt ?? (interruptedCard ? now : undefined)
@@ -622,6 +640,7 @@ export async function hydrate(): Promise<Hydrated> {
       ...(row.pipeline ? { pipeline: row.pipeline.split(',').filter(Boolean) } : {}),
       ...(row.stage != null ? { stage: row.stage } : {}),
       ...(row.attachments ? { attachments: row.attachments.split(',').filter(Boolean) } : {}),
+      ...repoCardFields(row.kind, row.payload),
     })
     tasks.set(row.canvasId, list)
   }

--- a/server/db/persist.ts
+++ b/server/db/persist.ts
@@ -452,6 +452,7 @@ export function saveComment(c: ElementComment) {
     failureReason: c.failureReason ?? null,
     resolvedBy: c.resolvedBy ?? null,
     resolvedAt: c.resolvedAt ?? null,
+    parentId: c.parentId ?? null,
   }
   swallow(
     db
@@ -684,6 +685,7 @@ export async function hydrate(): Promise<Hydrated> {
       ...(failureReason !== undefined ? { failureReason } : {}),
       ...(row.resolvedBy != null ? { resolvedBy: row.resolvedBy } : {}),
       ...(row.resolvedAt != null ? { resolvedAt: row.resolvedAt } : {}),
+      ...(row.parentId != null ? { parentId: row.parentId } : {}),
     })
     comments.set(row.canvasId, list)
   }

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -201,6 +201,7 @@ export const comments = pgTable(
     failureReason: text('failure_reason'),
     resolvedBy: text('resolved_by'),
     resolvedAt: bigint('resolved_at', { mode: 'number' }),
+    parentId: text('parent_id'),
   },
   (t) => [index('comments_canvas_idx').on(t.canvasId)],
 )

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -156,6 +156,10 @@ export const tasks = pgTable(
     attachments: text('attachments'),
     /** account id of the human who queued the card — picks the model credential */
     queuedByUserId: text('queued_by_user_id'),
+    /** structured cards ('sketch', 'design-system'); null for prompt cards */
+    kind: text('kind'),
+    /** JSON payload of a structured card — what its runner needs, never a secret */
+    payload: text('payload'),
   },
   (t) => [index('tasks_canvas_idx').on(t.canvasId)],
 )

--- a/server/github.ts
+++ b/server/github.ts
@@ -2,20 +2,19 @@ import { nanoid } from 'nanoid'
 import { and, desc, eq } from 'drizzle-orm'
 import { db } from './db/index.ts'
 import { githubConnections } from './db/schema.ts'
-import * as actions from './actions.ts'
 import { sanitizeSnapshotHtml } from './ingest.ts'
 import * as githubApp from './githubApp.ts'
-import type { Actor, Frame } from '../shared/types.ts'
+import type { Frame } from '../shared/types.ts'
 
 /**
  * GitHub repo as an import source — a ONE-TIME, CODE-ONLY job: connect a
  * repo (GitHub App install or fine-grained PAT), let doop enumerate its
- * screens from framework routing conventions, and land the selected ones on
- * the canvas. Repo HTML imports directly; screens that only exist as code
- * land as outline frames, which the reconstruction pass (githubRecon.ts)
- * designs from their source when a model is available. Nothing in this flow
- * touches the live site — capturing deployed pages belongs to the website
- * importer, and logged-in screens to the design-sync snippet.
+ * screens from framework routing conventions, and queue the selected ones as
+ * cards on the board. The resident Doop agent works the cards one by one
+ * (server/githubRecon.ts): repo HTML lands as-is, and a screen that only
+ * exists as code is designed from its source. Nothing in this flow touches
+ * the live site — capturing deployed pages belongs to the website importer,
+ * and logged-in screens to the design-sync snippet.
  *
  * Provenance follows the design-sync pattern: a marker meta stamped into the
  * frame HTML (`doop-github-screen`), no frame column. The marker carries the
@@ -388,7 +387,6 @@ export async function fetchRepoFile(conn: GithubConnection, path: string): Promi
 /* Marker + frame HTML                                                 */
 
 const GITHUB_META = 'doop-github-screen'
-const PLACEHOLDER_META = 'doop-github-placeholder'
 
 /** Same lockdown the importer and ingest stamp on their snapshots. */
 const SNAPSHOT_CSP = [
@@ -467,72 +465,10 @@ export function wrapGeneratedHtml(
   return injectHead(sanitizeSnapshotHtml(html), inject)
 }
 
-/** The stand-in frame for a screen that only exists as code. When the agent
- *  is about to reconstruct it, the copy says so ('sketching'); otherwise it
- *  is a plain outline, and a failed run gets an honest note. */
-/* same env read as server/auth.ts — not imported, so the pure parts of this
-   module stay loadable without pulling the auth stack into unit tests */
-const PUBLIC_ORIGIN = process.env.BETTER_AUTH_URL || 'http://localhost:4300'
-
-export function placeholderHtml(
-  conn: Pick<GithubConnection, 'id' | 'repo'>,
-  screen: { kind: ScreenKind; route: string; sourcePath: string; title: string },
-  state: 'plain' | 'sketching' | 'failed' = 'plain',
-  /** the frame's own address, once it exists — makes the agent prompt a
-   *  concrete deep link instead of a description */
-  link?: { canvasId: string; frameId: string },
-): string {
-  const reason =
-    state === 'sketching'
-      ? 'Doop is reading this screen’s source and sketching it here — give it a moment.'
-      : state === 'failed'
-        ? 'Doop couldn’t design this screen this time. Two ways to get it done:'
-        : screen.kind === 'story'
-          ? 'A Storybook story, imported as an outline — the repo holds its code.'
-          : 'Imported as an outline — the repo holds this screen’s code.'
-  /* Every resting state (plain outline or failed run) shows the two ways
-     forward: a ready-made prompt for people who drive their own agent over
-     MCP (that agent usually has the repo checked out — the best builder),
-     and connecting a model account so the Doop Agent handles it. Only the
-     transient 'sketching' card stays quiet. */
-  const prompt = link
-    ? `“On Doop, complete the import of ${PUBLIC_ORIGIN}/c/${encodeURIComponent(link.canvasId)}?frame=${encodeURIComponent(link.frameId)} — this screen’s source is ${escapeHtml(screen.sourcePath)} in ${escapeHtml(conn.repo)}; design the frame from that code.”`
-    : `“On my Doop canvas, design the outline frames imported from ${escapeHtml(conn.repo)} — read each screen’s source (the frame lists its file path) and design a faithful version in place.”`
-  const waysForward =
-    state === 'sketching'
-      ? ''
-      : `<p style="margin-top:14px"><b style="color:#444">Use your own agent</b> — with this repo checked out, prompt it:</p>` +
-        `<p style="margin-top:8px;font-family:ui-monospace,monospace;font-size:11.5px;background:#f7f7f8;border:1px solid #eee;border-radius:8px;padding:10px 12px;text-align:left">` +
-        prompt +
-        `</p>` +
-        `<p style="margin-top:12px"><b style="color:#444">Or connect your ChatGPT subscription</b> in Settings — the Doop Agent then sketches screens like this${state === 'failed' ? ' (delete this frame and re-import to retry)' : ' automatically'}.</p>`
-  return (
-    '<!doctype html>\n<html><head>' +
-    markerMeta(conn.id, screen) +
-    `<meta name="${PLACEHOLDER_META}" content="1">` +
-    `<meta http-equiv="Content-Security-Policy" content="${SNAPSHOT_CSP}">` +
-    '<style>*{margin:0;box-sizing:border-box}body{font-family:system-ui,sans-serif;height:100vh;display:grid;place-items:center;background:repeating-linear-gradient(45deg,#fafafa,#fafafa 12px,#f4f4f5 12px,#f4f4f5 24px);color:#555}main{text-align:center;max-width:520px;padding:32px;background:#fff;border:1px dashed #ccc;border-radius:12px}h1{font-size:18px;margin-bottom:6px}code{font-size:12px;color:#888}p{font-size:13px;line-height:1.5;color:#777;margin-top:10px}</style>' +
-    `</head><body><main><h1>${escapeHtml(screen.title)}</h1><code>${escapeHtml(screen.sourcePath || screen.route)}</code><p>${reason}</p>${waysForward}</main></body></html>`
-  )
-}
-
-function escapeHtml(value: string): string {
-  return value.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
-}
-
 /* ------------------------------------------------------------------ */
 /* Import + resync                                                     */
 
 const MAX_IMPORT_SCREENS = 40
-const DEFAULT_W = 1280
-const DEFAULT_H = 900
-
-export interface GithubImportResult {
-  frames: Frame[]
-  failures: { route: string; error: string }[]
-  /** outline frames awaiting the reconstruction pass (server-side only) */
-  pending: { frameId: string; screen: RepoScreen }[]
-}
 
 /** A screen's identity across analyze → import → resync. */
 function screenIdentity(s: { kind: string; route: string; sourcePath: string }): string {
@@ -569,109 +505,13 @@ export function matchSelection(manifest: RepoScreen[], raw: unknown): { screens:
   return { screens, rejected }
 }
 
-/** Import the selected screens — a one-time, code-only job: repo HTML lands
- *  directly; screens that only exist as code land as outline frames, listed
- *  in `pending` so the caller can hand them to the reconstruction pass
- *  (githubRecon.ts) when a model is available — `sketch` says whether one
- *  is, which the outline copy reflects. Nothing here touches the live site —
- *  that is the website importer's territory. The manifest is recomputed and
- *  the selection resolved against it — see matchSelection. */
-export async function importScreens(
-  conn: GithubConnection,
-  canvas: { id: string; frames: Frame[] },
-  rawSelection: unknown,
-  actor: Actor,
-  options: { sketch?: boolean } = {},
-): Promise<GithubImportResult> {
-  const manifest = await analyzeConnection(conn)
-  const { screens: selection, rejected } = matchSelection(manifest.screens, rawSelection)
-
-  /* same grid the site importer uses: 3 columns to the right of everything */
-  const rightmost = canvas.frames.reduce((right, f) => Math.max(right, f.x + f.width), 0)
-  const startX = canvas.frames.length ? rightmost + 80 : 120
-  const columns = 3
-  let column = 0
-  let y = 120
-  let rowHeight = 0
-
-  const frames: Frame[] = []
-  const failures: { route: string; error: string }[] = rejected.map((route) => ({
-    route,
-    error: 'not in the repository manifest — re-run the screen scan',
-  }))
-
-  const place = (name: string, html: string, width: number, height: number): Frame | undefined => {
-    const frame = actions.createFrame(
-      canvas.id,
-      { name: name.slice(0, 80), x: startX + column * (DEFAULT_W + 80), y, width, height, html },
-      actor,
-    )
-    if (!frame) return undefined
-    rowHeight = Math.max(rowHeight, height)
-    column++
-    if (column === columns) {
-      column = 0
-      y += rowHeight + 80
-      rowHeight = 0
-    }
-    return frame
-  }
-
-  const pending: { frameId: string; screen: RepoScreen }[] = []
-  for (const screen of selection) {
-    try {
-      let html: string
-      const compact = screen.kind === 'component' || screen.kind === 'story'
-      const width = compact ? 640 : DEFAULT_W
-      let height = DEFAULT_H
-      const name = screen.title
-      let outline = false
-      if (screen.source === 'static') {
-        html = wrapRepoHtml(await fetchRepoFile(conn, screen.sourcePath), conn, screen)
-      } else {
-        html = placeholderHtml(conn, screen, options.sketch ? 'sketching' : 'plain')
-        height = compact ? 420 : 800
-        outline = true
-      }
-      const frame = place(name, html, width, height)
-      if (frame && outline) {
-        /* the frame's id exists only now — re-render the outline so its
-           agent prompt deep-links to this exact frame */
-        actions.updateFrame(
-          frame.id,
-          {
-            html: placeholderHtml(conn, screen, options.sketch ? 'sketching' : 'plain', {
-              canvasId: canvas.id,
-              frameId: frame.id,
-            }),
-          },
-          actor,
-        )
-        if (options.sketch) pending.push({ frameId: frame.id, screen })
-      }
-      if (!frame) {
-        failures.push({ route: screen.route, error: 'canvas not found' })
-        continue
-      }
-      frames.push(frame)
-    } catch (e) {
-      /* the lane failed — keep the screen's place in the map */
-      const frame = place(screen.title, placeholderHtml(conn, screen), DEFAULT_W, 800)
-      if (frame) frames.push(frame)
-      failures.push({ route: screen.route, error: e instanceof Error ? e.message : 'import failed' })
-    }
-  }
-
+/** A card from this connection just landed a frame — the modal's "last
+ *  synced" reads it. Fire-and-forget. */
+export function markSynced(connectionId: string): void {
   db.update(githubConnections)
     .set({ lastSyncedAt: Date.now() })
-    .where(eq(githubConnections.id, conn.id))
+    .where(eq(githubConnections.id, connectionId))
     .catch((err: unknown) => console.error('[github] lastSyncedAt write failed', err))
-
-  return { frames, failures, pending }
-}
-
-export function isGithubPlaceholderHtml(html: string): boolean {
-  return html.includes(`name="${PLACEHOLDER_META}"`)
 }
 
 /** Frames imported by a connection, for the import modal's per-repo count. */

--- a/server/githubRecon.ts
+++ b/server/githubRecon.ts
@@ -1,38 +1,41 @@
-import { pickModel } from './agentModel.ts'
+import { ModelAuthError, type AgentModel } from './agentModel.ts'
 import type { TurnBlock } from './openaiAgent.ts'
 import { createAsset } from './assets.ts'
 import * as actions from './actions.ts'
+import { store } from './store.ts'
 import {
   fetchRepoBinary,
   fetchRepoFile,
   fetchTreePaths,
-  placeholderHtml,
+  getConnection,
+  githubFrameMarker,
+  markSynced,
   wrapGeneratedHtml,
+  wrapRepoHtml,
   type GithubConnection,
-  type RepoScreen,
 } from './github.ts'
-import type { Actor } from '../shared/types.ts'
+import type { Actor, AgentTask, Frame, RepoScreenRef } from '../shared/types.ts'
 
 /**
- * Reconstruction: the agent-designed lane of the GitHub import. A screen that
- * only exists as code (a Next page, a story) is imported as an outline frame
- * immediately; this pass then reads the screen's source closure from the
- * repo, has the model rewrite it into ONE self-contained HTML document, and
- * morphs it into the outline in place — people watching the canvas see the
- * sketch fill in. Runs only when a model is available (the requester's
- * connected account, else the server's agent tier); with no model the
- * outline simply stays, which is the honest fallback.
+ * The GitHub import's runner: the resident Doop agent hands every repo card
+ * it claims to runRepoCards. A design-system card distills the repo's theme
+ * into a pinned canvas guideline; a sketch card reads one screen's source
+ * closure from the repo, has the model rewrite it into ONE self-contained
+ * HTML document, and lands it as a properly sized frame next to its siblings
+ * from the same import. Nothing exists on the canvas until a card finishes,
+ * so a failed card leaves no debris — it waits on the board for a retry.
  *
- * This is still the one-time, code-only contract: everything the model sees
- * comes from the repository. Nothing here touches the live site.
+ * This is the one-time, code-only contract: everything the model sees comes
+ * from the repository. Nothing here touches the live site.
  */
 
 /** Bounded source closure: the screen's file, its resolvable local imports
  *  (depth-first, small), and the styling context that shapes every screen. */
 const MAX_CLOSURE_FILES = 10
 const MAX_CLOSURE_BYTES = 80_000
-const MAX_RECONSTRUCTIONS_PER_IMPORT = 12
-const RECON_CONCURRENCY = 2
+/** sketches from one claim that design at the same time — steady progress
+ *  without hammering the model or the GitHub API */
+const SKETCH_CONCURRENCY = 2
 const MODEL_MAX_TOKENS = 32_000
 const MAX_REQUEST_ROUNDS = 2
 const REVIEW_ROUNDS = 1
@@ -84,7 +87,7 @@ const IMPORT_RE = /import\s[^'"]*?['"]([^'"]+)['"]|from\s+['"]([^'"]+)['"]/g
 /** Collect the screen's bounded source closure as prompt-ready sections. */
 export async function collectClosure(
   conn: GithubConnection,
-  screen: RepoScreen,
+  screen: RepoScreenRef,
   paths: string[],
 ): Promise<{ path: string; text: string }[]> {
   const pathSet = new Set(paths)
@@ -159,7 +162,7 @@ Use request_files for this — batch what you need; you have a couple of rounds.
 
 Then produce a single COMPLETE, self-contained HTML document that faithfully renders this screen:
 - Translate the component structure and its styling into real inline <style> CSS, using the palette, fonts and tokens you found — not defaults, not guesses.
-- The document is exactly 1280px wide. Choose the natural height for the content and declare it as the LAST line of your output, an HTML comment: <!-- doop-height: 900 -->
+- The document's width is given in the request. Choose the natural height for the content and declare it as the LAST line of your output, an HTML comment: <!-- doop-height: 900 -->
 - Dynamic data (user names, table rows, dates) gets realistic, specific placeholder values — never lorem ipsum or "Item 1". Static marketing copy comes from the source, verbatim.
 - Reproduce the ENTIRE page top to bottom — every section the source renders (hero, features, FAQ, footer, all of it). A truncated page is a failed reconstruction; declare the true height.
 - No <script> tags, no external CSS or JS. Google Fonts via <link> are allowed when the source names a font (check _document/layout for font loading).
@@ -223,11 +226,7 @@ Rules the agents must follow verbatim belong here; keep it under 350 lines. No c
 
 /** Distill the repo's design system into style-guide markdown. Reuses the
  *  same seeding logic as screen closures but aimed at the system files. */
-export async function extractDesignSystem(
-  conn: GithubConnection,
-  paths: string[],
-  model: NonNullable<Awaited<ReturnType<typeof pickModel>>>,
-): Promise<string> {
+export async function extractDesignSystem(conn: GithubConnection, paths: string[], model: AgentModel): Promise<string> {
   const seeds = [
     'package.json',
     ...paths.filter((p) => !p.includes('node_modules') && /(^|\/)tailwind\.config\.[jt]s$/.test(p)).slice(0, 1),
@@ -346,212 +345,328 @@ export async function resolveRepoAssets(conn: GithubConnection, html: string, pa
   return html.replace(REPO_REF_RE, (_full, pre, p, post) => pre + (urls.get(p) ?? TRANSPARENT_PX) + post)
 }
 
-/** Reconstruct the given outline frames in the background. Fire-and-forget
- *  from the import route — every failure lands in the frame itself (the
- *  outline flips to a 'failed' note) and in the log, never in the response. */
-export function scheduleReconstructions(
-  conn: GithubConnection,
-  jobs: { frameId: string; screen: RepoScreen }[],
-  requester: Actor,
-  payerId: string,
-  opts: { designSystem?: boolean } = {},
-): void {
-  if (!jobs.length && !opts.designSystem) return
-  void (async () => {
-    const model = await pickModel(payerId)
-    if (!model) return /* no model — outlines stay, which the copy reflects */
-    /* The sketching is the Doop Agent's work, and it should look like it:
-       an agent actor gives it live presence, a task entry ("is working
-       on…") on the board/feed, and frame edits attributed to Doop instead
-       of the human who clicked Import. */
-    const actor = actions.resolveActor({ name: 'Doop', kind: 'agent', owner: requester.name })
-    const paths = await fetchTreePaths(conn)
+/* ------------------------------------------------------------------ */
+/* Frame placement                                                     */
+
+const PAGE_W = 1280
+const COMPONENT_W = 640
+const STATIC_H = 900
+const GAP = 80
+/** how wide a repo's import grid grows before a new row starts */
+const ROW_WIDTH = 3200
+
+/** Where the next frame from this connection goes: frames flow in rows
+ *  from the import's origin — right of the row's last frame while it fits,
+ *  else a fresh row under everything the connection has landed so far. The
+ *  grid is derived from the frames on the canvas, not remembered, so it
+ *  survives restarts and frames finishing in any order. */
+export function nextRepoFramePosition(
+  frames: Pick<Frame, 'x' | 'y' | 'width' | 'height' | 'html'>[],
+  connectionId: string,
+  width: number,
+): { x: number; y: number } {
+  const siblings = frames.filter((f) => githubFrameMarker(f.html)?.connectionId === connectionId)
+  if (!siblings.length) {
+    const rightmost = frames.reduce((right, f) => Math.max(right, f.x + f.width), 0)
+    return { x: frames.length ? rightmost + GAP : 120, y: 120 }
+  }
+  const originX = Math.min(...siblings.map((f) => f.x))
+  const rowY = Math.max(...siblings.map((f) => f.y))
+  const rowRight = Math.max(...siblings.filter((f) => f.y === rowY).map((f) => f.x + f.width))
+  if (rowRight + GAP + width <= originX + ROW_WIDTH) return { x: rowRight + GAP, y: rowY }
+  const bottom = Math.max(...siblings.map((f) => f.y + f.height))
+  return { x: originX, y: bottom + GAP }
+}
+
+function isCompact(screen: RepoScreenRef): boolean {
+  return screen.kind === 'component' || screen.kind === 'story'
+}
+
+/** Slug of the guideline a repo's design-system card writes. */
+export function designSystemSlug(repo: string): string {
+  return `${repo
+    .split('/')
+    .pop()!
+    .toLowerCase()
+    .replace(/[^a-z0-9-]+/g, '-')}-design-system`
+}
+
+/* ------------------------------------------------------------------ */
+/* The runner                                                          */
+
+type RepoCard = AgentTask & { payload: NonNullable<AgentTask['payload']> }
+
+function isRepoCard(card: AgentTask): card is RepoCard {
+  return (card.kind === 'sketch' || card.kind === 'design-system') && !!card.payload
+}
+
+/** Why a card failed, in words a human can act on from the board. */
+function failureReason(err: unknown): string {
+  if (err instanceof ModelAuthError)
+    return 'The connected model account turned down the request. Reconnect it in Settings, then retry.'
+  const message = err instanceof Error ? err.message : 'unknown error'
+  return `Doop could not finish this: ${message.slice(0, 200)}. Retry when you are ready.`
+}
+
+/** A billing/auth failure is account-wide — one card proving it is enough;
+ *  the rest fail with the same reason without another model call each. The
+ *  server tier rewraps ModelAuthError with its own wording (cause kept), so
+ *  the cause chain is checked, not just the top error. */
+function isAccountError(err: unknown): boolean {
+  for (let e = err, depth = 0; e instanceof Error && depth < 5; e = e.cause, depth++) {
+    if (e instanceof ModelAuthError) return true
+    if (/credit|billing|quota|api key|credentials|unauthorized|401|403/i.test(e.message)) return true
+  }
+  return false
+}
+
+/**
+ * Work the repo cards one claim handed over. The sweep already resolved the
+ * model (the requester's account, else the server tier) and claimed the
+ * cards, so every outcome here is a card outcome: advanced on success,
+ * failed with a reason otherwise. Design-system cards run first — the guide
+ * they pin grounds the sketches — then sketches, a couple at a time.
+ */
+export async function runRepoCards(
+  canvasId: string,
+  cards: AgentTask[],
+  model: AgentModel,
+  actor: Actor,
+): Promise<void> {
+  const repoCards = cards.filter(isRepoCard)
+  const byConnection = new Map<string, RepoCard[]>()
+  for (const card of repoCards) {
+    const list = byConnection.get(card.payload.connectionId) ?? []
+    list.push(card)
+    byConnection.set(card.payload.connectionId, list)
+  }
+  for (const card of cards) {
+    if (!isRepoCard(card)) actions.failCard(canvasId, card.id, 'This card lost its repository details. Import again.')
+  }
+
+  for (const [connectionId, group] of byConnection) {
+    const repo = group[0]!.payload.repo
+    const conn = await getConnection(canvasId, connectionId)
+    if (!conn) {
+      const reason = `The connection to ${repo} was removed. Reconnect the repository and import again.`
+      for (const card of group) actions.failCard(canvasId, card.id, reason)
+      continue
+    }
+    let paths: string[]
+    try {
+      paths = await fetchTreePaths(conn)
+    } catch (err) {
+      for (const card of group) actions.failCard(canvasId, card.id, failureReason(err))
+      continue
+    }
+
+    /* an account-wide failure (auth, billing, quota) anywhere in the group
+       fails every card still waiting with the same reason — no card repeats
+       a request the account already turned down */
+    let accountDead: string | undefined
 
     /* the design system first: it becomes a pinned canvas guideline every
        agent follows, and it grounds the sketches below */
-    let designSystemMd = ''
-    if (opts.designSystem) {
-      try {
-        actions.setAgentStatus(conn.canvasId, actor, `Reading ${conn.repo}’s design system — theme, tokens, type`)
-        designSystemMd = await extractDesignSystem(conn, paths, model)
-        const slug = `${conn.repo
-          .split('/')
-          .pop()!
-          .toLowerCase()
-          .replace(/[^a-z0-9-]+/g, '-')}-design-system`
-        actions.setGuideline(conn.canvasId, slug, designSystemMd, actor, undefined, `${conn.repo} design system`)
-      } catch (err) {
-        console.error(`[github-recon] design system extraction for ${conn.repo} failed`, err)
-      }
-    }
-
-    const queue = jobs.slice(0, MAX_RECONSTRUCTIONS_PER_IMPORT)
-    if (!queue.length) {
-      actions.setAgentStatus(conn.canvasId, actor, '')
-      return
-    }
-    const plural = queue.length === 1 ? 'screen' : 'screens'
-    actions.setAgentStatus(
-      conn.canvasId,
-      actor,
-      `Sketching ${queue.length} ${plural} from ${conn.repo} — reading source, designing frames`,
-    )
-    console.log(`[github-recon] ${queue.length} screen(s) from ${conn.repo} on ${model.label}`)
-
-    /* a billing/auth failure is account-wide — one screen proving it is
-       enough; the rest flip to the actionable 'failed' card without another
-       model call each */
-    const failedCard = (job: { frameId: string; screen: RepoScreen }) =>
-      placeholderHtml(conn, job.screen, 'failed', { canvasId: conn.canvasId, frameId: job.frameId })
-    let accountDead = false
-    const isAccountError = (err: unknown) =>
-      err instanceof Error && /credit|billing|quota|api key|unauthorized|401|403/i.test(err.message)
-
-    async function runOne(job: { frameId: string; screen: RepoScreen }) {
+    for (const card of group.filter((c) => c.kind === 'design-system')) {
       if (accountDead) {
-        actions.updateFrame(job.frameId, { html: failedCard(job) }, actor)
-        return
+        actions.failCard(canvasId, card.id, accountDead)
+        continue
       }
       try {
-        const closure = await collectClosure(conn, job.screen, paths)
-        if (!closure.length) throw new Error('no readable source')
-        const source = closure.map((f) => `===== ${f.path} =====\n${f.text}`).join('\n\n')
-        const componentBrief =
-          job.screen.kind === 'component' || job.screen.kind === 'story'
-            ? `This is a COMPONENT, not a page: present it as an isolated library card — a quiet neutral backdrop, the component rendered at natural size, and its key variants/states side by side when the source defines them. Keep the card compact.\n\n`
-            : ''
-        const systemContext = designSystemMd
-          ? `The product's design system, distilled from this repo (follow it exactly):\n${designSystemMd}\n\n`
-          : ''
-        const messages: Parameters<NonNullable<typeof model>['run']>[0]['messages'] = [
-          {
-            role: 'user',
-            content:
-              `Screen: ${job.screen.title} (route ${job.screen.route}) from ${conn.repo}.\n\n` +
-              componentBrief +
-              systemContext +
-              `Repository file tree (investigate with request_files):\n${treeExcerpt(paths, job.screen.sourcePath)}\n\n${source}`,
-          },
-        ]
-        /* the investigation loop: the model reads the tree and pulls the
-           theme/locale/component files it needs before designing */
-        const pathSet = new Set(paths)
-        let requestedBudget = MAX_REQUESTED_BYTES
-        let result = null as Awaited<ReturnType<NonNullable<typeof model>['run']>> | null
-        for (let round = 0; round <= MAX_REQUEST_ROUNDS; round++) {
-          result = await model!.run({
-            system: [{ text: SYSTEM_PROMPT, cache: true }],
-            tools: round < MAX_REQUEST_ROUNDS ? [REQUEST_FILES_TOOL] : [],
-            messages,
-            maxTokens: MODEL_MAX_TOKENS,
-          })
-          if (result.stop_reason !== 'tool_use') break
-          const calls = result.content.filter((b) => b.type === 'tool_use')
-          messages.push({ role: 'assistant', content: result.content })
-          const results = []
-          for (const call of calls) {
-            const wanted = (
-              Array.isArray((call.input as { paths?: unknown })?.paths)
-                ? ((call.input as { paths: unknown[] }).paths as unknown[])
-                : []
-            )
-              .map(String)
-              .filter((p) => pathSet.has(p))
-              .slice(0, MAX_REQUESTED_FILES)
-            const sections: string[] = []
-            for (const p of wanted) {
-              if (requestedBudget <= 0) break
-              try {
-                let text = await fetchRepoFile(conn, p)
-                if (text.length > requestedBudget) text = text.slice(0, requestedBudget) + '\n/* …truncated… */'
-                requestedBudget -= text.length
-                sections.push(`===== ${p} =====\n${text}`)
-              } catch {
-                sections.push(`===== ${p} =====\n/* unreadable */`)
-              }
-            }
-            results.push({
-              type: 'tool_result' as const,
-              tool_use_id: call.id,
-              content: sections.join('\n\n') || 'none of those paths exist in the tree',
-            })
-          }
-          messages.push({ role: 'user', content: results })
-        }
-        const { html, height } = extractHtml((result?.content ?? []) as { type: string; text?: string }[])
-        const withAssets = await resolveRepoAssets(conn, html, pathSet)
-        let frame = actions.updateFrame(
-          job.frameId,
-          { html: wrapGeneratedHtml(withAssets, conn, job.screen), height },
-          actor,
-        )
-
-        /* Doop's own doctrine: never ship without looking. Render the draft,
-           show the model its own output, and let it fix what is visibly
-           wrong — the single biggest quality lever short of executing the
-           app. Draft stays on the canvas while the fix round runs. */
-        for (let round = 0; frame && round < REVIEW_ROUNDS; round++) {
-          try {
-            const { renderFrame } = await import('./screenshot.ts')
-            const shot = await renderFrame(frame, frame.height > 4000 ? 0.7 : 1, {
-              type: 'jpeg',
-              quality: 72,
-              maxHeight: 8000,
-            })
-            messages.push({ role: 'assistant', content: (result?.content ?? []) as TurnBlock[] })
-            messages.push({
-              role: 'user',
-              content: [
-                {
-                  type: 'image',
-                  source: { type: 'base64', media_type: 'image/jpeg', data: shot.toString('base64') },
-                },
-                {
-                  type: 'text',
-                  text: 'This is YOUR reconstruction, rendered. Judge it against the source you read like a senior designer: wrong palette or fonts, broken or overlapping layout, clipped or missing sections, dead empty areas, images that did not resolve. Then output the corrected COMPLETE document — same rules, full page, ending with the height comment. If it is genuinely faithful already, output the document unchanged.',
-                },
-              ],
-            })
-            const fixed = await model!.run({
-              system: [{ text: SYSTEM_PROMPT, cache: true }],
-              tools: [],
-              messages,
-              maxTokens: MODEL_MAX_TOKENS,
-            })
-            result = fixed
-            const redo = extractHtml(fixed.content as { type: string; text?: string }[])
-            const redoAssets = await resolveRepoAssets(conn, redo.html, pathSet)
-            frame = actions.updateFrame(
-              job.frameId,
-              { html: wrapGeneratedHtml(redoAssets, conn, job.screen), height: redo.height },
-              actor,
-            )
-          } catch (err) {
-            console.error(`[github-recon] review round for ${job.screen.route} failed — keeping the draft`, err)
-            break
-          }
-        }
+        actions.setAgentStatus(canvasId, actor, `Reading ${repo}’s design system — theme, tokens, type`)
+        const md = await extractDesignSystem(conn, paths, model)
+        actions.setGuideline(canvasId, designSystemSlug(repo), md, actor, undefined, `${repo} design system`)
+        actions.advanceCard(canvasId, card.id, actor)
       } catch (err) {
-        console.error(`[github-recon] ${job.screen.route} failed`, err)
-        if (isAccountError(err)) accountDead = true
-        actions.updateFrame(job.frameId, { html: failedCard(job) }, actor)
+        console.error(`[github-recon] design system extraction for ${repo} failed`, err)
+        const reason = failureReason(err)
+        if (isAccountError(err)) accountDead = reason
+        actions.failCard(canvasId, card.id, reason)
       }
     }
 
-    /* small worker pool: steady progress on the canvas without hammering
-       the model or the GitHub API */
-    /* a model turn can outlast the presence TTL — keep Doop visibly in the
-       room for as long as the pass is actually alive */
-    const heartbeat = setInterval(() => actions.heartbeatAgent(conn.canvasId, actor), 15_000)
-    try {
-      const workers = Array.from({ length: Math.min(RECON_CONCURRENCY, queue.length) }, async () => {
-        for (let job = queue.shift(); job; job = queue.shift()) await runOne(job)
-      })
-      await Promise.all(workers)
-    } finally {
-      clearInterval(heartbeat)
-      actions.setAgentStatus(conn.canvasId, actor, '')
+    const queue = group.filter((c) => c.kind === 'sketch' && c.payload.screen)
+    if (!queue.length) continue
+    console.log(`[github-recon] ${queue.length} screen(s) from ${repo} on ${model.label}`)
+    const worker = async () => {
+      for (let card = queue.shift(); card; card = queue.shift()) {
+        if (accountDead) {
+          actions.failCard(canvasId, card.id, accountDead)
+          continue
+        }
+        const screen = card.payload.screen!
+        try {
+          actions.setAgentStatus(
+            canvasId,
+            actor,
+            screen.source === 'static'
+              ? `Importing ${screen.title} from ${repo}`
+              : `Sketching ${screen.title} from ${repo}`,
+          )
+          await sketchScreen(canvasId, conn, screen, paths, model, actor)
+          markSynced(conn.id)
+          actions.advanceCard(canvasId, card.id, actor)
+        } catch (err) {
+          console.error(`[github-recon] ${screen.route} failed`, err)
+          const reason = failureReason(err)
+          if (isAccountError(err)) accountDead = reason
+          actions.failCard(canvasId, card.id, reason)
+        }
+      }
     }
-    console.log(`[github-recon] ${conn.repo} done`)
-  })().catch((err) => console.error('[github-recon] pass failed', err))
+    await Promise.all(Array.from({ length: Math.min(SKETCH_CONCURRENCY, queue.length) }, worker))
+    console.log(`[github-recon] ${repo} done`)
+  }
+}
+
+/** Land one frame for a screen at the connection's next grid slot. */
+function placeRepoFrame(
+  canvasId: string,
+  conn: GithubConnection,
+  screen: RepoScreenRef,
+  html: string,
+  width: number,
+  height: number,
+  actor: Actor,
+): Frame {
+  const canvas = store.getCanvas(canvasId)
+  if (!canvas) throw new Error('canvas not found')
+  const at = nextRepoFramePosition(canvas.frames, conn.id, width)
+  const frame = actions.createFrame(canvasId, { name: screen.title.slice(0, 80), ...at, width, height, html }, actor)
+  if (!frame) throw new Error('canvas not found')
+  return frame
+}
+
+/** One screen, source to frame. Repo HTML lands as-is; code is designed by
+ *  the model, rendered, reviewed once by the model, and fixed. */
+async function sketchScreen(
+  canvasId: string,
+  conn: GithubConnection,
+  screen: RepoScreenRef,
+  paths: string[],
+  model: AgentModel,
+  actor: Actor,
+): Promise<void> {
+  if (screen.source === 'static') {
+    const html = wrapRepoHtml(await fetchRepoFile(conn, screen.sourcePath), conn, screen)
+    placeRepoFrame(canvasId, conn, screen, html, PAGE_W, STATIC_H, actor)
+    return
+  }
+
+  const width = isCompact(screen) ? COMPONENT_W : PAGE_W
+  const closure = await collectClosure(conn, screen, paths)
+  if (!closure.length) throw new Error('no readable source')
+  const source = closure.map((f) => `===== ${f.path} =====\n${f.text}`).join('\n\n')
+  const componentBrief = isCompact(screen)
+    ? `This is a COMPONENT, not a page: present it as an isolated library card — a quiet neutral backdrop, the component rendered at natural size, and its key variants/states side by side when the source defines them. Keep the card compact.\n\n`
+    : ''
+  const designSystemMd = store.getGuidelines(canvasId).find((g) => g.name === designSystemSlug(conn.repo))?.markdown
+  const systemContext = designSystemMd
+    ? `The product's design system, distilled from this repo (follow it exactly):\n${designSystemMd}\n\n`
+    : ''
+  const messages: Parameters<AgentModel['run']>[0]['messages'] = [
+    {
+      role: 'user',
+      content:
+        `Screen: ${screen.title} (route ${screen.route}) from ${conn.repo}. The document is exactly ${width}px wide.\n\n` +
+        componentBrief +
+        systemContext +
+        `Repository file tree (investigate with request_files):\n${treeExcerpt(paths, screen.sourcePath)}\n\n${source}`,
+    },
+  ]
+  /* the investigation loop: the model reads the tree and pulls the
+     theme/locale/component files it needs before designing */
+  const pathSet = new Set(paths)
+  let requestedBudget = MAX_REQUESTED_BYTES
+  let result: Awaited<ReturnType<AgentModel['run']>> | null = null
+  for (let round = 0; round <= MAX_REQUEST_ROUNDS; round++) {
+    result = await model.run({
+      system: [{ text: SYSTEM_PROMPT, cache: true }],
+      tools: round < MAX_REQUEST_ROUNDS ? [REQUEST_FILES_TOOL] : [],
+      messages,
+      maxTokens: MODEL_MAX_TOKENS,
+    })
+    if (result.stop_reason !== 'tool_use') break
+    const calls = result.content.filter((b) => b.type === 'tool_use')
+    messages.push({ role: 'assistant', content: result.content })
+    const results = []
+    for (const call of calls) {
+      const wanted = (
+        Array.isArray((call.input as { paths?: unknown })?.paths)
+          ? ((call.input as { paths: unknown[] }).paths as unknown[])
+          : []
+      )
+        .map(String)
+        .filter((p) => pathSet.has(p))
+        .slice(0, MAX_REQUESTED_FILES)
+      const sections: string[] = []
+      for (const p of wanted) {
+        if (requestedBudget <= 0) break
+        try {
+          let text = await fetchRepoFile(conn, p)
+          if (text.length > requestedBudget) text = text.slice(0, requestedBudget) + '\n/* …truncated… */'
+          requestedBudget -= text.length
+          sections.push(`===== ${p} =====\n${text}`)
+        } catch {
+          sections.push(`===== ${p} =====\n/* unreadable */`)
+        }
+      }
+      results.push({
+        type: 'tool_result' as const,
+        tool_use_id: call.id,
+        content: sections.join('\n\n') || 'none of those paths exist in the tree',
+      })
+    }
+    messages.push({ role: 'user', content: results })
+  }
+  const { html, height } = extractHtml((result?.content ?? []) as { type: string; text?: string }[])
+  const withAssets = await resolveRepoAssets(conn, html, pathSet)
+  let frame = placeRepoFrame(canvasId, conn, screen, wrapGeneratedHtml(withAssets, conn, screen), width, height, actor)
+
+  /* Doop's own doctrine: never ship without looking. Render the draft,
+     show the model its own output, and let it fix what is visibly
+     wrong — the single biggest quality lever short of executing the
+     app. Draft stays on the canvas while the fix round runs. */
+  for (let round = 0; round < REVIEW_ROUNDS; round++) {
+    try {
+      const { renderFrame } = await import('./screenshot.ts')
+      const shot = await renderFrame(frame, frame.height > 4000 ? 0.7 : 1, {
+        type: 'jpeg',
+        quality: 72,
+        maxHeight: 8000,
+      })
+      messages.push({ role: 'assistant', content: (result?.content ?? []) as TurnBlock[] })
+      messages.push({
+        role: 'user',
+        content: [
+          {
+            type: 'image',
+            source: { type: 'base64', media_type: 'image/jpeg', data: shot.toString('base64') },
+          },
+          {
+            type: 'text',
+            text: 'This is YOUR reconstruction, rendered. Judge it against the source you read like a senior designer: wrong palette or fonts, broken or overlapping layout, clipped or missing sections, dead empty areas, images that did not resolve. Then output the corrected COMPLETE document — same rules, full page, ending with the height comment. If it is genuinely faithful already, output the document unchanged.',
+          },
+        ],
+      })
+      const fixed = await model.run({
+        system: [{ text: SYSTEM_PROMPT, cache: true }],
+        tools: [],
+        messages,
+        maxTokens: MODEL_MAX_TOKENS,
+      })
+      result = fixed
+      const redo = extractHtml(fixed.content as { type: string; text?: string }[])
+      const redoAssets = await resolveRepoAssets(conn, redo.html, pathSet)
+      frame =
+        actions.updateFrame(
+          frame.id,
+          { html: wrapGeneratedHtml(redoAssets, conn, screen), height: redo.height },
+          actor,
+        ) ?? frame
+    } catch (err) {
+      console.error(`[github-recon] review round for ${screen.route} failed — keeping the draft`, err)
+      break
+    }
+  }
 }

--- a/server/guide.ts
+++ b/server/guide.ts
@@ -171,21 +171,19 @@ Viewers watch designs assemble live. Stream with append_frame_html:
   component 480×360, square social post 640×640. Set width/height on create_frame, or
   adjust later with update_frame.
 
-## GitHub outline frames — design them from source
+## GitHub-imported frames — the repo is the source of truth
 
 Frames whose HTML carries a "doop-github-screen" marker meta were imported from a
-connected GitHub repository. Ones that ALSO carry "doop-github-placeholder" are
-outlines: the screen exists in that repo only as code (a Next.js page, a Storybook
-story) and is waiting to be designed. The marker records the repo, the route and the
-source file path.
+connected GitHub repository: repo HTML as-is, or a screen that exists in that repo only
+as code (a Next.js page, a Storybook story, a component) sketched by Doop from its
+source. The marker records the repo, the route and the source file path.
 
 If you have that repository available (checked out locally, or reachable through your
-own tools), you are the best agent for the job: read the screen's source file and the
-components it imports, then set_frame_html a complete self-contained document that
-faithfully renders it — real CSS derived from its actual classes and design tokens,
-realistic placeholder data, no scripts. Design at the frame's width and resize the
-frame to the content. Updating the outline in place (not a new frame) is correct here —
-that is what the outline is for.
+own tools), you are the best agent to improve such a frame: read the screen's source
+file and the components it imports, then set_frame_html a complete self-contained
+document that faithfully renders it — real CSS derived from its actual classes and
+design tokens, realistic placeholder data, no scripts. Design at the frame's width and
+resize the frame to the content. Keep the marker meta so the frame stays traceable.
 
 ## Images — search first, then upload
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -29,8 +29,6 @@ import {
 import * as ingest from './ingest.ts'
 import * as github from './github.ts'
 import * as githubApp from './githubApp.ts'
-import { scheduleReconstructions } from './githubRecon.ts'
-import { pickModel } from './agentModel.ts'
 import { seed } from './seed.ts'
 import * as allowance from './allowance.ts'
 import * as modelAccounts from './modelAccounts.ts'
@@ -987,30 +985,54 @@ app.post('/api/canvases/:id/github/:connId/analyze', async (req, res) => {
   }
 })
 
+/* one import at a time per repo connection — see the route */
+const connectionLocks = new Map<string, Promise<unknown>>()
+async function withConnectionLock<T>(connectionId: string, fn: () => Promise<T>): Promise<T> {
+  const previous = connectionLocks.get(connectionId) ?? Promise.resolve()
+  const run = previous.then(fn, fn)
+  const tail = run.catch(() => {})
+  connectionLocks.set(connectionId, tail)
+  try {
+    return await run
+  } finally {
+    if (connectionLocks.get(connectionId) === tail) connectionLocks.delete(connectionId)
+  }
+}
+
 app.post('/api/canvases/:id/github/:connId/import', async (req, res) => {
   const c = requireDurableCanvas(req, res, req.params.id)
   if (!c) return
   const conn = await github.getConnection(c.id, req.params.connId)
   if (!conn) return res.status(404).json({ error: 'connection not found' })
   if (!takeImportSlot(req.user!.id)) return res.status(429).json({ error: 'too many imports — wait a minute' })
+  /* design-system-only import is the headline flow now — screens optional */
+  const designSystem = req.body?.design_system !== false
+  const rawScreens = Array.isArray(req.body?.screens) ? (req.body.screens as unknown[]) : []
+  if (!rawScreens.length && !designSystem)
+    return res.status(400).json({ error: 'pick components or screens, or enable the design-system extraction' })
   try {
-    const actor = actions.resolveActor({ name: req.user!.name, kind: 'user' })
-    /* code-only screens get agent reconstruction when a model can run it —
-       the requester's own account, else the server tier (same resolution as
-       every other agent task, billed to the same person) */
-    const sketch = !!(await pickModel(req.user!.id))
-    const designSystem = sketch && req.body?.design_system !== false
-    /* design-system-only import is the headline flow now — screens optional */
-    const rawScreens = Array.isArray(req.body?.screens) ? (req.body.screens as unknown[]) : []
-    if (!rawScreens.length && !designSystem)
-      return res.status(400).json({ error: 'pick components or screens, or enable the design-system extraction' })
-    let result: { frames: unknown[]; failures: unknown[] } = { frames: [], failures: [] }
-    let pending: Parameters<typeof scheduleReconstructions>[1] = []
-    if (rawScreens.length) {
-      ;({ pending, ...result } = await github.importScreens(conn, c, rawScreens, actor, { sketch }))
-    }
-    scheduleReconstructions(conn, pending, actor, req.user!.id, { designSystem })
-    res.json(result)
+    /* the selection is resolved against a manifest computed right now — see
+       matchSelection for why the client never dictates paths */
+    const { screens, rejected } = rawScreens.length
+      ? github.matchSelection((await github.analyzeConnection(conn)).screens, rawScreens)
+      : { screens: [], rejected: [] }
+    const input = { connectionId: conn.id, repo: conn.repo, screens, designSystem }
+    /* plan → gate → queue runs one import at a time per connection, so two
+       overlapping imports of the same screens cannot both pass the plan and
+       both pay while only one queues */
+    const outcome = await withConnectionLock(conn.id, async () => {
+      /* nothing new to queue (all rejected, or already on the board) costs nothing */
+      if (!actions.planRepoCards(c.id, input).length) return { cards: [] as string[] }
+      /* the import is the Doop Agent's work, card by card — same gate as a card
+         typed on the board: a free task, or the requester's own model account */
+      const gate = await allowance.consumeResidentTask(req.user!.id)
+      if (!gate.ok) return { limit: gate }
+      const cards = actions.addRepoCards(c.id, input, req.user!.name, req.user!.id)
+      return { cards: cards.map((card) => card.id) }
+    })
+    if (outcome.limit)
+      return res.status(403).json({ error: 'resident_limit', used: outcome.limit.used, limit: outcome.limit.limit })
+    res.json({ cards: outcome.cards, rejected })
   } catch (e) {
     res.status(400).json({ error: e instanceof Error ? e.message : 'import failed' })
   }

--- a/server/index.ts
+++ b/server/index.ts
@@ -1172,6 +1172,36 @@ app.post('/api/frames/:id/comments', async (req, res) => {
   res.json(comment)
 })
 
+app.post('/api/comments/:id/replies', async (req, res) => {
+  const found = actions.findComment(req.params.id)
+  if (!found) return res.status(404).json({ error: 'comment not found' })
+  if (!requireCanvas(req, res, found.canvasId)) return
+  const text = String(req.body?.text ?? '')
+  if (!text.trim() || !actions.openThread(req.params.id)) {
+    return res.status(404).json({ error: 'thread resolved or empty text' })
+  }
+  /* same rule as a fresh comment: only an @mention costs a resident task */
+  let gate: Awaited<ReturnType<typeof allowance.consumeResidentTask>> | undefined
+  if (mentionedRole(text)) {
+    gate = await allowance.consumeResidentTask(req.user!.id)
+    if (!gate.ok) {
+      return res.status(403).json({ error: 'resident_limit', used: gate.used, limit: gate.limit })
+    }
+  }
+  const reply = actions.replyToComment(req.params.id, text, req.user!.name, req.user!.id)
+  if (!reply) {
+    /* the thread closed while the meter was being written: give the task
+       back — a failed refund is logged, never turned into a 500 */
+    if (gate) {
+      await allowance.refundResidentTask(gate, req.user!.id).catch((err) => {
+        console.error(`[comments] could not refund a resident task for ${req.user!.id}:`, err)
+      })
+    }
+    return res.status(409).json({ error: 'thread resolved meanwhile' })
+  }
+  res.json(reply)
+})
+
 app.post('/api/comments/:id/resolve', (req, res) => {
   const found = actions.findComment(req.params.id)
   if (!found) return res.status(404).json({ error: 'comment not found' })

--- a/server/resident.ts
+++ b/server/resident.ts
@@ -316,7 +316,18 @@ async function runAgent(canvasId: string, agentName: string, stalled: Set<string
           comments
             .map((c) => {
               const fname = store.getFrame(c.frameId)?.name ?? 'unknown frame'
-              return `- ${c.from} on frame ${c.frameId} "${fname}", element ${c.selector}\n  element HTML at comment time: ${c.snippet}\n  comment: "${c.text}"`
+              /* a reply carries the conversation it answers, so "make it
+                 bigger" reads against what was said before */
+              const history = actions.commentThread(c)
+              const earlier = history
+                .slice(
+                  0,
+                  history.findIndex((x) => x.id === c.id),
+                )
+                .map((x) => `    ${x.from}: "${x.text}"`)
+                .join('\n')
+              const thread = earlier ? `\n  earlier in this thread:\n${earlier}` : ''
+              return `- ${c.from} on frame ${c.frameId} "${fname}", element ${c.selector}\n  element HTML at comment time: ${c.snippet}${thread}\n  comment: "${c.text}"`
             })
             .join('\n'),
       )

--- a/server/resident.ts
+++ b/server/resident.ts
@@ -16,6 +16,7 @@ import { describeInspiration, INSPIRATION_USAGE_NOTE, searchInspiration } from '
 import type { Frame } from '../shared/types.ts'
 import { websiteAccessErrorMessage } from './websiteAccess.ts'
 import { executeGuardedBatch } from './guardedBatch.ts'
+import { runRepoCards } from './githubRecon.ts'
 
 /**
  * The resident design team: a server-side Claude tool loop, run once per
@@ -227,16 +228,37 @@ async function runAgent(canvasId: string, agentName: string, stalled: Set<string
      shows up in presence. */
   const claimed = actions.takeFeedbackFor(canvasId, role.name, payer)
   const comments = actions.takeAgentCommentsFor(canvasId, role.name, payer)
-  const cards = actions.takeQueuedCardsFor(canvasId, role.name, payer)
-  if (claimed.length === 0 && comments.length === 0 && cards.length === 0) {
+  const allCards = actions.takeQueuedCardsFor(canvasId, role.name, payer)
+  if (claimed.length === 0 && comments.length === 0 && allCards.length === 0) {
     /* nothing actually claimable for this payer — do not re-pick them */
     stalled.add(payer)
     return 'no-model'
   }
+  /* structured repo cards (the GitHub import) have their own runner with
+     repo-reading tools; only prompt cards go through the chat loop below */
+  const repoCards = allCards.filter((c) => c.kind)
+  const cards = allCards.filter((c) => !c.kind)
 
   /* presence otherwise only refreshes on tool activity, and the sweep's TTL
      is shorter than a big generation turn */
   const heartbeat = setInterval(() => actions.heartbeatAgent(canvasId, actor), 15_000)
+
+  if (repoCards.length > 0) {
+    try {
+      await runRepoCards(canvasId, repoCards, model, actor)
+    } catch (err) {
+      /* the runner fails cards one by one; this is the backstop for a
+         failure outside any card, so none stays claimed forever */
+      console.error('[resident] repo cards errored', err)
+      for (const c of repoCards)
+        actions.failCard(canvasId, c.id, 'Doop hit a snag before finishing. Retry when you are ready.')
+    }
+    if (claimed.length === 0 && comments.length === 0 && cards.length === 0) {
+      clearInterval(heartbeat)
+      actions.setAgentStatus(canvasId, actor, '')
+      return 'ran'
+    }
+  }
 
   try {
     const tasks = actions.getTasks(canvasId)

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -181,6 +181,33 @@ export interface AgentTask {
   attachments?: string[]
   /** index into pipeline of the stage that is queued or running right now */
   stage?: number
+  /** structured board cards the resident runner dispatches on, instead of
+   *  handing the title to the chat agent. Absent on prompt cards. */
+  kind?: RepoCardKind
+  payload?: RepoCardPayload
+}
+
+export type RepoCardKind = 'sketch' | 'design-system'
+
+/** A screen of a connected GitHub repository, as the import manifest lists it. */
+export interface RepoScreenRef {
+  kind: 'page' | 'story' | 'component' | 'static'
+  route: string
+  sourcePath: string
+  title: string
+  /** where the pixels come from: repo HTML, or the agent's sketch of the code */
+  source: 'static' | 'placeholder'
+}
+
+/** What a repo card carries: enough to run it from any process, later. The
+ *  connection is looked up by id at run time, so no credential is ever here. */
+export interface RepoCardPayload {
+  connectionId: string
+  repo: string
+  /** one import = one click; groups the cards it queued on the board */
+  importId: string
+  /** the screen to sketch — absent on a design-system card */
+  screen?: RepoScreenRef
 }
 
 /** Human feedback left on an agent task: an open request on the canvas that ANY

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -236,6 +236,9 @@ export interface ElementComment {
   failureReason?: string
   resolvedBy?: string
   resolvedAt?: number
+  /** set on a reply: the root comment of its thread. Replies inherit the
+   *  root's anchor and are listed under its pin instead of getting their own */
+  parentId?: string
 }
 
 export interface ActivityItem {

--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -54,6 +54,30 @@ function pipelineOf(t: AgentTask): string[] {
   return t.pipeline?.length ? t.pipeline : [DEFAULT_ROLE_ID]
 }
 
+/** The repo a structured card came from — the GitHub import's cards wear it
+ *  so a dozen of them read as one import, not as spam. */
+function RepoTag({ task }: { task: AgentTask }) {
+  if (!task.payload) return null
+  return (
+    <span className="inline-flex max-w-full items-center gap-1 overflow-hidden text-ellipsis whitespace-nowrap font-mono text-[10.5px] text-ink-faint">
+      ⎇ {task.payload.repo}
+      {task.kind === 'design-system' ? ' · design system' : task.payload.screen ? ` · ${task.payload.screen.kind}` : ''}
+    </span>
+  )
+}
+
+/** Queued cards from one import (same click on the same repo), oldest first. */
+function groupImports(queued: AgentTask[]): { key: string; cards: AgentTask[] }[] {
+  const groups: { key: string; cards: AgentTask[] }[] = []
+  for (const t of queued) {
+    const key = t.payload?.importId ? `import:${t.payload.importId}` : t.id
+    const group = groups.find((g) => g.key === key)
+    if (group) group.cards.push(t)
+    else groups.push({ key, cards: [t] })
+  }
+  return groups
+}
+
 /** The pipeline of a card with its current position marked. */
 function Trail({ task, state }: { task: AgentTask; state: 'queued' | 'working' | 'done' }) {
   const pipeline = pipelineOf(task)
@@ -207,7 +231,13 @@ export function Board({ canvasId }: { canvasId: string }) {
                   ✕
                 </Button>
                 <h3 className={cardH3Cls}>{t.status}</h3>
-                <Trail task={t} state="queued" />
+                {t.payload ? (
+                  <div className="mt-1.5">
+                    <RepoTag task={t} />
+                  </div>
+                ) : (
+                  <Trail task={t} state="queued" />
+                )}
                 <div className={metaCls}>
                   <b>Attempt stopped</b>
                   {t.agentName ? <span> · {t.agentName}</span> : null}
@@ -231,26 +261,57 @@ export function Board({ canvasId }: { canvasId: string }) {
                 </Button>
               </Card>
             ))}
-            {queued.map((t) => (
-              <Card key={t.id} className={cn(cardBase, 'bg-surface')}>
-                <Button
-                  variant="bare"
-                  className={dismissCls}
-                  title="Remove this card"
-                  onClick={() => api.completeCard(canvasId, t.id).catch(console.error)}
-                >
-                  ✕
-                </Button>
-                <h3 className={cardH3Cls}>{t.status}</h3>
-                <Trail task={t} state="queued" />
-                <div className={metaCls}>
-                  <b>{t.queuedBy}</b> · {timeAgo(t.startedAt)}
-                </div>
-                <div className="mt-[9px] font-mono text-[11px] text-ink-faint">
-                  ✦ waiting for {roleName(pipelineOf(t)[t.stage ?? 0])}
-                </div>
-              </Card>
-            ))}
+            {groupImports(queued).map(({ key, cards }) => {
+              const t = cards[0]!
+              const isImport = cards.length > 1 || !!t.payload
+              return (
+                <Card key={key} className={cn(cardBase, 'bg-surface')}>
+                  <Button
+                    variant="bare"
+                    className={dismissCls}
+                    title={cards.length > 1 ? 'Remove these cards' : 'Remove this card'}
+                    onClick={() => Promise.all(cards.map((c) => api.completeCard(canvasId, c.id))).catch(console.error)}
+                  >
+                    ✕
+                  </Button>
+                  {isImport ? (
+                    <>
+                      <h3 className={cardH3Cls}>
+                        {cards.length === 1 ? t.status : `${cards.length} cards from ${t.payload?.repo}`}
+                      </h3>
+                      {cards.length === 1 ? (
+                        <div className="mt-1.5">
+                          <RepoTag task={t} />
+                        </div>
+                      ) : (
+                        <div className="mt-2 flex flex-wrap gap-1">
+                          {cards.map((c) => (
+                            <span
+                              key={c.id}
+                              className="rounded-full border border-line px-2 py-0.5 text-[11px] text-ink-soft"
+                              title={c.payload?.screen?.route}
+                            >
+                              {c.kind === 'design-system' ? '✦ design system' : c.status}
+                            </span>
+                          ))}
+                        </div>
+                      )}
+                    </>
+                  ) : (
+                    <>
+                      <h3 className={cardH3Cls}>{t.status}</h3>
+                      <Trail task={t} state="queued" />
+                    </>
+                  )}
+                  <div className={metaCls}>
+                    <b>{t.queuedBy}</b> · {timeAgo(t.startedAt)}
+                  </div>
+                  <div className="mt-[9px] font-mono text-[11px] text-ink-faint">
+                    ✦ waiting for {roleName(pipelineOf(t)[t.stage ?? 0])}
+                  </div>
+                </Card>
+              )
+            })}
             {draft === null ? (
               <Button
                 variant="ghost"
@@ -357,7 +418,13 @@ export function Board({ canvasId }: { canvasId: string }) {
                 className={cn(cardBase, 'border-brand bg-surface shadow-[0_0_0_1px_var(--brand),var(--shadow-card)]')}
               >
                 <h3 className={cardH3Cls}>{t.status}</h3>
-                {t.queuedBy && <Trail task={t} state="working" />}
+                {t.payload ? (
+                  <div className="mt-1.5">
+                    <RepoTag task={t} />
+                  </div>
+                ) : (
+                  t.queuedBy && <Trail task={t} state="working" />
+                )}
                 <div className={metaCls}>
                   <Dot
                     size="sm"
@@ -388,6 +455,11 @@ export function Board({ canvasId }: { canvasId: string }) {
                 <h3 className="break-words pr-4 font-display text-[13.5px] font-semibold leading-[1.35] tracking-[-0.01em] text-ink-soft">
                   {t.status}
                 </h3>
+                {t.payload && (
+                  <div className="mt-1">
+                    <RepoTag task={t} />
+                  </div>
+                )}
                 {t.queuedBy && pipelineOf(t).length > 1 && <Trail task={t} state="done" />}
                 <div className={metaCls}>
                   <span className="font-[750] text-[#1e7a4c]">✓</span> {t.agentName || t.queuedBy}

--- a/src/components/DashShell.tsx
+++ b/src/components/DashShell.tsx
@@ -68,7 +68,7 @@ export function AccountMenu() {
           </DropdownMenuItem>
         )}
         <DropdownMenuItem asChild>
-          <a href="/blog" target="_blank" rel="noopener noreferrer">
+          <a href="/docs" target="_blank" rel="noopener noreferrer">
             <IconHelp /> Help &amp; docs
           </a>
         </DropdownMenuItem>

--- a/src/components/DashShell.tsx
+++ b/src/components/DashShell.tsx
@@ -68,7 +68,7 @@ export function AccountMenu() {
           </DropdownMenuItem>
         )}
         <DropdownMenuItem asChild>
-          <a href="/docs" target="_blank" rel="noopener noreferrer">
+          <a href="https://doop.design/docs" target="_blank" rel="noopener noreferrer">
             <IconHelp /> Help &amp; docs
           </a>
         </DropdownMenuItem>

--- a/src/components/FrameContextMenu.tsx
+++ b/src/components/FrameContextMenu.tsx
@@ -2,7 +2,8 @@ import type { MutableRefObject } from 'react'
 import type { Frame } from '../../shared/types'
 import { api } from '../lib/api'
 import { copyFrame, duplicateFrame, hasFrameClip, pasteFrameAtScreen } from '../lib/frameClipboard'
-import { deleteFrameTracked } from '../lib/history'
+import { deleteFramesTracked } from '../lib/history'
+import { useStore } from '../lib/store'
 import { MOD_KEY } from '../lib/keys'
 import { ContextMenuContent, ContextMenuItem, ContextMenuSeparator } from './ui/context-menu'
 import { MenuHint } from './ui/menu'
@@ -10,6 +11,13 @@ import { MenuHint } from './ui/menu'
 /** Right-click menu for a frame. FrameView owns the trigger, and passes the
  *  point the right-click happened at — Paste lands there. */
 export function FrameContextMenu({ frame, at }: { frame: Frame; at: MutableRefObject<{ x: number; y: number }> }) {
+  /* a right-click inside a multi-selection acts on the whole group */
+  const groupSize = useStore((s) => (s.selectedIds.includes(frame.id) ? s.selectedIds.length : 1))
+  function deleteSelection() {
+    const s = useStore.getState()
+    const ids = s.selectedIds.includes(frame.id) ? s.selectedIds : [frame.id]
+    deleteFramesTracked(s.canvas?.frames.filter((f) => ids.includes(f.id)) ?? [frame])
+  }
   return (
     <ContextMenuContent>
       <ContextMenuItem onSelect={() => copyFrame(frame)}>
@@ -50,8 +58,8 @@ export function FrameContextMenu({ frame, at }: { frame: Frame; at: MutableRefOb
         Add to design memory
       </ContextMenuItem>
       <ContextMenuSeparator />
-      <ContextMenuItem tone="danger" onSelect={() => deleteFrameTracked(frame)}>
-        Delete frame
+      <ContextMenuItem tone="danger" onSelect={deleteSelection}>
+        {groupSize > 1 ? `Delete ${groupSize} frames` : 'Delete frame'}
         <MenuHint>⌫</MenuHint>
       </ContextMenuItem>
     </ContextMenuContent>

--- a/src/components/FrameView.tsx
+++ b/src/components/FrameView.tsx
@@ -226,7 +226,9 @@ export const FrameView = memo(function FrameView({ frame, raster }: { frame: Fra
   }, [runtimeReady, html, editing, suspendPost])
 
   /* ---- element comments ---- */
-  const comments = useStore((s) => s.comments).filter((c) => c.frameId === frame.id && !c.resolvedAt)
+  const frameComments = useStore((s) => s.comments).filter((c) => c.frameId === frame.id)
+  /* only thread roots get a pin; replies live inside the root's popover */
+  const comments = frameComments.filter((c) => !c.parentId && !c.resolvedAt)
   const [probe, setProbe] = useState<ProbeHit | null>(null)
   /* element selected for text editing inside the iframe (edit mode only) */
   const [activeHit, setActiveHit] = useState<ProbeHit | null>(null)
@@ -623,17 +625,20 @@ export const FrameView = memo(function FrameView({ frame, raster }: { frame: Fra
                   const pos = pinPos[c.id]
                   if (!pos) return null
                   const open = openThread === c.id
+                  const replies = frameComments.filter((r) => r.parentId === c.id).reverse() // store is newest-first
+                  const thread = [c, ...replies.sort((a, b) => a.at - b.at)]
+                  /* the pin reflects the newest agent request in the thread */
+                  const agentItem = [...thread].reverse().find((x) => x.forAgent && !x.resolvedAt)
+                  const working = agentItem?.claimedBy && !agentItem.failedAt
                   return (
                     <div
                       key={c.id}
                       className={cn(
                         'pointer-events-auto absolute z-[4] grid h-[26px] w-[26px] cursor-pointer place-items-center rounded-[50%_50%_50%_4px] border-2 border-white text-[13px] text-white [transform:translate(-50%,-50%)_scale(min(calc(1/var(--zoom,1)),2.4))] animate-[chip-in_0.25s_ease]',
-                        c.failedAt
+                        agentItem?.failedAt
                           ? 'bg-accent-ink! font-extrabold shadow-[0_0_0_3px_rgba(208,52,31,0.2),var(--shadow-card)]'
                           : 'shadow-card',
-                        !c.failedAt &&
-                          c.claimedBy &&
-                          !c.resolvedAt &&
+                        working &&
                           "after:absolute after:-inset-1.5 after:rounded-[inherit] after:border-2 after:border-current after:opacity-50 after:content-[''] after:[animation:stream-pulse_1.1s_ease-in-out_infinite]",
                       )}
                       style={{
@@ -647,12 +652,23 @@ export const FrameView = memo(function FrameView({ frame, raster }: { frame: Fra
                         setComposing(false)
                         setOpenThread(open ? null : c.id)
                       }}
-                      title={`${c.from}: ${c.text}`}
+                      title={`${c.from}: ${c.text}${thread.length > 1 ? ` (${thread.length - 1} replies)` : ''}`}
                     >
-                      {c.failedAt ? '!' : c.claimedBy && !c.resolvedAt ? '✦' : '💬'}
+                      {agentItem?.failedAt ? '!' : working ? '✦' : '💬'}
                       {open && (
                         <CommentThread
-                          comment={c}
+                          thread={thread}
+                          onReply={(text) =>
+                            api
+                              .replyComment(c.id, text)
+                              .then(() => posthog.capture('element_comment_replied'))
+                              .catch((err) => {
+                                /* the wall explains a hit limit; anything else
+                                   surfaces in the thread so the draft survives */
+                                if (isResidentLimit(err)) useStore.getState().setLimitWall(true)
+                                throw err
+                              })
+                          }
                           onResolve={() => {
                             api
                               .resolveComment(c.id)
@@ -660,8 +676,8 @@ export const FrameView = memo(function FrameView({ frame, raster }: { frame: Fra
                               .catch(console.error)
                             setOpenThread(null)
                           }}
-                          onRetry={() =>
-                            api.retryComment(c.id).catch((err) => {
+                          onRetry={(id) =>
+                            api.retryComment(id).catch((err) => {
                               if (isResidentLimit(err)) useStore.getState().setLimitWall(true)
                               else console.error(err)
                             })
@@ -842,44 +858,96 @@ function CommentComposer({
   )
 }
 
+/** Where an @agent request in the thread stands, or null for a human note. */
+function agentStatus(c: ElementComment): string | null {
+  const target = c.targetAgent ?? roleName(DEFAULT_ROLE_ID)
+  if (c.failedAt) return `${target} stopped`
+  if (c.resolvedAt) return c.forAgent ? `✓ ${c.resolvedBy ?? target}` : null
+  if (c.claimedBy) return `✦ ${c.claimedBy} is on it`
+  return c.forAgent ? `✦ waiting for ${target}` : null
+}
+
 function CommentThread({
-  comment,
+  thread,
+  onReply,
   onResolve,
   onRetry,
 }: {
-  comment: ElementComment
+  /** root comment first, then its replies oldest → newest */
+  thread: ElementComment[]
+  /** rejects when the reply did not land — the draft is kept for a retry */
+  onReply: (text: string) => Promise<unknown>
   onResolve: () => void
-  onRetry: () => void
+  onRetry: (commentId: string) => void
 }) {
-  const target = comment.targetAgent ?? roleName(DEFAULT_ROLE_ID)
-  const status = comment.failedAt
-    ? `${target} stopped`
-    : comment.claimedBy && !comment.resolvedAt
-      ? `✦ ${comment.claimedBy} is on it`
-      : comment.forAgent
-        ? `✦ waiting for ${target}`
-        : null
+  const [reply, setReply] = useState('')
+  const [sending, setSending] = useState(false)
+  const [failed, setFailed] = useState(false)
+  const listRef = useRef<HTMLDivElement>(null)
+  /* a long conversation opens (and grows) scrolled to its newest message */
+  useEffect(() => {
+    listRef.current?.scrollTo({ top: listRef.current.scrollHeight })
+  }, [thread.length])
+  const send = () => {
+    if (!reply.trim() || sending) return
+    const submitted = reply
+    setSending(true)
+    setFailed(false)
+    onReply(submitted)
+      /* only clear what was sent — text typed meanwhile is a new draft */
+      .then(() => setReply((current) => (current === submitted ? '' : current)))
+      .catch(() => setFailed(true))
+      .finally(() => setSending(false))
+  }
+  const mentioned = mentionedRole(reply)
   return (
     <div
-      className="absolute top-[calc(100%_+_8px)] left-1/2 w-[230px] -translate-x-1/2 cursor-default rounded-[10px] border border-line bg-surface p-2.5 text-left shadow-pop animate-[chip-in_0.18s_ease]"
+      className="absolute top-[calc(100%_+_8px)] left-1/2 w-[250px] -translate-x-1/2 cursor-default rounded-[10px] border border-line bg-surface p-2.5 text-left shadow-pop animate-[chip-in_0.18s_ease]"
       onClick={(e) => e.stopPropagation()}
     >
-      <div className="flex items-center justify-between gap-2 text-[12px]">
-        <b style={{ color: colorFor(comment.from) }}>{comment.from}</b>
-        {status && <span className="whitespace-nowrap text-[11px] font-semibold text-brand">{status}</span>}
+      <div ref={listRef} className="-mx-1 max-h-[240px] overflow-y-auto px-1">
+        {thread.map((c, i) => {
+          const status = agentStatus(c)
+          return (
+            <div key={c.id} className={cn(i > 0 && 'mt-2 border-t border-line-soft pt-2')}>
+              <div className="flex items-center justify-between gap-2 text-[12px]">
+                <b style={{ color: colorFor(c.from) }}>{c.from}</b>
+                {status && <span className="whitespace-nowrap text-[11px] font-semibold text-brand">{status}</span>}
+              </div>
+              <div className="mt-1 break-words text-[13px] leading-[1.45] text-ink">{c.text}</div>
+              {c.failedAt ? (
+                <div className="mt-1 flex items-center gap-2 text-[11px] leading-[1.4] text-accent-ink">
+                  <span>{c.failureReason ?? 'The agent did not finish.'}</span>
+                  <Button
+                    variant="danger-solid"
+                    size="pill"
+                    className="shrink-0 px-[9px] py-[3px] text-[11px]"
+                    onClick={() => onRetry(c.id)}
+                  >
+                    ↻ Retry
+                  </Button>
+                </div>
+              ) : null}
+            </div>
+          )
+        })}
       </div>
-      <div className="mt-1.5 mb-2 break-words text-[13px] leading-[1.45] text-ink">{comment.text}</div>
-      {comment.failedAt ? (
-        <div className="-mt-0.5 mb-2 text-[11px] leading-[1.4] text-accent-ink">
-          {comment.failureReason ?? 'The agent did not finish.'}
+      <Textarea
+        variant="bare"
+        className="mt-2 min-h-[38px] md:text-[13px]"
+        value={reply}
+        placeholder="Reply… (@doop to ask the agent)"
+        onChange={(e) => setReply(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) send()
+        }}
+      />
+      {failed && (
+        <div className="mt-1 text-[11px] leading-[1.4] text-accent-ink">
+          That reply did not go through — it may be resolved already. Try again.
         </div>
-      ) : null}
-      <div className="flex items-center gap-1.5">
-        {comment.failedAt ? (
-          <Button variant="danger-solid" size="pill" className="px-[11px] py-[5px]" onClick={onRetry}>
-            ↻ Retry
-          </Button>
-        ) : null}
+      )}
+      <div className="mt-1.5 flex items-center gap-1.5">
         <Button
           variant="ghost"
           size="pill"
@@ -887,6 +955,23 @@ function CommentThread({
           onClick={onResolve}
         >
           ✓ Resolve
+        </Button>
+        {mentioned && (
+          <span
+            className="ml-auto truncate text-[11px] font-semibold text-brand"
+            title={`${mentioned.name} will pick this up`}
+          >
+            {mentioned.emoji} {mentioned.name}
+          </span>
+        )}
+        <Button
+          variant="solid"
+          size="pill"
+          className={cn('px-3 py-[4px] text-xs', !mentioned && 'ml-auto')}
+          disabled={!reply.trim() || sending}
+          onClick={send}
+        >
+          {sending ? 'Posting…' : 'Reply'}
         </Button>
       </div>
     </div>

--- a/src/components/FrameView.tsx
+++ b/src/components/FrameView.tsx
@@ -9,6 +9,7 @@ import { getIdentity } from '../lib/identity'
 import { FRAME_BOOTSTRAP } from '../lib/frameRuntime'
 import { recordCreate, recordUpdate } from '../lib/history'
 import { snapFrame } from '../lib/snap'
+import { gesture } from '../lib/gesture'
 import { FrameContextMenu } from './FrameContextMenu'
 import { ContextMenu, ContextMenuTrigger } from './ui/context-menu'
 import { AGENT_ROLES, DEFAULT_ROLE_ID, mentionedRole, roleName } from '../../shared/agents'
@@ -124,6 +125,11 @@ export const FrameView = memo(function FrameView({ frame, raster }: { frame: Fra
     const start = { x: e.clientX, y: e.clientY }
     const off = { x: e.nativeEvent.offsetX, y: e.nativeEvent.offsetY }
     const orig = { x: frame.x, y: frame.y, width: frame.width, height: frame.height }
+    /* the drag's baseline: finger position and frame rect the deltas are
+       measured from. Starts at pointer-down, and re-anchors while a pinch
+       owns the finger so the drag resumes from where the finger is (and at
+       the zoom it is now) rather than jumping by the pinch's displacement */
+    let base = { x: start.x, y: start.y, rect: orig }
     let moved = false
     /* ⌥⇧-drag duplicates: the moment the drag is real, leave a copy of the
        frame at its origin and keep dragging this one — same net effect as
@@ -133,6 +139,13 @@ export const FrameView = memo(function FrameView({ frame, raster }: { frame: Fra
     if (duplicating) setDuping(true)
 
     function onMove(ev: PointerEvent) {
+      if (ev.pointerId !== e.pointerId) return
+      /* a second finger turns the gesture into a pinch: the frame stays put */
+      if (gesture.pinching) {
+        const cur = useStore.getState().canvas?.frames.find((x) => x.id === frame.id)
+        base = { x: ev.clientX, y: ev.clientY, rect: cur ? { ...cur } : base.rect }
+        return
+      }
       if (Math.abs(ev.clientX - start.x) + Math.abs(ev.clientY - start.y) > 4) moved = true
       if (duplicating && moved && !dupDropped) {
         dupDropped = true
@@ -145,15 +158,16 @@ export const FrameView = memo(function FrameView({ frame, raster }: { frame: Fra
           .catch(console.error)
       }
       const zoom = useStore.getState().viewport.zoom
-      const dx = (ev.clientX - start.x) / zoom
-      const dy = (ev.clientY - start.y) / zoom
+      const dx = (ev.clientX - base.x) / zoom
+      const dy = (ev.clientY - base.y) / zoom
+      const from = base.rect
       const raw =
         mode === 'move'
-          ? { ...orig, x: Math.round(orig.x + dx), y: Math.round(orig.y + dy) }
+          ? { ...from, x: Math.round(from.x + dx), y: Math.round(from.y + dy) }
           : {
-              ...orig,
-              width: Math.max(120, Math.round(orig.width + dx)),
-              height: Math.max(80, Math.round(orig.height + dy)),
+              ...from,
+              width: Math.max(120, Math.round(from.width + dx)),
+              height: Math.max(80, Math.round(from.height + dy)),
             }
       /* edges pull onto neighbouring frames' edges/centers; ⌥ drags free */
       const others = useStore.getState().canvas?.frames.filter((f) => f.id !== frame.id) ?? []

--- a/src/components/FrameView.tsx
+++ b/src/components/FrameView.tsx
@@ -7,7 +7,7 @@ import { sendWs } from '../lib/ws'
 import { throttle } from '../lib/throttle'
 import { getIdentity } from '../lib/identity'
 import { FRAME_BOOTSTRAP } from '../lib/frameRuntime'
-import { recordCreate, recordUpdate } from '../lib/history'
+import { recordCreate, recordUpdate, recordUpdates, trackSave } from '../lib/history'
 import { snapFrame } from '../lib/snap'
 import { gesture } from '../lib/gesture'
 import { FrameContextMenu } from './FrameContextMenu'
@@ -80,6 +80,8 @@ interface ProbeHit {
   rect: { x: number; y: number; width: number; height: number }
 }
 
+type DragRect = { id: string; x: number; y: number; width: number; height: number }
+
 interface HoverHit {
   tag: string
   rect: { x: number; y: number; width: number; height: number }
@@ -89,7 +91,10 @@ interface HoverHit {
    `--zoom` CSS variable the Stage sets, so a viewport change never re-renders
    this component — memo holds as long as the frame and raster are unchanged. */
 export const FrameView = memo(function FrameView({ frame, raster }: { frame: Frame; raster: number }) {
-  const selected = useStore((s) => s.selectedId === frame.id)
+  const selected = useStore((s) => s.selectedIds.includes(frame.id))
+  /* space held: the shield stays up even in edit mode, so the press reaches
+     the Stage and pans instead of vanishing into the editable iframe */
+  const panMode = useStore((s) => s.panMode)
   const select = useStore((s) => s.select)
   const flash = useStore((s) => s.flashes[frame.id])
   const stream = useStore((s) => s.streams[frame.id])
@@ -109,17 +114,40 @@ export const FrameView = memo(function FrameView({ frame, raster }: { frame: Fra
      lands in the store — otherwise a stale post would morph the edit away */
   const [suspendPost, setSuspendPost] = useState(false)
 
-  const sendDrag = useRef(
-    throttle((f: { id: string; x: number; y: number; width: number; height: number }) => {
-      sendWs({ type: 'frame:drag', frameId: f.id, x: f.x, y: f.y, width: f.width, height: f.height })
-    }, 50),
-  ).current
+  /* one throttle per frame, so a group drag broadcasts every member —
+     a single throttle would keep only the last frame written each tick */
+  const dragSenders = useRef(new Map<string, (f: DragRect) => void>()).current
+  function sendDrag(id: string, f: DragRect) {
+    let send = dragSenders.get(id)
+    if (!send) {
+      send = throttle((r: DragRect) => {
+        sendWs({ type: 'frame:drag', frameId: r.id, x: r.x, y: r.y, width: r.width, height: r.height })
+      }, 50)
+      dragSenders.set(id, send)
+    }
+    send(f)
+  }
 
   function startDrag(e: React.PointerEvent, mode: 'move' | 'resize', probeOnClick = false, panelOnClick = false) {
     if (e.button !== 0) return
+    /* space held: let the event reach the Stage, which pans */
+    if (useStore.getState().panMode) return
     e.stopPropagation()
     e.preventDefault()
-    select(frame.id)
+    /* ⌥⇧-drag duplicates: the moment the drag is real, leave a copy of the
+       frame at its origin and keep dragging this one — same net effect as
+       Figma's "drag off a duplicate", without retargeting the drag */
+    const duplicating = mode === 'move' && e.altKey && e.shiftKey
+    /* plain ⇧-click adds to (or drops from) the selection; a dropped frame
+       does not start a drag */
+    if (mode === 'move' && e.shiftKey && !e.altKey) {
+      useStore.getState().toggleSelect(frame.id)
+      if (!useStore.getState().selectedIds.includes(frame.id)) return
+    } else if (!useStore.getState().selectedIds.includes(frame.id)) {
+      /* clicking a frame already in a group keeps the group — the drag
+         moves all of them */
+      select(frame.id)
+    }
     setDragging(true)
     clearHover()
     const start = { x: e.clientX, y: e.clientY }
@@ -131,12 +159,15 @@ export const FrameView = memo(function FrameView({ frame, raster }: { frame: Fra
        the zoom it is now) rather than jumping by the pinch's displacement */
     let base = { x: start.x, y: start.y, rect: orig }
     let moved = false
-    /* ⌥⇧-drag duplicates: the moment the drag is real, leave a copy of the
-       frame at its origin and keep dragging this one — same net effect as
-       Figma's "drag off a duplicate", without retargeting the drag */
-    const duplicating = mode === 'move' && e.altKey && e.shiftKey
     let dupDropped = false
     if (duplicating) setDuping(true)
+    /* a move carries every selected frame along; a resize is this frame only */
+    const frames = useStore.getState().canvas?.frames ?? []
+    const selectedIds = mode === 'move' ? useStore.getState().selectedIds : [frame.id]
+    const group = frames
+      .filter((f) => selectedIds.includes(f.id))
+      .map((f) => ({ id: f.id, orig: { x: f.x, y: f.y, width: f.width, height: f.height } }))
+    const groupIds = new Set(group.map((g) => g.id))
 
     function onMove(ev: PointerEvent) {
       if (ev.pointerId !== e.pointerId) return
@@ -149,13 +180,17 @@ export const FrameView = memo(function FrameView({ frame, raster }: { frame: Fra
       if (Math.abs(ev.clientX - start.x) + Math.abs(ev.clientY - start.y) > 4) moved = true
       if (duplicating && moved && !dupDropped) {
         dupDropped = true
-        api
-          .createFrame(frame.canvasId, { name: frame.name, html: frame.html, ...orig })
-          .then((f) => {
-            posthog.capture('frame_duplicated', { via: 'drag' })
-            recordCreate(f)
-          })
-          .catch(console.error)
+        for (const g of group) {
+          const src = frames.find((f) => f.id === g.id)
+          if (!src) continue
+          api
+            .createFrame(src.canvasId, { name: src.name, html: src.html, ...g.orig })
+            .then((f) => {
+              posthog.capture('frame_duplicated', { via: 'drag' })
+              recordCreate(f)
+            })
+            .catch(console.error)
+        }
       }
       const zoom = useStore.getState().viewport.zoom
       const dx = (ev.clientX - base.x) / zoom
@@ -169,14 +204,26 @@ export const FrameView = memo(function FrameView({ frame, raster }: { frame: Fra
               width: Math.max(120, Math.round(from.width + dx)),
               height: Math.max(80, Math.round(from.height + dy)),
             }
-      /* edges pull onto neighbouring frames' edges/centers; ⌥ drags free */
-      const others = useStore.getState().canvas?.frames.filter((f) => f.id !== frame.id) ?? []
+      /* edges pull onto neighbouring frames' edges/centers; ⌥ drags free.
+         Frames riding along in the group are not neighbours. */
+      const others = useStore.getState().canvas?.frames.filter((f) => !groupIds.has(f.id)) ?? []
       const snapped = ev.altKey ? { ...raw, guides: [] } : snapFrame(mode, raw, others, zoom)
       useStore.getState().setSnapGuides(snapped.guides)
-      const patch = mode === 'move' ? { x: snapped.x, y: snapped.y } : { width: snapped.width, height: snapped.height }
-      useStore.getState().patchFrameLocal(frame.id, patch)
-      const f = useStore.getState().canvas?.frames.find((x) => x.id === frame.id)
-      if (f) sendDrag({ id: f.id, x: f.x, y: f.y, width: f.width, height: f.height })
+      if (mode === 'move') {
+        /* the snapped delta of the dragged frame moves the whole group */
+        const sdx = snapped.x - orig.x
+        const sdy = snapped.y - orig.y
+        for (const g of group) {
+          useStore.getState().patchFrameLocal(g.id, { x: g.orig.x + sdx, y: g.orig.y + sdy })
+        }
+      } else {
+        useStore.getState().patchFrameLocal(frame.id, { width: snapped.width, height: snapped.height })
+      }
+      const live = useStore.getState().canvas?.frames ?? []
+      for (const g of group) {
+        const f = live.find((x) => x.id === g.id)
+        if (f) sendDrag(f.id, { id: f.id, x: f.x, y: f.y, width: f.width, height: f.height })
+      }
     }
     function onUp() {
       window.removeEventListener('pointermove', onMove)
@@ -184,11 +231,17 @@ export const FrameView = memo(function FrameView({ frame, raster }: { frame: Fra
       setDragging(false)
       if (duplicating) setDuping(false)
       useStore.getState().setSnapGuides([])
-      const f = useStore.getState().canvas?.frames.find((x) => x.id === frame.id)
-      if (f) {
-        api.updateFrame(f.id, { x: f.x, y: f.y, width: f.width, height: f.height }).catch(console.error)
-        recordUpdate(f.id, orig, { x: f.x, y: f.y, width: f.width, height: f.height })
+      const live = useStore.getState().canvas?.frames ?? []
+      const updates: { frameId: string; before: typeof orig; after: typeof orig }[] = []
+      for (const g of group) {
+        const f = live.find((x) => x.id === g.id)
+        if (!f) continue
+        const after = { x: f.x, y: f.y, width: f.width, height: f.height }
+        trackSave(api.updateFrame(f.id, after).catch(console.error))
+        updates.push({ frameId: f.id, before: g.orig, after })
       }
+      if (updates.length === 1) recordUpdate(updates[0].frameId, updates[0].before, updates[0].after)
+      else recordUpdates(updates)
       /* a click (no drag) on the frame surface targets the element under
          the cursor: probe it and show the element toolbar */
       if (!moved && probeOnClick) probeAt(off.x, off.y)
@@ -433,8 +486,9 @@ export const FrameView = memo(function FrameView({ frame, raster }: { frame: Fra
         /* deferPanel: when this right-click is what selects the frame, the
            Inspector waits until the menu closes — it must not slide in
            underneath the menu the user just opened */
-        const alreadySelected = store.selectedId === frame.id
-        select(frame.id)
+        const alreadySelected = store.selectedIds.includes(frame.id)
+        /* a right-click inside a group keeps the group, so Delete takes all */
+        if (!alreadySelected) select(frame.id)
         closePopovers()
         store.openCtxMenu({ frameId: frame.id, deferPanel: !alreadySelected })
       }}
@@ -561,7 +615,7 @@ export const FrameView = memo(function FrameView({ frame, raster }: { frame: Fra
             )}
             {/* shield keeps pointer events on the canvas, not the iframe;
             lifted while editing so clicks land in the editable document */}
-            {!editing && <div className="absolute inset-0" />}
+            {(!editing || panMode) && <div className="absolute inset-0" />}
             {hover && !editing && !dragging && (
               <div
                 className="pointer-events-none absolute z-[3] bg-[rgba(60,130,246,0.06)] shadow-[inset_0_0_0_calc(1.5px/var(--zoom,1))_#3c82f6]"

--- a/src/components/Stage.tsx
+++ b/src/components/Stage.tsx
@@ -9,6 +9,7 @@ import { Cursors } from './Cursors'
 import { SnapGuides } from './SnapGuides'
 import { MOD_KEY } from '../lib/keys'
 import { cn } from '../lib/utils'
+import { gesture } from '../lib/gesture'
 import { hasFrameClip, pasteFrameAtScreen } from '../lib/frameClipboard'
 import { MenuHint } from './ui/menu'
 import { ContextMenu, ContextMenuContent, ContextMenuItem, ContextMenuTrigger } from './ui/context-menu'
@@ -217,6 +218,70 @@ export function Stage({ onAddFrame }: { onAddFrame: () => void }) {
     }
   }, [])
 
+  /* touch: a two-finger pinch zooms around the fingers' midpoint and pans
+     with it. iOS never maps a pinch onto ctrl+wheel the way desktop browsers
+     do, so it needs its own listener — on touch events rather than pointers,
+     because frames swallow pointerdown to start their own drag and a pinch
+     must win regardless of what the fingers landed on. */
+  useEffect(() => {
+    const el = ref.current
+    if (!el) return
+    let prev: { dist: number; x: number; y: number } | null = null
+
+    function pinchOf(touches: TouchList) {
+      const rect = el!.getBoundingClientRect()
+      const [a, b] = [touches[0], touches[1]]
+      return {
+        dist: Math.hypot(b.clientX - a.clientX, b.clientY - a.clientY),
+        x: (a.clientX + b.clientX) / 2 - rect.left,
+        y: (a.clientY + b.clientY) / 2 - rect.top,
+      }
+    }
+    function onStart(e: TouchEvent) {
+      if (e.touches.length < 2) return
+      e.preventDefault()
+      prev = pinchOf(e.touches)
+      gesture.pinching = true
+    }
+    function onMove(e: TouchEvent) {
+      if (!prev || e.touches.length < 2) return
+      e.preventDefault()
+      const cur = pinchOf(e.touches)
+      const vp = useStore.getState().viewport
+      const zoom = Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, vp.zoom * (cur.dist / Math.max(1, prev.dist))))
+      const scale = zoom / vp.zoom
+      /* the world point under the previous midpoint stays under the new one */
+      useStore.getState().setViewport({
+        x: cur.x - (prev.x - vp.x) * scale,
+        y: cur.y - (prev.y - vp.y) * scale,
+        zoom,
+      })
+      prev = cur
+    }
+    function onEnd(e: TouchEvent) {
+      /* three fingers down and one lifts: the pair that remains may not be
+         the pair being tracked, so measure it afresh instead of comparing
+         it against the old pair's spread */
+      if (e.touches.length >= 2) {
+        prev = pinchOf(e.touches)
+        return
+      }
+      prev = null
+      gesture.pinching = false
+    }
+    el.addEventListener('touchstart', onStart, { passive: false })
+    el.addEventListener('touchmove', onMove, { passive: false })
+    el.addEventListener('touchend', onEnd)
+    el.addEventListener('touchcancel', onEnd)
+    return () => {
+      el.removeEventListener('touchstart', onStart)
+      el.removeEventListener('touchmove', onMove)
+      el.removeEventListener('touchend', onEnd)
+      el.removeEventListener('touchcancel', onEnd)
+      gesture.pinching = false
+    }
+  }, [])
+
   /* ⌘0 → 100%, ⌘+ / ⌘− → step zoom, all pivoting on the view center —
      preventDefault keeps the browser's own page zoom out of it */
   useEffect(() => {
@@ -271,10 +336,14 @@ export function Stage({ onAddFrame }: { onAddFrame: () => void }) {
     let moved = false
 
     function onMove(ev: PointerEvent) {
+      if (ev.pointerId !== e.pointerId) return
       const dx = ev.clientX - last.x
       const dy = ev.clientY - last.y
       if (Math.abs(dx) + Math.abs(dy) > 2) moved = true
       last = { x: ev.clientX, y: ev.clientY }
+      /* a pinch owns the viewport while it lasts; keep tracking the finger
+         so the pan resumes from where it is, not from where the pinch began */
+      if (gesture.pinching) return
       const vp = useStore.getState().viewport
       useStore.getState().setViewport({ ...vp, x: vp.x + dx, y: vp.y + dy })
     }

--- a/src/components/Stage.tsx
+++ b/src/components/Stage.tsx
@@ -28,7 +28,10 @@ export function Stage({ onAddFrame }: { onAddFrame: () => void }) {
   const setViewport = useStore((s) => s.setViewport)
   const canvas = useStore((s) => s.canvas)
   const select = useStore((s) => s.select)
+  const panMode = useStore((s) => s.panMode)
   const [panning, setPanning] = useState(false)
+  /* the selection rectangle being dragged out, in world coordinates */
+  const [marquee, setMarquee] = useState<{ x: number; y: number; width: number; height: number } | null>(null)
   /* where the background menu opened, so Paste drops the frame there */
   const bgAt = useRef({ x: 0, y: 0 })
   /* iframe oversampling factor — bumped only once the zoom settles */
@@ -325,11 +328,47 @@ export function Stage({ onAddFrame }: { onAddFrame: () => void }) {
     }
   }
 
+  /* space bar → pan mode: the stage drags the viewport instead of drawing a
+     marquee, and frames let the press fall through to it. Held-space repeats
+     must not re-trigger, and typing in a field is never a pan. */
+  useEffect(() => {
+    function isTyping(e: KeyboardEvent) {
+      const t = e.target as HTMLElement
+      return t.tagName === 'INPUT' || t.tagName === 'TEXTAREA' || t.isContentEditable
+    }
+    function onDown(e: KeyboardEvent) {
+      if (e.key !== ' ' || isTyping(e)) return
+      e.preventDefault()
+      if (!useStore.getState().panMode) useStore.getState().setPanMode(true)
+    }
+    function onUp(e: KeyboardEvent) {
+      if (e.key === ' ') useStore.getState().setPanMode(false)
+    }
+    const reset = () => useStore.getState().setPanMode(false)
+    window.addEventListener('keydown', onDown)
+    window.addEventListener('keyup', onUp)
+    window.addEventListener('blur', reset)
+    return () => {
+      window.removeEventListener('keydown', onDown)
+      window.removeEventListener('keyup', onUp)
+      window.removeEventListener('blur', reset)
+      reset()
+    }
+  }, [])
+
   function onPointerDown(e: React.PointerEvent) {
-    /* pan on background drag or middle mouse anywhere */
     const isBackground = e.target === e.currentTarget || (e.target as HTMLElement).classList.contains('world')
-    if (!isBackground && e.button !== 1) return
-    if (e.button !== 0 && e.button !== 1) return
+    /* pan: middle mouse anywhere, space-drag anywhere, or a finger on the
+       background (touch has no space bar, and one-finger pan is how phones
+       move around) */
+    const pan = e.button === 1 || (e.button === 0 && (useStore.getState().panMode || e.pointerType === 'touch'))
+    if (pan) return startPan(e, isBackground)
+    /* left drag on the background draws a selection marquee */
+    if (e.button !== 0 || !isBackground) return
+    startMarquee(e)
+  }
+
+  function startPan(e: React.PointerEvent, isBackground: boolean) {
     e.currentTarget.setPointerCapture(e.pointerId)
     setPanning(true)
     let last = { x: e.clientX, y: e.clientY }
@@ -351,7 +390,49 @@ export function Stage({ onAddFrame }: { onAddFrame: () => void }) {
       window.removeEventListener('pointermove', onMove)
       window.removeEventListener('pointerup', onUp)
       setPanning(false)
-      if (!moved) select(null)
+      if (!moved && isBackground) select(null)
+    }
+    window.addEventListener('pointermove', onMove)
+    window.addEventListener('pointerup', onUp)
+  }
+
+  function startMarquee(e: React.PointerEvent) {
+    e.currentTarget.setPointerCapture(e.pointerId)
+    const origin = toWorld(e.clientX, e.clientY)
+    /* ⇧-marquee adds to what is already selected */
+    const keep = e.shiftKey ? useStore.getState().selectedIds : []
+    let moved = false
+
+    function onMove(ev: PointerEvent) {
+      const cur = toWorld(ev.clientX, ev.clientY)
+      const zoom = useStore.getState().viewport.zoom
+      if (Math.abs(cur.x - origin.x) * zoom + Math.abs(cur.y - origin.y) * zoom > 3) moved = true
+      if (!moved) return
+      const rect = {
+        x: Math.min(origin.x, cur.x),
+        y: Math.min(origin.y, cur.y),
+        width: Math.abs(cur.x - origin.x),
+        height: Math.abs(cur.y - origin.y),
+      }
+      setMarquee(rect)
+      const frames = useStore.getState().canvas?.frames ?? []
+      const hits = frames
+        .filter(
+          (f) =>
+            f.x < rect.x + rect.width &&
+            f.x + f.width > rect.x &&
+            f.y < rect.y + rect.height &&
+            f.y + f.height > rect.y,
+        )
+        .map((f) => f.id)
+      useStore.getState().selectMany([...keep, ...hits.filter((id) => !keep.includes(id))])
+    }
+    function onUp() {
+      window.removeEventListener('pointermove', onMove)
+      window.removeEventListener('pointerup', onUp)
+      setMarquee(null)
+      /* a plain click on empty canvas clears the selection */
+      if (!moved && !e.shiftKey) select(null)
     }
     window.addEventListener('pointermove', onMove)
     window.addEventListener('pointerup', onUp)
@@ -371,7 +452,14 @@ export function Stage({ onAddFrame }: { onAddFrame: () => void }) {
             /* `stage` is a behaviour hook, not a style: frameClipboard.ts queries
            `.stage` to map screen coordinates into the canvas. No CSS is
            attached to it — everything visual is in the utilities beside it. */
-            className={cn('stage absolute inset-0 touch-none', panning ? 'cursor-grabbing' : 'cursor-default')}
+            className={cn(
+              'stage absolute inset-0 touch-none',
+              panning
+                ? 'cursor-grabbing! [&_*]:cursor-grabbing!'
+                : panMode
+                  ? 'cursor-grab! [&_*]:cursor-grab!'
+                  : 'cursor-default',
+            )}
             onPointerDown={onPointerDown}
             onPointerMove={onPointerMove}
             onContextMenu={(e) => {
@@ -402,6 +490,12 @@ export function Stage({ onAddFrame }: { onAddFrame: () => void }) {
               <FlowOverlay />
               <SnapGuides />
               <Cursors />
+              {marquee && (
+                <div
+                  className="pointer-events-none absolute bg-brand/10 [box-shadow:inset_0_0_0_calc(1px/var(--zoom,1))_var(--brand)]"
+                  style={{ left: marquee.x, top: marquee.y, width: marquee.width, height: marquee.height }}
+                />
+              )}
             </div>
           </div>
         </ContextMenuTrigger>

--- a/src/components/ui/modal.tsx
+++ b/src/components/ui/modal.tsx
@@ -4,17 +4,17 @@ import { cva, type VariantProps } from 'class-variance-authority'
 
 import { cn } from '@/lib/utils'
 
-/* Doop's modal: a hard-shadowed card on a dimmed canvas. Built on Radix so it
-   brings a focus trap, Escape and scroll-locking with it — the hand-rolled
-   backdrop divs it replaces had none of that. Call sites mount it
-   conditionally, so `open` defaults to true and `onClose` is the only
-   dismissal wiring they need. */
+/* Doop's modal: a hairline card lifted on the soft pop shadow, over a dimmed
+   canvas. Built on Radix so it brings a focus trap, Escape and scroll-locking
+   with it — the hand-rolled backdrop divs it replaces had none of that. Call
+   sites mount it conditionally, so `open` defaults to true and `onClose` is
+   the only dismissal wiring they need. */
 const modalVariants = cva(
   [
     'fixed left-1/2 top-1/2 z-[60] w-full -translate-x-1/2 -translate-y-1/2 overflow-y-auto',
-    'rounded-[14px] border border-ink bg-surface p-5 text-ink shadow-[4px_4px_0_rgba(18,18,23,0.9)]',
+    'rounded-[14px] border border-line bg-surface p-5 text-ink shadow-pop',
     'animate-[modal-in_0.2s_cubic-bezier(0.2,0.9,0.3,1.2)] outline-none',
-    'max-h-[calc(100dvh-24px)] sm:max-h-[calc(100vh-96px)] sm:rounded-[16px] sm:p-7 sm:shadow-[8px_8px_0_rgba(18,18,23,0.9)]',
+    'max-h-[calc(100dvh-24px)] sm:max-h-[calc(100vh-96px)] sm:rounded-[16px] sm:p-7',
   ],
   {
     variants: {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -74,9 +74,12 @@ export interface RepoManifest {
   truncated: boolean
 }
 
+/** An import queues board cards — nothing lands on the canvas until the
+ *  Doop Agent finishes each one. `rejected` lists selections the server no
+ *  longer finds in the repo manifest. */
 export interface GithubImportResult {
-  frames: Frame[]
-  failures: { route: string; error: string }[]
+  cards: string[]
+  rejected: string[]
 }
 
 export interface DiscoveredPage {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -295,6 +295,8 @@ export const api = {
     req(`/api/canvases/${canvasId}/cards/${cardId}/retry`, { method: 'POST' }),
   addComment: (frameId: string, input: { selector: string; snippet: string; text: string }) =>
     req(`/api/frames/${frameId}/comments`, { method: 'POST', body: JSON.stringify(input) }),
+  replyComment: (commentId: string, text: string) =>
+    req(`/api/comments/${commentId}/replies`, { method: 'POST', body: JSON.stringify({ text }) }),
   resolveComment: (commentId: string) => req(`/api/comments/${commentId}/resolve`, { method: 'POST' }),
   retryComment: (commentId: string) => req(`/api/comments/${commentId}/retry`, { method: 'POST' }),
   retryTaskFeedback: (feedbackId: string) => req(`/api/feedback/${feedbackId}/retry`, { method: 'POST' }),

--- a/src/lib/gesture.ts
+++ b/src/lib/gesture.ts
@@ -1,0 +1,6 @@
+/* Cross-component gesture state that never renders. A two-finger pinch on
+   the stage has to silence whatever single-pointer drag the first finger
+   started (a canvas pan, a frame move), and those drags live in other
+   components — so the flag is a plain module value they can read on every
+   pointermove without subscribing to anything. */
+export const gesture = { pinching: false }

--- a/src/lib/history.ts
+++ b/src/lib/history.ts
@@ -14,6 +14,9 @@ type Entry =
   | { type: 'update'; frameId: string; before: Patch; after: Patch; at: number }
   | { type: 'create'; frameId: string; snapshot: Snapshot }
   | { type: 'delete'; frameId: string; snapshot: Snapshot }
+  /* one multi-frame action (a group move, a group delete): undone and
+     redone as a unit */
+  | { type: 'group'; entries: Entry[] }
 
 const MAX = 100
 /* consecutive edits to the same fields land as one entry within this window
@@ -23,6 +26,13 @@ const COALESCE_MS = 1500
 let undoStack: Entry[] = []
 let redoStack: Entry[] = []
 let busy = false
+/* saves still in flight from a drag: undo/redo wait for them so the inverse
+   write never lands before (and gets overwritten by) the original */
+let inflight: Promise<unknown> = Promise.resolve()
+
+export function trackSave(p: Promise<unknown>) {
+  inflight = inflight.then(() => p.catch(() => undefined))
+}
 
 export function clearHistory() {
   undoStack = []
@@ -39,15 +49,24 @@ function snapshot(f: Frame): Snapshot {
   return { canvasId: f.canvasId, name: f.name, html: f.html, x: f.x, y: f.y, width: f.width, height: f.height }
 }
 
-export function recordUpdate(frameId: string, before: Patch, after: Patch) {
+type UpdateEntry = Extract<Entry, { type: 'update' }>
+
+function updateEntry(frameId: string, before: Patch, after: Patch): UpdateEntry | null {
   const keys = (Object.keys(after) as (keyof Patch)[]).filter((k) => before[k] !== after[k])
-  if (!keys.length) return
+  if (!keys.length) return null
   const b: Patch = {}
   const a: Patch = {}
   for (const k of keys) {
     b[k] = before[k] as never
     a[k] = after[k] as never
   }
+  return { type: 'update', frameId, before: b, after: a, at: Date.now() }
+}
+
+export function recordUpdate(frameId: string, before: Patch, after: Patch) {
+  const entry = updateEntry(frameId, before, after)
+  if (!entry) return
+  const keys = Object.keys(entry.after) as (keyof Patch)[]
   const top = undoStack[undoStack.length - 1]
   if (
     top?.type === 'update' &&
@@ -56,12 +75,19 @@ export function recordUpdate(frameId: string, before: Patch, after: Patch) {
     keys.every((k) => k in top.after)
   ) {
     /* merge a burst of saves: keep the oldest before, the newest after */
-    top.after = { ...top.after, ...a }
+    top.after = { ...top.after, ...entry.after }
     top.at = Date.now()
     redoStack = []
     return
   }
-  push({ type: 'update', frameId, before: b, after: a, at: Date.now() })
+  push(entry)
+}
+
+/** Several frames moved together (a group drag): one undo step. */
+export function recordUpdates(items: { frameId: string; before: Patch; after: Patch }[]) {
+  const entries = items.map((i) => updateEntry(i.frameId, i.before, i.after)).filter((e): e is UpdateEntry => !!e)
+  if (entries.length === 1) push(entries[0])
+  else if (entries.length) push({ type: 'group', entries })
 }
 
 export function recordCreate(frame: Frame) {
@@ -70,16 +96,25 @@ export function recordCreate(frame: Frame) {
 
 /** Delete a frame through the API, remembering enough to bring it back. */
 export function deleteFrameTracked(frame: Frame) {
-  push({ type: 'delete', frameId: frame.id, snapshot: snapshot(frame) })
-  api.deleteFrame(frame.id).catch(console.error)
+  deleteFramesTracked([frame])
+}
+
+/** Delete several frames as one undo step. */
+export function deleteFramesTracked(frames: Frame[]) {
+  if (!frames.length) return
+  const entries: Entry[] = frames.map((f) => ({ type: 'delete', frameId: f.id, snapshot: snapshot(f) }))
+  push(entries.length === 1 ? entries[0] : { type: 'group', entries })
+  for (const f of frames) api.deleteFrame(f.id).catch(console.error)
 }
 
 /* undoing a delete recreates the frame under a fresh server id — every
    other entry that pointed at the old id must follow it */
 function remapId(oldId: string, newId: string) {
-  for (const e of [...undoStack, ...redoStack]) {
-    if (e.frameId === oldId) e.frameId = newId
+  const visit = (e: Entry) => {
+    if (e.type === 'group') e.entries.forEach(visit)
+    else if (e.frameId === oldId) e.frameId = newId
   }
+  for (const e of [...undoStack, ...redoStack]) visit(e)
 }
 
 async function recreate(e: { frameId: string; snapshot: Snapshot }) {
@@ -90,49 +125,64 @@ async function recreate(e: { frameId: string; snapshot: Snapshot }) {
   useStore.getState().select(f.id)
 }
 
-export async function undo() {
+/* Apply an entry and report which of its members took effect. A group's
+   frames are independent, so every member is attempted even if one fails;
+   the survivors are what the opposite stack gets, so a partially failed
+   group can still be reversed. Failed members are dropped, exactly as a
+   failed single entry is: the frame is gone or the canvas moved on. */
+async function apply(e: Entry, direction: 'undo' | 'redo'): Promise<Entry | null> {
+  if (e.type === 'group') {
+    const results = await Promise.allSettled(e.entries.map((child) => apply(child, direction)))
+    const ok = results.flatMap((r) => (r.status === 'fulfilled' && r.value ? [r.value] : []))
+    const failed = results.find((r): r is PromiseRejectedResult => r.status === 'rejected')
+    if (failed) console.error(`${direction} failed for ${e.entries.length - ok.length} frame(s)`, failed.reason)
+    return ok.length === 0 ? null : ok.length === 1 ? ok[0] : { type: 'group', entries: ok }
+  }
+  const forward = direction === 'redo'
+  if (e.type === 'update') {
+    const patch = forward ? e.after : e.before
+    useStore.getState().patchFrameLocal(e.frameId, patch)
+    try {
+      await api.updateFrame(e.frameId, patch)
+    } catch (err) {
+      /* the server kept the old value — put the local copy back in step
+         with it rather than leave a client-only position behind */
+      useStore.getState().patchFrameLocal(e.frameId, forward ? e.before : e.after)
+      throw err
+    }
+  } else if ((e.type === 'create') === forward) {
+    await recreate(e)
+  } else {
+    await api.deleteFrame(e.frameId)
+  }
+  return e
+}
+
+async function step(direction: 'undo' | 'redo') {
   if (busy) return
-  const e = undoStack.pop()
+  const [from, to] = direction === 'undo' ? [undoStack, redoStack] : [redoStack, undoStack]
+  const e = from.pop()
   if (!e) return
   busy = true
   try {
-    if (e.type === 'update') {
-      useStore.getState().patchFrameLocal(e.frameId, e.before)
-      await api.updateFrame(e.frameId, e.before)
-    } else if (e.type === 'create') {
-      await api.deleteFrame(e.frameId)
-    } else {
-      await recreate(e)
+    await inflight
+    const applied = await apply(e, direction)
+    if (applied) {
+      to.push(applied)
+      posthog.capture(direction === 'undo' ? 'canvas_undo' : 'canvas_redo')
     }
-    redoStack.push(e)
-    posthog.capture('canvas_undo')
   } catch (err) {
     /* the frame is gone or the canvas moved on — drop the entry */
-    console.error('undo failed', err)
+    console.error(`${direction} failed`, err)
   } finally {
     busy = false
   }
 }
 
-export async function redo() {
-  if (busy) return
-  const e = redoStack.pop()
-  if (!e) return
-  busy = true
-  try {
-    if (e.type === 'update') {
-      useStore.getState().patchFrameLocal(e.frameId, e.after)
-      await api.updateFrame(e.frameId, e.after)
-    } else if (e.type === 'create') {
-      await recreate(e)
-    } else {
-      await api.deleteFrame(e.frameId)
-    }
-    undoStack.push(e)
-    posthog.capture('canvas_redo')
-  } catch (err) {
-    console.error('redo failed', err)
-  } finally {
-    busy = false
-  }
+export function undo() {
+  return step('undo')
+}
+
+export function redo() {
+  return step('redo')
 }

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -38,7 +38,14 @@ interface State {
   /** which tab the side panel shows — in the store so a Memory-suggestion
    *  toast anywhere in the app can jump straight to the Memory tab */
   panelTab: 'tasks' | 'activity' | 'memory'
+  /** every selected frame, in selection order — marquee and ⇧-click build
+   *  this up; a plain click collapses it to one */
+  selectedIds: string[]
+  /** the primary selection (the last frame added) — what the Inspector,
+   *  presence, and the flow overlay follow */
   selectedId: string | null
+  /** space bar held: the stage pans on drag instead of drawing a marquee */
+  panMode: boolean
   /** the Inspector panel is showing — opened by clicking a frame's name, not
    *  by mere selection, so clicking around a frame doesn't slide the panel in */
   inspectorOpen: boolean
@@ -99,6 +106,11 @@ interface State {
   allowanceChanged(): void
   requestFlyTo(frameId: string): void
   select(id: string | null): void
+  /** ⇧-click: add the frame to the selection, or drop it if already in */
+  toggleSelect(id: string): void
+  /** marquee: replace the selection with these frames */
+  selectMany(ids: string[]): void
+  setPanMode(v: boolean): void
   setInspectorOpen(v: boolean): void
   openCtxMenu(menu: { frameId: string; deferPanel: boolean }): void
   closeCtxMenu(): void
@@ -122,7 +134,9 @@ export const useStore = create<State>((set, get) => ({
   limitWall: false,
   allowanceVersion: 0,
   flyTo: null,
+  selectedIds: [],
   selectedId: null,
+  panMode: false,
   inspectorOpen: false,
   ctxMenu: null,
   viewport: { x: 0, y: 0, zoom: 1 },
@@ -206,9 +220,15 @@ export const useStore = create<State>((set, get) => ({
   removeFrame: (frameId) =>
     set((s) => {
       if (!s.canvas) return {}
+      const selectedIds = s.selectedIds.filter((id) => id !== frameId)
       return {
         canvas: { ...s.canvas, frames: s.canvas.frames.filter((f) => f.id !== frameId) },
-        selectedId: s.selectedId === frameId ? null : s.selectedId,
+        selectedIds,
+        /* losing the primary promotes the last surviving member, so a group
+           never sits selected with nothing driving the Inspector/presence */
+        selectedId: s.selectedId === frameId ? (selectedIds[selectedIds.length - 1] ?? null) : s.selectedId,
+        /* an open Inspector must not silently retarget onto the promoted frame */
+        inspectorOpen: s.selectedId === frameId ? false : s.inspectorOpen,
         ctxMenu: s.ctxMenu?.frameId === frameId ? null : s.ctxMenu,
       }
     }),
@@ -256,7 +276,24 @@ export const useStore = create<State>((set, get) => ({
      panel must not follow surface clicks, paste, or undo onto another frame.
      Re-selecting the same frame keeps an open panel open. */
   select: (selectedId) =>
-    set((s) => (s.selectedId === selectedId ? { selectedId } : { selectedId, inspectorOpen: false })),
+    set((s) => {
+      const selectedIds = selectedId ? [selectedId] : []
+      return s.selectedId === selectedId
+        ? { selectedId, selectedIds }
+        : { selectedId, selectedIds, inspectorOpen: false }
+    }),
+  toggleSelect: (id) =>
+    set((s) => {
+      const selectedIds = s.selectedIds.includes(id) ? s.selectedIds.filter((x) => x !== id) : [...s.selectedIds, id]
+      const selectedId = selectedIds[selectedIds.length - 1] ?? null
+      return selectedId === s.selectedId ? { selectedIds } : { selectedIds, selectedId, inspectorOpen: false }
+    }),
+  selectMany: (ids) =>
+    set((s) => {
+      const selectedId = ids[ids.length - 1] ?? null
+      return selectedId === s.selectedId ? { selectedIds: ids } : { selectedIds: ids, selectedId, inspectorOpen: false }
+    }),
+  setPanMode: (panMode) => set({ panMode }),
   setInspectorOpen: (inspectorOpen) => set({ inspectorOpen }),
   openCtxMenu: (ctxMenu) => set({ ctxMenu }),
   closeCtxMenu: () => set({ ctxMenu: null }),

--- a/src/pages/CanvasPage.tsx
+++ b/src/pages/CanvasPage.tsx
@@ -19,7 +19,7 @@ import { Board } from '../components/Board'
 import { Inspector } from '../components/Inspector'
 import { ActivityPanel } from '../components/ActivityPanel'
 import { ConnectModal } from '../components/ConnectModal'
-import { LimitWall } from '../components/TeamAllowance'
+import { LimitWall, isResidentLimit } from '../components/TeamAllowance'
 import { PromptBar } from '../components/PromptBar'
 import { WorkingNow } from '../components/WorkingNow'
 import { Onboarding } from '../components/Onboarding'
@@ -519,13 +519,14 @@ export function CanvasPage({ canvasId }: { canvasId: string }) {
             setShowImport(false)
             setView('canvas')
             select(frameIds[0] ?? null)
-            const imported =
-              frameIds.length === 0
-                ? 'Doop is importing the design system — watch the canvas'
-                : frameIds.length === 1
-                  ? '1 item imported'
-                  : `${frameIds.length} items imported`
+            const imported = frameIds.length === 1 ? '1 item imported' : `${frameIds.length} items imported`
             showToast(failedCount ? `${imported} · ${failedCount} failed` : imported)
+          }}
+          onQueued={(cardCount) => {
+            setShowImport(false)
+            setGhInstallPass(null)
+            setView('board')
+            showToast(`${cardCount} ${cardCount === 1 ? 'card' : 'cards'} queued — Doop is on it`)
           }}
         />
       )}
@@ -547,12 +548,15 @@ function ImportModal({
   installError,
   onClose,
   onDone,
+  onQueued,
 }: {
   canvasId: string
   installPass: string | null
   installError: string | null
   onClose: () => void
   onDone: (frameIds: string[], failedCount: number) => void
+  /** a repo import queues cards on the board instead of landing frames */
+  onQueued: (cardCount: number) => void
 }) {
   const [url, setUrl] = useState('')
   const [wholeSite, setWholeSite] = useState(false)
@@ -674,22 +678,27 @@ function ImportModal({
     const screens = repoReview.manifest.screens.filter((s) => repoSelected.has(screenKey(s)))
     try {
       const result = await api.importGithubScreens(canvasId, repoReview.connection.id, screens, extractSystem)
-      if (!result.frames.length && screens.length) {
-        const reason = result.failures[0]?.error
-        setError(reason ? `No screens could be imported — ${reason}` : 'No screens could be imported')
+      if (!result.cards.length) {
+        setError(
+          result.rejected.length
+            ? 'Those screens are no longer in the repository — re-run the scan'
+            : 'Everything you picked is already on the board',
+        )
         setBusy(null)
         return
       }
       posthog.capture('github_screens_imported', {
         requested_count: screens.length,
-        imported_count: result.frames.length,
-        failed_count: result.failures.length,
+        queued_count: result.cards.length,
+        rejected_count: result.rejected.length,
       })
-      onDone(
-        result.frames.map((frame) => frame.id),
-        result.failures.length,
-      )
+      onQueued(result.cards.length)
     } catch (e) {
+      if (isResidentLimit(e)) {
+        useStore.getState().setLimitWall(true)
+        onClose()
+        return
+      }
       setError(errorMessage(e, 'repository import failed'))
       setBusy(null)
     }
@@ -725,8 +734,9 @@ function ImportModal({
             </div>
             <ModalLede>
               {repoReview.manifest.framework ? `A ${repoReview.manifest.framework} app. ` : ''}Doop distills the repo's
-              design system into a style guide pinned to this canvas — every agent follows it from then on. Components
-              come along as sketched library cards; whole pages are optional.
+              design system into a style guide pinned to this canvas — every agent follows it from then on. Each
+              component or page you pick becomes a card on the board: Doop sketches it from the source and lands it as a
+              frame. Whole pages are optional.
             </ModalLede>
             <CheckboxCard
               checked={extractSystem}
@@ -738,11 +748,6 @@ function ImportModal({
             <div className="mt-4 flex items-center justify-between px-[2px] pb-[9px]">
               <b className="text-[12px] text-ink-soft">
                 {repoSelected.size} of {visibleScreens.length} selected
-                {repoSelected.size > 12 && (
-                  <span className="ml-2 font-normal text-ink-faint">
-                    — Doop sketches 12 per import; the rest stay outlines
-                  </span>
-                )}
               </b>
               <span className="flex gap-3">
                 <Button

--- a/src/pages/CanvasPage.tsx
+++ b/src/pages/CanvasPage.tsx
@@ -27,7 +27,7 @@ import { ShareModal } from '../components/ShareModal'
 import { BrainIcon } from '../components/BrainIcon'
 import { getIdentity, setName } from '../lib/identity'
 import { copyFrame, duplicateFrame, hasFrameClip, pasteFrameCentered, pasteImagesCentered } from '../lib/frameClipboard'
-import { clearHistory, deleteFrameTracked, recordCreate, redo, undo } from '../lib/history'
+import { clearHistory, deleteFramesTracked, recordCreate, redo, undo } from '../lib/history'
 import { authClient } from '../lib/auth'
 import { posthog } from '../lib/posthog'
 import { useIsMobile } from '../hooks/use-mobile'
@@ -132,10 +132,11 @@ export function CanvasPage({ canvasId }: { canvasId: string }) {
       const t = e.target as HTMLElement
       if (t.tagName === 'INPUT' || t.tagName === 'TEXTAREA' || t.isContentEditable) return
       const sel = useStore.getState().selectedId
-      if ((e.key === 'Delete' || e.key === 'Backspace') && sel) {
+      const selectedIds = useStore.getState().selectedIds
+      if ((e.key === 'Delete' || e.key === 'Backspace') && selectedIds.length) {
         e.preventDefault()
-        const frame = useStore.getState().canvas?.frames.find((f) => f.id === sel)
-        if (frame) deleteFrameTracked(frame)
+        const frames = useStore.getState().canvas?.frames.filter((f) => selectedIds.includes(f.id)) ?? []
+        deleteFramesTracked(frames)
       }
       if (e.key === 'Escape') select(null)
       if ((e.metaKey || e.ctrlKey) && !e.altKey && e.key.toLowerCase() === 'z') {

--- a/tests/commentReplies.test.ts
+++ b/tests/commentReplies.test.ts
@@ -1,0 +1,124 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Frame } from '../shared/types.ts'
+
+/* Replies are persisted and broadcast like any comment; the unit tests only
+   care about how a thread is shaped, so both sides are stubbed. */
+vi.mock('../server/db/persist.ts', () => ({
+  saveTask: () => {},
+  saveFeedback: () => {},
+  saveComment: () => {},
+  saveActivity: () => {},
+  saveDecision: () => {},
+  saveProposal: () => {},
+}))
+
+const actions = await import('../server/actions.ts')
+const { store } = await import('../server/store.ts')
+const { DEFAULT_ROLE_ID, roleName } = await import('../shared/agents.ts')
+
+const AGENT = roleName(DEFAULT_ROLE_ID)
+const CANVAS = 'canvas-1'
+const FRAME: Frame = {
+  id: 'f1',
+  canvasId: CANVAS,
+  name: 'Hero',
+  html: '<p/>',
+  x: 0,
+  y: 0,
+  width: 10,
+  height: 10,
+  createdAt: 0,
+  updatedAt: 0,
+  updatedBy: 'alice',
+}
+
+beforeEach(() => {
+  actions.wire(
+    () => {},
+    () => {},
+  )
+  actions.hydrateLogs({
+    tasks: new Map(),
+    feedback: new Map(),
+    comments: new Map([[CANVAS, []]]),
+    activity: new Map(),
+    decisions: new Map(),
+    proposals: new Map(),
+  })
+  vi.spyOn(store, 'getFrame').mockImplementation((id) => (id === FRAME.id ? FRAME : undefined))
+})
+
+function root() {
+  return actions.addElementComment(
+    FRAME.id,
+    { selector: '.hero h1', snippet: '<h1>Hi</h1>', text: 'Too small' },
+    'alice',
+  )!
+}
+
+describe('replying to a comment', () => {
+  it('threads the reply under the root and inherits its element', () => {
+    const parent = root()
+    const reply = actions.replyToComment(parent.id, 'Agreed', 'bob')!
+    expect(reply.parentId).toBe(parent.id)
+    expect(reply.selector).toBe(parent.selector)
+    expect(reply.snippet).toBe(parent.snippet)
+    expect(actions.commentThread(reply).map((c) => c.text)).toEqual(['Too small', 'Agreed'])
+  })
+
+  it('gives every message a distinct timestamp so order survives a reload', () => {
+    const parent = root()
+    const first = actions.replyToComment(parent.id, 'one', 'bob')!
+    const second = actions.replyToComment(parent.id, 'two', 'carol')!
+    expect(first.at).toBeGreaterThan(parent.at)
+    expect(second.at).toBeGreaterThan(first.at)
+  })
+
+  it('re-roots a reply to a reply, keeping threads one level deep', () => {
+    const parent = root()
+    const first = actions.replyToComment(parent.id, 'Agreed', 'bob')!
+    const second = actions.replyToComment(first.id, 'Same', 'carol')!
+    expect(second.parentId).toBe(parent.id)
+    expect(actions.commentThread(parent).map((c) => c.from)).toEqual(['alice', 'bob', 'carol'])
+  })
+
+  it('routes an @mention in a reply to the agent with the thread anchor', () => {
+    const parent = root()
+    const reply = actions.replyToComment(parent.id, `@${DEFAULT_ROLE_ID} make it 48px`, 'alice', 'alice')!
+    expect(reply.forAgent).toBe(true)
+    expect(reply.targetAgent).toBe(AGENT)
+    expect(actions.takeAgentCommentsFor(CANVAS, AGENT, 'alice').map((c) => c.id)).toEqual([reply.id])
+  })
+
+  it('reports whether a thread can take a reply before anything is metered', () => {
+    const parent = root()
+    const reply = actions.replyToComment(parent.id, 'Agreed', 'bob')!
+    expect(actions.openThread(reply.id)?.root.id).toBe(parent.id)
+    actions.resolveComment(parent.id, 'alice')
+    expect(actions.openThread(reply.id)).toBeUndefined()
+    expect(actions.openThread('missing')).toBeUndefined()
+  })
+
+  it('refuses replies on a resolved thread or with empty text', () => {
+    const parent = root()
+    expect(actions.replyToComment(parent.id, '   ', 'bob')).toBeUndefined()
+    actions.resolveComment(parent.id, 'alice')
+    expect(actions.replyToComment(parent.id, 'Late', 'bob')).toBeUndefined()
+    expect(actions.replyToComment('missing', 'Hello', 'bob')).toBeUndefined()
+  })
+
+  it('resolving the root closes every open reply so none stays queued for an agent', () => {
+    const parent = root()
+    const reply = actions.replyToComment(parent.id, `@${DEFAULT_ROLE_ID} bigger`, 'alice', 'alice')!
+    actions.resolveComment(parent.id, 'alice')
+    expect(actions.findComment(reply.id)?.resolvedAt).toBeDefined()
+    expect(actions.takeAgentCommentsFor(CANVAS, AGENT, 'alice')).toEqual([])
+  })
+
+  it('resolving a reply leaves the thread open', () => {
+    const parent = root()
+    const reply = actions.replyToComment(parent.id, `@${DEFAULT_ROLE_ID} bigger`, 'alice', 'alice')!
+    actions.resolveComment(reply.id, AGENT)
+    expect(actions.findComment(parent.id)?.resolvedAt).toBeUndefined()
+  })
+})

--- a/tests/github.test.ts
+++ b/tests/github.test.ts
@@ -1,13 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import {
-  detectFramework,
-  detectScreens,
-  githubFrameMarker,
-  isGithubPlaceholderHtml,
-  matchSelection,
-  placeholderHtml,
-  wrapRepoHtml,
-} from '../server/github.ts'
+import { detectFramework, detectScreens, githubFrameMarker, matchSelection, wrapRepoHtml } from '../server/github.ts'
 
 /**
  * The GitHub import source's pure core: screen enumeration from framework
@@ -106,18 +98,6 @@ describe('provenance marker', () => {
     expect(html).not.toContain('onload')
     expect(html).toContain('Content-Security-Policy')
     expect(html).toContain('https://raw.githubusercontent.com/acme/app/main/public/')
-    expect(isGithubPlaceholderHtml(html)).toBe(false)
-  })
-
-  it('marks placeholders as such, still carrying the screen marker', () => {
-    const html = placeholderHtml(conn, {
-      kind: 'page',
-      route: '/dashboard',
-      sourcePath: 'app/dashboard/page.tsx',
-      title: 'Dashboard',
-    })
-    expect(isGithubPlaceholderHtml(html)).toBe(true)
-    expect(githubFrameMarker(html)?.route).toBe('/dashboard')
   })
 
   it('returns undefined for unmarked frames', () => {

--- a/tests/githubRecon.test.ts
+++ b/tests/githubRecon.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from 'vitest'
-import { extractHtml, resolveImport, treeExcerpt } from '../server/githubRecon.ts'
+import {
+  designSystemSlug,
+  extractHtml,
+  nextRepoFramePosition,
+  resolveImport,
+  treeExcerpt,
+} from '../server/githubRecon.ts'
+import { wrapGeneratedHtml } from '../server/github.ts'
 
 /** The reconstruction pass's pure core: import resolution against a repo
  *  tree, and pulling the HTML document (+ declared height) out of a model
@@ -81,5 +88,52 @@ describe('repo asset references', () => {
   it('extractHtml raises the height ceiling for full pages', () => {
     const { height } = extractHtml([{ type: 'text', text: '<!doctype html><p>x</p>\n<!-- doop-height: 6600 -->' }])
     expect(height).toBe(6600)
+  })
+})
+
+describe('nextRepoFramePosition', () => {
+  const CONN = 'conn-1'
+  const marked = (x: number, y: number, width: number, height: number, conn = CONN) => ({
+    x,
+    y,
+    width,
+    height,
+    html: wrapGeneratedHtml(
+      '<html><head></head><body>x</body></html>',
+      { id: conn, repo: 'a/b', branch: 'main' },
+      {
+        kind: 'component',
+        route: 'src/Button.tsx',
+        sourcePath: 'src/Button.tsx',
+      },
+    ),
+  })
+  const plain = (x: number, y: number, width: number, height: number) => ({ x, y, width, height, html: '<p/>' })
+
+  it('starts the import right of everything on the canvas, or at the origin on an empty one', () => {
+    expect(nextRepoFramePosition([], CONN, 640)).toEqual({ x: 120, y: 120 })
+    expect(nextRepoFramePosition([plain(100, 300, 1000, 500)], CONN, 640)).toEqual({ x: 1180, y: 120 })
+  })
+
+  it('flows siblings into the current row while it fits, then wraps under everything', () => {
+    const frames = [plain(100, 300, 1000, 500), marked(1180, 120, 640, 420)]
+    expect(nextRepoFramePosition(frames, CONN, 640)).toEqual({ x: 1900, y: 120 })
+    const fullRow = [
+      marked(120, 120, 1280, 900),
+      marked(1480, 120, 1280, 700),
+      /* a taller frame in the row decides where the next row starts */
+    ]
+    expect(nextRepoFramePosition(fullRow, CONN, 1280)).toEqual({ x: 120, y: 1100 })
+  })
+
+  it('only counts frames from the same connection as siblings', () => {
+    const frames = [marked(120, 120, 640, 420, 'other-conn')]
+    expect(nextRepoFramePosition(frames, CONN, 640)).toEqual({ x: 840, y: 120 })
+  })
+})
+
+describe('designSystemSlug', () => {
+  it('names the guide after the repository', () => {
+    expect(designSystemSlug('acme/Web.App')).toBe('web-app-design-system')
   })
 })

--- a/tests/repoCards.test.ts
+++ b/tests/repoCards.test.ts
@@ -1,0 +1,156 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { RepoScreenRef } from '../shared/types.ts'
+
+/* Same stubs as residentQueue.test.ts: the queue mirrors into Postgres and
+   broadcasts; a unit test only cares about the cards themselves. */
+vi.mock('../server/db/persist.ts', () => ({
+  saveTask: () => {},
+  saveFeedback: () => {},
+  saveComment: () => {},
+  saveActivity: () => {},
+  saveDecision: () => {},
+  saveProposal: () => {},
+  saveCanvas: () => {},
+}))
+
+const actions = await import('../server/actions.ts')
+const { store } = await import('../server/store.ts')
+const { DEFAULT_ROLE_ID, roleName } = await import('../shared/agents.ts')
+
+const AGENT = roleName(DEFAULT_ROLE_ID)
+
+/**
+ * The GitHub import queues one structured card per screen (plus the
+ * design-system extraction) instead of landing outline frames. These tests
+ * pin what the import route relies on: ordering, de-duplication against cards
+ * already on the board, and that the cards claim like any other board card
+ * while carrying what the runner needs.
+ */
+
+const button: RepoScreenRef = {
+  kind: 'component',
+  route: 'src/ui/Button.tsx',
+  sourcePath: 'src/ui/Button.tsx',
+  title: 'Button',
+  source: 'placeholder',
+}
+const pricing: RepoScreenRef = {
+  kind: 'page',
+  route: '/pricing',
+  sourcePath: 'app/pricing/page.tsx',
+  title: 'Pricing',
+  source: 'placeholder',
+}
+
+let canvasId: string
+
+beforeEach(() => {
+  actions.hydrateLogs({
+    tasks: new Map(),
+    feedback: new Map(),
+    comments: new Map(),
+    activity: new Map(),
+    decisions: new Map(),
+    proposals: new Map(),
+  })
+  canvasId = store.createCanvas('repo cards', 'kevin').id
+})
+
+describe('addRepoCards', () => {
+  it('queues the design system first, then one sketch card per screen, all for Doop', () => {
+    const cards = actions.addRepoCards(
+      canvasId,
+      { connectionId: 'conn-1', repo: 'acme/app', screens: [button, pricing], designSystem: true },
+      'kevin',
+      'user-1',
+    )
+    expect(cards.map((c) => c.kind)).toEqual(['design-system', 'sketch', 'sketch'])
+    expect(cards.map((c) => c.status)).toEqual(['Design system of acme/app', 'Button', 'Pricing'])
+    expect(cards.every((c) => c.queuedBy === 'kevin' && c.queuedByUserId === 'user-1' && !c.agentName)).toBe(true)
+    expect(cards[1]!.payload).toEqual({
+      connectionId: 'conn-1',
+      repo: 'acme/app',
+      importId: cards[0]!.payload!.importId,
+      screen: button,
+    })
+    /* oldest first is how the sweep works a queue */
+    expect(cards[0]!.startedAt).toBeLessThan(cards[2]!.startedAt)
+    expect(actions.pendingWorkAgents(canvasId)).toEqual([AGENT])
+  })
+
+  it('does not queue a screen that is already waiting or in flight from the same connection', () => {
+    actions.addRepoCards(
+      canvasId,
+      { connectionId: 'conn-1', repo: 'acme/app', screens: [button], designSystem: true },
+      'kevin',
+      'user-1',
+    )
+    const again = actions.addRepoCards(
+      canvasId,
+      { connectionId: 'conn-1', repo: 'acme/app', screens: [button, pricing], designSystem: true },
+      'kevin',
+      'user-1',
+    )
+    expect(again.map((c) => c.status)).toEqual(['Pricing'])
+    /* a finished card is history — the same screen can be imported again */
+    for (const c of actions.getTasks(canvasId)) actions.completeCard(canvasId, c.id)
+    const fresh = actions.addRepoCards(
+      canvasId,
+      { connectionId: 'conn-1', repo: 'acme/app', screens: [button], designSystem: false },
+      'kevin',
+      'user-1',
+    )
+    expect(fresh.map((c) => c.kind)).toEqual(['sketch'])
+  })
+
+  it('claims like any board card and keeps its payload through the claim', () => {
+    actions.addRepoCards(
+      canvasId,
+      { connectionId: 'conn-1', repo: 'acme/app', screens: [button], designSystem: false },
+      'kevin',
+      'user-1',
+    )
+    expect(actions.nextWorkPayer(canvasId, AGENT)).toBe('user-1')
+    const claimed = actions.takeQueuedCardsFor(canvasId, AGENT, 'user-1')
+    expect(claimed).toHaveLength(1)
+    expect(claimed[0]!.agentName).toBe(AGENT)
+    expect(claimed[0]!.kind).toBe('sketch')
+    expect(claimed[0]!.payload?.screen?.sourcePath).toBe('src/ui/Button.tsx')
+    expect(actions.takeQueuedCardsFor(canvasId, AGENT, 'user-1')).toHaveLength(0)
+  })
+})
+
+describe('trimTaskLog', () => {
+  it('drops the oldest finished tasks first and never an open card', () => {
+    const now = Date.now()
+    const list = Array.from({ length: 130 }, (_, i) => ({
+      id: `t${i}`,
+      agentName: i % 3 === 0 ? '' : AGENT,
+      color: '#000',
+      status: `task ${i}`,
+      startedAt: now - i,
+      /* every third task is an open queued card; the rest are finished */
+      ...(i % 3 === 0 ? { queuedBy: 'kevin', stage: 0 } : { endedAt: now }),
+    }))
+    const trimmed = actions.trimTaskLog(list)
+    expect(trimmed).toHaveLength(100)
+    expect(trimmed.filter((t) => t.queuedBy && !t.endedAt)).toHaveLength(44)
+    /* newest first is preserved; the finished tasks that survive are the newest ones */
+    expect(trimmed[0]!.id).toBe('t0')
+    expect(trimmed.some((t) => t.id === 't128')).toBe(false)
+    expect(trimmed.some((t) => t.id === 't1')).toBe(true)
+  })
+})
+
+describe('planRepoCards', () => {
+  it('reports nothing to queue when every screen is already on the board, without touching it', () => {
+    const input = { connectionId: 'conn-1', repo: 'acme/app', screens: [button], designSystem: true }
+    actions.addRepoCards(canvasId, input, 'kevin', 'user-1')
+    const before = actions.getTasks(canvasId).length
+    expect(actions.planRepoCards(canvasId, input)).toEqual([])
+    expect(actions.getTasks(canvasId)).toHaveLength(before)
+    expect(actions.planRepoCards(canvasId, { ...input, screens: [button, pricing] }).map((w) => w.title)).toEqual([
+      'Pricing',
+    ])
+  })
+})

--- a/tests/selection.test.ts
+++ b/tests/selection.test.ts
@@ -1,0 +1,166 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Canvas, Frame } from '../shared/types'
+
+/* the history module talks to the server and analytics — stub both so the
+   undo stack can be exercised as pure bookkeeping */
+const api = {
+  updateFrame: vi.fn(async (_id: string, _patch: object) => ({})),
+  deleteFrame: vi.fn(async () => ({})),
+  createFrame: vi.fn(async (_canvasId: string, rest: Partial<Frame>) => ({ ...frame('new'), ...rest, id: 'new' })),
+}
+vi.mock('../src/lib/api', () => ({ api }))
+vi.mock('../src/lib/posthog', () => ({ posthog: { capture: vi.fn() } }))
+
+const { useStore } = await import('../src/lib/store')
+const history = await import('../src/lib/history')
+
+function frame(id: string, x = 0, y = 0): Frame {
+  return {
+    id,
+    canvasId: 'c1',
+    name: id,
+    html: '',
+    x,
+    y,
+    width: 100,
+    height: 100,
+  } as Frame
+}
+
+function seed(...frames: Frame[]) {
+  useStore.getState().setCanvas({ id: 'c1', name: 'c', frames } as unknown as Canvas)
+}
+
+beforeEach(() => {
+  seed(frame('a'), frame('b'), frame('c'))
+  useStore.getState().select(null)
+  history.clearHistory()
+  vi.clearAllMocks()
+})
+
+describe('multi-selection in the store', () => {
+  it('a plain select collapses to one frame and makes it primary', () => {
+    useStore.getState().selectMany(['a', 'b'])
+    useStore.getState().select('c')
+    expect(useStore.getState().selectedIds).toEqual(['c'])
+    expect(useStore.getState().selectedId).toBe('c')
+  })
+
+  it('toggleSelect adds, then drops, keeping the last-added frame primary', () => {
+    const s = useStore.getState()
+    s.select('a')
+    s.toggleSelect('b')
+    expect(useStore.getState().selectedIds).toEqual(['a', 'b'])
+    expect(useStore.getState().selectedId).toBe('b')
+    useStore.getState().toggleSelect('b')
+    expect(useStore.getState().selectedIds).toEqual(['a'])
+    expect(useStore.getState().selectedId).toBe('a')
+    useStore.getState().toggleSelect('a')
+    expect(useStore.getState().selectedId).toBeNull()
+  })
+
+  it('removing a frame drops it from the selection and promotes a survivor', () => {
+    useStore.getState().selectMany(['a', 'b'])
+    useStore.getState().removeFrame('b')
+    expect(useStore.getState().selectedIds).toEqual(['a'])
+    expect(useStore.getState().selectedId).toBe('a')
+    useStore.getState().removeFrame('a')
+    expect(useStore.getState().selectedId).toBeNull()
+  })
+
+  it('changing the primary frame closes the inspector, re-selecting keeps it', () => {
+    useStore.getState().select('a')
+    useStore.getState().setInspectorOpen(true)
+    useStore.getState().selectMany(['b', 'a'])
+    expect(useStore.getState().inspectorOpen).toBe(true)
+    useStore.getState().toggleSelect('c')
+    expect(useStore.getState().inspectorOpen).toBe(false)
+  })
+})
+
+describe('grouped history', () => {
+  it('a group move undoes and redoes as one step', async () => {
+    history.recordUpdates([
+      { frameId: 'a', before: { x: 0, y: 0 }, after: { x: 10, y: 10 } },
+      { frameId: 'b', before: { x: 0, y: 0 }, after: { x: 10, y: 10 } },
+    ])
+    await history.undo()
+    expect(api.updateFrame).toHaveBeenCalledTimes(2)
+    expect(api.updateFrame).toHaveBeenCalledWith('a', { x: 0, y: 0 })
+    expect(api.updateFrame).toHaveBeenCalledWith('b', { x: 0, y: 0 })
+    await history.undo()
+    expect(api.updateFrame).toHaveBeenCalledTimes(2)
+    await history.redo()
+    expect(api.updateFrame).toHaveBeenCalledTimes(4)
+    expect(api.updateFrame).toHaveBeenLastCalledWith('b', { x: 10, y: 10 })
+  })
+
+  it('a group delete removes every frame and one undo brings them all back', async () => {
+    const frames = useStore.getState().canvas!.frames
+    history.deleteFramesTracked(frames.slice(0, 2))
+    expect(api.deleteFrame).toHaveBeenCalledTimes(2)
+    await history.undo()
+    expect(api.createFrame).toHaveBeenCalledTimes(2)
+    expect(api.createFrame).toHaveBeenCalledWith('c1', expect.objectContaining({ name: 'a' }))
+    expect(api.createFrame).toHaveBeenCalledWith('c1', expect.objectContaining({ name: 'b' }))
+  })
+})
+
+describe('review follow-ups', () => {
+  it('deleting the primary frame promotes the last surviving member', () => {
+    useStore.getState().selectMany(['a', 'b', 'c'])
+    useStore.getState().removeFrame('c')
+    expect(useStore.getState().selectedIds).toEqual(['a', 'b'])
+    expect(useStore.getState().selectedId).toBe('b')
+  })
+
+  it('an open Inspector closes when its frame is deleted out from under it', () => {
+    useStore.getState().selectMany(['a', 'b'])
+    useStore.getState().setInspectorOpen(true)
+    useStore.getState().removeFrame('b')
+    expect(useStore.getState().selectedId).toBe('a')
+    expect(useStore.getState().inspectorOpen).toBe(false)
+  })
+
+  it('undo waits for in-flight drag saves before writing the inverse', async () => {
+    const order: string[] = []
+    let release!: () => void
+    const pending = new Promise<void>((r) => (release = r)).then(() => order.push('save'))
+    history.trackSave(pending)
+    history.recordUpdate('a', { x: 0 }, { x: 10 })
+    api.updateFrame.mockImplementationOnce(async () => {
+      order.push('undo')
+      return {}
+    })
+    const undone = history.undo()
+    await Promise.resolve()
+    expect(order).toEqual([])
+    release()
+    await undone
+    expect(order).toEqual(['save', 'undo'])
+  })
+
+  it('a failing member of a group does not stop the others, and the survivors stay redoable', async () => {
+    history.recordUpdates([
+      { frameId: 'a', before: { x: 0 }, after: { x: 1 } },
+      { frameId: 'b', before: { x: 0 }, after: { x: 1 } },
+    ])
+    api.updateFrame.mockImplementationOnce(async (id: string) => {
+      if (id === 'a') throw new Error('boom')
+      return {}
+    })
+    await history.undo()
+    expect(api.updateFrame).toHaveBeenCalledTimes(2)
+    /* a's rejected undo is rolled back locally so it matches the server */
+    const frames = useStore.getState().canvas!.frames
+    expect(frames.find((f) => f.id === 'a')!.x).toBe(1)
+    expect(frames.find((f) => f.id === 'b')!.x).toBe(0)
+    /* only b was undone, so only b comes back on redo */
+    await history.redo()
+    expect(api.updateFrame).toHaveBeenCalledTimes(3)
+    expect(api.updateFrame).toHaveBeenLastCalledWith('b', { x: 1 })
+    /* and that redo is itself undoable */
+    await history.undo()
+    expect(api.updateFrame).toHaveBeenLastCalledWith('b', { x: 0 })
+  })
+})


### PR DESCRIPTION
Syncs the private PRs merged since #104 into OSS (cherry-picked with `-x`):

- **style(modal): lift modals on the soft pop shadow** (#135)
- **fix(dash): Help & docs link** (#142) — private points at its `/docs` route; OSS has neither `/docs` nor `/blog`, so a follow-up commit points the link at `https://doop.design/docs`.
- **fix(stage): pinch to zoom on touch screens** (#137)
- **feat(comments): reply inside an element comment thread** (#140, supersedes #107, closes #83) — migration regenerated in OSS numbering as `0008_comment_replies`.
- **feat(canvas): marquee selection, shift-click multi-select and space-to-pan** (#141, supersedes #108, closes #89)
- **feat(github): queue repo imports as board cards instead of outline frames** (#138) — migration regenerated as `0009_repo_cards`.

Also fixed while regenerating: the OSS `0006`/`0007` snapshots still carried the private-only `founder_emails` table (no OSS migration ever created it), which made drizzle-kit emit a `DROP TABLE` that would fail at boot. Both snapshots are corrected so future generates diff cleanly.

Skipped on purpose: private #134/#136 (already in OSS as #103/#106), #143 (docs/superpowers cleanup; OSS removed `docs/` in #101), and the export-script removal.

Verified locally: `typecheck`, `lint`, `format:check`, `build`, and `test` (243 passing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nx3BPgXLp5zixxocSWKSNd
