### PR TITLE
fix(importer): allow bigger stylesheets

### DIFF
--- a/server/importer.ts
+++ b/server/importer.ts
@@ -400,18 +400,19 @@ export async function importSitePages(rawUrls: string[], concurrency = 3): Promi
 interface CapturedCss {
   css: string
   complete: boolean
-  /* Why a sheet came back incomplete. 'limit' is Doop refusing an oversized
-     sheet; 'fetch' is the sheet itself being unreachable. The two need
-     different words in the error — blaming the site for our own budget sends
-     people debugging the wrong end. */
-  reason?: 'limit' | 'fetch'
+  /* Why a sheet came back incomplete, so the error can name the real cause.
+     'oversized' is strictly a size limit and is the ONLY reason that may claim
+     a sheet is too big — dropped @imports and unreachable sheets are
+     'incomplete', because telling someone their CSS is over 2 MB when it isn't
+     sends them debugging the wrong end. */
+  reason?: 'oversized' | 'incomplete'
 }
 
 const formatMb = (bytes: number) => `${(bytes / 1_000_000).toFixed(1).replace(/\.0$/, '')} MB`
 
 /** Fetch a stylesheet, resolve depth-1 @imports, absolutize its url() refs. */
 async function fetchCss(sheetUrl: string, depth = 0): Promise<CapturedCss> {
-  if (depth > 1) return { css: '', complete: false, reason: 'limit' }
+  if (depth > 1) return { css: '', complete: false, reason: 'incomplete' }
   let url: URL
   let res: Response | undefined
   let css: string
@@ -425,29 +426,29 @@ async function fetchCss(sheetUrl: string, depth = 0): Promise<CapturedCss> {
       })
       if (res.status < 300 || res.status >= 400) break
       const location = res.headers.get('location')
-      if (!location) return { css: '', complete: false, reason: 'fetch' }
+      if (!location) return { css: '', complete: false, reason: 'incomplete' }
       url = parsePublicHttpUrl(new URL(location, url).href)
       res = undefined
     }
-    if (!res?.ok) return { css: '', complete: false, reason: 'fetch' }
+    if (!res?.ok) return { css: '', complete: false, reason: 'incomplete' }
     if (res.headers.get('cf-mitigated')?.toLowerCase() === 'challenge')
-      return { css: '', complete: false, reason: 'fetch' }
+      return { css: '', complete: false, reason: 'incomplete' }
     const contentType = res.headers.get('content-type') ?? ''
     if (contentType && !/text\/css|text\/plain|application\/octet-stream/i.test(contentType)) {
-      return { css: '', complete: false, reason: 'fetch' }
+      return { css: '', complete: false, reason: 'incomplete' }
     }
     const bounded = await readTextBounded(res, MAX_SHEET_BYTES)
-    if (bounded === null) return { css: '', complete: false, reason: 'limit' }
+    if (bounded === null) return { css: '', complete: false, reason: 'oversized' }
     css = bounded
   } catch {
-    return { css: '', complete: false, reason: 'fetch' }
+    return { css: '', complete: false, reason: 'incomplete' }
   }
 
   let complete = true
   let reason: CapturedCss['reason']
   const imports = [...css.matchAll(/@import\s+(?:url\()?\s*['"]?([^'")\s]+)['"]?\s*\)?[^;]*;/g)]
   for (const [index, m] of imports.entries()) {
-    let child: CapturedCss = { css: '', complete: false, reason: 'limit' }
+    let child: CapturedCss = { css: '', complete: false, reason: 'incomplete' }
     if (index < MAX_CSS_IMPORTS) {
       try {
         child = await fetchCss(new URL(m[1], url).href, depth + 1)
@@ -465,7 +466,7 @@ async function fetchCss(sheetUrl: string, depth = 0): Promise<CapturedCss> {
     if (css.length > MAX_SHEET_BYTES) {
       css = css.slice(0, MAX_SHEET_BYTES)
       complete = false
-      reason ??= 'limit'
+      reason ??= 'oversized'
     }
   }
   /* relative url(...) inside the sheet must resolve against the SHEET's URL,
@@ -627,7 +628,7 @@ export async function importPage(rawUrl: string, options: { includePreview?: boo
       const captured = await fetchCss(sheet)
       if (!captured.complete) {
         throw new WebsiteCaptureUnavailableError(
-          captured.reason === 'limit'
+          captured.reason === 'oversized'
             ? `This page has a stylesheet larger than Doop's ${formatMb(MAX_SHEET_BYTES)} per-stylesheet import limit`
             : 'The webpage HTML was captured, but one or more stylesheets could not be fully loaded',
         )

--- a/server/importer.ts
+++ b/server/importer.ts
@@ -29,10 +29,11 @@ const VIEWPORT_WIDTH = 1280
 const MAX_HEIGHT = 6000
 const MAX_PREVIEW_HEIGHT = 4000
 const MAX_PREVIEW_TEXT_CHARS = 6000
-const MAX_TOTAL_BYTES = 2_000_000
-/* A single sheet may use the whole style budget: real sites ship one big
-   bundled stylesheet, and a stricter per-sheet cap rejected pages that fit. */
-const MAX_SHEET_BYTES = MAX_TOTAL_BYTES
+/* One budget for all of a page's CSS, shared by every sheet and @import.
+   Real sites ship one big bundled stylesheet, so a per-sheet cap below the
+   page budget only rejected pages that fit. */
+const MAX_CSS_BYTES = 2_000_000
+const MAX_DOCUMENT_BYTES = 3_000_000
 const MAX_DISCOVERY_BYTES = 2_000_000
 const MAX_SITEMAPS = 12
 const DISCOVERY_CONCURRENCY = 6
@@ -397,22 +398,20 @@ export async function importSitePages(rawUrls: string[], concurrency = 3): Promi
   return results
 }
 
-interface CapturedCss {
-  css: string
-  complete: boolean
-  /* Why a sheet came back incomplete, so the error can name the real cause.
-     'oversized' is strictly a size limit and is the ONLY reason that may claim
-     a sheet is too big — dropped @imports and unreachable sheets are
-     'incomplete', because telling someone their CSS is over 2 MB when it isn't
-     sends them debugging the wrong end. */
-  reason?: 'oversized' | 'incomplete'
-}
+type CapturedCss = { ok: true; css: string } | { ok: false; reason: 'oversized' | 'unreachable' }
 
-const formatMb = (bytes: number) => `${(bytes / 1_000_000).toFixed(1).replace(/\.0$/, '')} MB`
+const OVERSIZED: CapturedCss = { ok: false, reason: 'oversized' }
+const UNREACHABLE: CapturedCss = { ok: false, reason: 'unreachable' }
 
-/** Fetch a stylesheet, resolve depth-1 @imports, absolutize its url() refs. */
-async function fetchCss(sheetUrl: string, depth = 0): Promise<CapturedCss> {
-  if (depth > 1) return { css: '', complete: false, reason: 'incomplete' }
+const CSS_OVERSIZED_MESSAGE = `This page's stylesheets are larger than Doop's ${MAX_CSS_BYTES / 1_000_000} MB import limit`
+const CSS_UNREACHABLE_MESSAGE = 'The webpage HTML was captured, but one or more stylesheets could not be fully loaded'
+
+/** Fetch a stylesheet within the bytes still available for the page's CSS,
+ *  resolve depth-1 @imports against the same budget, absolutize its url() refs.
+ *  Fetching stops at the first failure: the import cannot succeed anyway, and
+ *  the budget bounds how much an untrusted host can make us download. */
+async function fetchCss(sheetUrl: string, budget: number, depth = 0): Promise<CapturedCss> {
+  if (depth > 1) return UNREACHABLE
   let url: URL
   let res: Response | undefined
   let css: string
@@ -426,48 +425,35 @@ async function fetchCss(sheetUrl: string, depth = 0): Promise<CapturedCss> {
       })
       if (res.status < 300 || res.status >= 400) break
       const location = res.headers.get('location')
-      if (!location) return { css: '', complete: false, reason: 'incomplete' }
+      if (!location) return UNREACHABLE
       url = parsePublicHttpUrl(new URL(location, url).href)
       res = undefined
     }
-    if (!res?.ok) return { css: '', complete: false, reason: 'incomplete' }
-    if (res.headers.get('cf-mitigated')?.toLowerCase() === 'challenge')
-      return { css: '', complete: false, reason: 'incomplete' }
+    if (!res?.ok) return UNREACHABLE
+    if (res.headers.get('cf-mitigated')?.toLowerCase() === 'challenge') return UNREACHABLE
     const contentType = res.headers.get('content-type') ?? ''
-    if (contentType && !/text\/css|text\/plain|application\/octet-stream/i.test(contentType)) {
-      return { css: '', complete: false, reason: 'incomplete' }
-    }
-    const bounded = await readTextBounded(res, MAX_SHEET_BYTES)
-    if (bounded === null) return { css: '', complete: false, reason: 'oversized' }
+    if (contentType && !/text\/css|text\/plain|application\/octet-stream/i.test(contentType)) return UNREACHABLE
+    const bounded = await readTextBounded(res, budget)
+    if (bounded === null) return OVERSIZED
     css = bounded
   } catch {
-    return { css: '', complete: false, reason: 'incomplete' }
+    return UNREACHABLE
   }
 
-  let complete = true
-  let reason: CapturedCss['reason']
   const imports = [...css.matchAll(/@import\s+(?:url\()?\s*['"]?([^'")\s]+)['"]?\s*\)?[^;]*;/g)]
   for (const [index, m] of imports.entries()) {
-    let child: CapturedCss = { css: '', complete: false, reason: 'incomplete' }
-    if (index < MAX_CSS_IMPORTS) {
-      try {
-        child = await fetchCss(new URL(m[1], url).href, depth + 1)
-      } catch {
-        /* dead import */
-      }
+    if (index >= MAX_CSS_IMPORTS) return UNREACHABLE
+    let child: CapturedCss
+    try {
+      child = await fetchCss(new URL(m[1], url).href, budget - Buffer.byteLength(css), depth + 1)
+    } catch {
+      child = UNREACHABLE
     }
-    if (!child.complete) {
-      complete = false
-      reason ??= child.reason
-    }
-    /* Imports beyond the bounded fetch budget are removed rather than left
-       active in the snapshot for a later browser to fetch. */
+    if (!child.ok) return child
+    /* Inline the import rather than leave it active in the snapshot for a
+       later browser to fetch. */
     css = css.replace(m[0], child.css)
-    if (css.length > MAX_SHEET_BYTES) {
-      css = css.slice(0, MAX_SHEET_BYTES)
-      complete = false
-      reason ??= 'oversized'
-    }
+    if (Buffer.byteLength(css) > budget) return OVERSIZED
   }
   /* relative url(...) inside the sheet must resolve against the SHEET's URL,
      not the document base */
@@ -478,7 +464,7 @@ async function fetchCss(sheetUrl: string, depth = 0): Promise<CapturedCss> {
       return _all
     }
   })
-  return { css, complete, reason }
+  return { ok: true, css }
 }
 
 export interface ImportedPage {
@@ -625,17 +611,10 @@ export async function importPage(rawUrl: string, options: { includePreview?: boo
 
     let css = ''
     for (const sheet of snap.sheets) {
-      const captured = await fetchCss(sheet)
-      if (!captured.complete) {
+      const captured = await fetchCss(sheet, MAX_CSS_BYTES - Buffer.byteLength(css))
+      if (!captured.ok) {
         throw new WebsiteCaptureUnavailableError(
-          captured.reason === 'oversized'
-            ? `This page has a stylesheet larger than Doop's ${formatMb(MAX_SHEET_BYTES)} per-stylesheet import limit`
-            : 'The webpage HTML was captured, but one or more stylesheets could not be fully loaded',
-        )
-      }
-      if (css.length + captured.css.length + 1 > MAX_TOTAL_BYTES) {
-        throw new WebsiteCaptureUnavailableError(
-          `This page's stylesheets add up to more than Doop's ${formatMb(MAX_TOTAL_BYTES)} import limit`,
+          captured.reason === 'oversized' ? CSS_OVERSIZED_MESSAGE : CSS_UNREACHABLE_MESSAGE,
         )
       }
       css += captured.css + '\n'
@@ -664,7 +643,7 @@ export async function importPage(rawUrl: string, options: { includePreview?: boo
     else html = inject + html
     html = '<!doctype html>\n' + html
 
-    if (html.length > MAX_TOTAL_BYTES * 1.5) {
+    if (html.length > MAX_DOCUMENT_BYTES) {
       throw new WebsiteCaptureUnavailableError('The captured webpage is too large to import safely')
     }
 

--- a/server/importer.ts
+++ b/server/importer.ts
@@ -29,8 +29,10 @@ const VIEWPORT_WIDTH = 1280
 const MAX_HEIGHT = 6000
 const MAX_PREVIEW_HEIGHT = 4000
 const MAX_PREVIEW_TEXT_CHARS = 6000
-const MAX_SHEET_BYTES = 600_000
 const MAX_TOTAL_BYTES = 2_000_000
+/* A single sheet may use the whole style budget: real sites ship one big
+   bundled stylesheet, and a stricter per-sheet cap rejected pages that fit. */
+const MAX_SHEET_BYTES = MAX_TOTAL_BYTES
 const MAX_DISCOVERY_BYTES = 2_000_000
 const MAX_SITEMAPS = 12
 const DISCOVERY_CONCURRENCY = 6
@@ -398,11 +400,18 @@ export async function importSitePages(rawUrls: string[], concurrency = 3): Promi
 interface CapturedCss {
   css: string
   complete: boolean
+  /* Why a sheet came back incomplete. 'limit' is Doop refusing an oversized
+     sheet; 'fetch' is the sheet itself being unreachable. The two need
+     different words in the error — blaming the site for our own budget sends
+     people debugging the wrong end. */
+  reason?: 'limit' | 'fetch'
 }
+
+const formatMb = (bytes: number) => `${(bytes / 1_000_000).toFixed(1).replace(/\.0$/, '')} MB`
 
 /** Fetch a stylesheet, resolve depth-1 @imports, absolutize its url() refs. */
 async function fetchCss(sheetUrl: string, depth = 0): Promise<CapturedCss> {
-  if (depth > 1) return { css: '', complete: false }
+  if (depth > 1) return { css: '', complete: false, reason: 'limit' }
   let url: URL
   let res: Response | undefined
   let css: string
@@ -416,27 +425,29 @@ async function fetchCss(sheetUrl: string, depth = 0): Promise<CapturedCss> {
       })
       if (res.status < 300 || res.status >= 400) break
       const location = res.headers.get('location')
-      if (!location) return { css: '', complete: false }
+      if (!location) return { css: '', complete: false, reason: 'fetch' }
       url = parsePublicHttpUrl(new URL(location, url).href)
       res = undefined
     }
-    if (!res?.ok) return { css: '', complete: false }
-    if (res.headers.get('cf-mitigated')?.toLowerCase() === 'challenge') return { css: '', complete: false }
+    if (!res?.ok) return { css: '', complete: false, reason: 'fetch' }
+    if (res.headers.get('cf-mitigated')?.toLowerCase() === 'challenge')
+      return { css: '', complete: false, reason: 'fetch' }
     const contentType = res.headers.get('content-type') ?? ''
     if (contentType && !/text\/css|text\/plain|application\/octet-stream/i.test(contentType)) {
-      return { css: '', complete: false }
+      return { css: '', complete: false, reason: 'fetch' }
     }
     const bounded = await readTextBounded(res, MAX_SHEET_BYTES)
-    if (bounded === null) return { css: '', complete: false }
+    if (bounded === null) return { css: '', complete: false, reason: 'limit' }
     css = bounded
   } catch {
-    return { css: '', complete: false }
+    return { css: '', complete: false, reason: 'fetch' }
   }
 
   let complete = true
+  let reason: CapturedCss['reason']
   const imports = [...css.matchAll(/@import\s+(?:url\()?\s*['"]?([^'")\s]+)['"]?\s*\)?[^;]*;/g)]
   for (const [index, m] of imports.entries()) {
-    let child: CapturedCss = { css: '', complete: false }
+    let child: CapturedCss = { css: '', complete: false, reason: 'limit' }
     if (index < MAX_CSS_IMPORTS) {
       try {
         child = await fetchCss(new URL(m[1], url).href, depth + 1)
@@ -444,13 +455,17 @@ async function fetchCss(sheetUrl: string, depth = 0): Promise<CapturedCss> {
         /* dead import */
       }
     }
-    if (!child.complete) complete = false
+    if (!child.complete) {
+      complete = false
+      reason ??= child.reason
+    }
     /* Imports beyond the bounded fetch budget are removed rather than left
        active in the snapshot for a later browser to fetch. */
     css = css.replace(m[0], child.css)
     if (css.length > MAX_SHEET_BYTES) {
       css = css.slice(0, MAX_SHEET_BYTES)
       complete = false
+      reason ??= 'limit'
     }
   }
   /* relative url(...) inside the sheet must resolve against the SHEET's URL,
@@ -462,7 +477,7 @@ async function fetchCss(sheetUrl: string, depth = 0): Promise<CapturedCss> {
       return _all
     }
   })
-  return { css, complete }
+  return { css, complete, reason }
 }
 
 export interface ImportedPage {
@@ -612,11 +627,15 @@ export async function importPage(rawUrl: string, options: { includePreview?: boo
       const captured = await fetchCss(sheet)
       if (!captured.complete) {
         throw new WebsiteCaptureUnavailableError(
-          'The webpage HTML was captured, but one or more stylesheets could not be fully loaded',
+          captured.reason === 'limit'
+            ? `This page has a stylesheet larger than Doop's ${formatMb(MAX_SHEET_BYTES)} per-stylesheet import limit`
+            : 'The webpage HTML was captured, but one or more stylesheets could not be fully loaded',
         )
       }
       if (css.length + captured.css.length + 1 > MAX_TOTAL_BYTES) {
-        throw new WebsiteCaptureUnavailableError('The webpage styles are too large to import safely')
+        throw new WebsiteCaptureUnavailableError(
+          `This page's stylesheets add up to more than Doop's ${formatMb(MAX_TOTAL_BYTES)} import limit`,
+        )
       }
       css += captured.css + '\n'
     }

--- a/tests/importer.test.ts
+++ b/tests/importer.test.ts
@@ -234,7 +234,10 @@ describe('webpage capture', () => {
     expect(browserMocks.openIsolatedPage).not.toHaveBeenCalled()
   })
 
-  it('rejects captured HTML when every external stylesheet is blocked', async () => {
+  const css = (body: string) => new Response(body, { headers: { 'content-type': 'text/css' } })
+  const blocked = (status = 200) =>
+    new Response('<html>challenge</html>', { status, headers: { 'content-type': 'text/html' } })
+  const stubContextPageWithSheets = (sheets: string[]) => {
     contextMocks.configured.mockReturnValue(true)
     contextMocks.scrape.mockResolvedValue({
       html: '<!doctype html><html><head><link rel="stylesheet" href="/app.css"></head><body>From Context</body></html>',
@@ -242,19 +245,21 @@ describe('webpage capture', () => {
       title: 'Context title',
       description: '',
     })
-    publicUrlMocks.fetchPinned.mockResolvedValue(
-      new Response('<html>challenge</html>', { headers: { 'content-type': 'text/html' } }),
-    )
-    const page = stubPage({
+    return stubPage({
       finalUrl: 'about:blank',
       contextPath: true,
       snapshot: {
-        sheets: ['https://example.com/app.css'],
+        sheets,
         title: 'Context title',
         height: 777,
         html: '<html><head></head><body>From Context</body></html>',
       },
     })
+  }
+
+  it('rejects captured HTML when every external stylesheet is blocked', async () => {
+    publicUrlMocks.fetchPinned.mockResolvedValue(blocked())
+    const page = stubContextPageWithSheets(['https://example.com/app.css'])
 
     await expect(importPage('https://example.com')).rejects.toThrow('stylesheets could not be fully loaded')
 
@@ -266,30 +271,10 @@ describe('webpage capture', () => {
   })
 
   it('rejects a partial stylesheet capture instead of accepting a materially unstyled page', async () => {
-    contextMocks.configured.mockReturnValue(true)
-    contextMocks.scrape.mockResolvedValue({
-      html: '<html><head></head><body>From Context</body></html>',
-      finalUrl: 'https://example.com/final',
-      title: 'Context title',
-      description: '',
-    })
     publicUrlMocks.fetchPinned
-      .mockResolvedValueOnce(
-        new Response('html { box-sizing: border-box }', { headers: { 'content-type': 'text/css' } }),
-      )
-      .mockResolvedValueOnce(
-        new Response('<html>challenge</html>', { status: 403, headers: { 'content-type': 'text/html' } }),
-      )
-    const page = stubPage({
-      finalUrl: 'about:blank',
-      contextPath: true,
-      snapshot: {
-        sheets: ['https://example.com/reset.css', 'https://example.com/app.css'],
-        title: 'Context title',
-        height: 777,
-        html: '<html><head></head><body>From Context</body></html>',
-      },
-    })
+      .mockResolvedValueOnce(css('html { box-sizing: border-box }'))
+      .mockResolvedValueOnce(blocked(403))
+    const page = stubContextPageWithSheets(['https://example.com/reset.css', 'https://example.com/app.css'])
 
     await expect(importPage('https://example.com')).rejects.toThrow('stylesheets could not be fully loaded')
 
@@ -297,98 +282,73 @@ describe('webpage capture', () => {
     expect(page.close).toHaveBeenCalledOnce()
   })
 
-  it('inlines a single stylesheet that fits the total style budget', async () => {
-    contextMocks.configured.mockReturnValue(true)
-    contextMocks.scrape.mockResolvedValue({
-      html: '<!doctype html><html><head><link rel="stylesheet" href="/app.css"></head><body>From Context</body></html>',
-      finalUrl: 'https://example.com/final',
-      title: 'Context title',
-      description: '',
-    })
-    /* One big bundled sheet is how real sites ship CSS; it used to be turned
-       away by a per-sheet cap stricter than the budget it fits inside. */
-    const bundled = `body { color: red } ${'/* padding */'.repeat(60_000)}`
-    publicUrlMocks.fetchPinned.mockResolvedValue(new Response(bundled, { headers: { 'content-type': 'text/css' } }))
-    const page = stubPage({
-      finalUrl: 'about:blank',
-      contextPath: true,
-      snapshot: {
-        sheets: ['https://example.com/app.css'],
-        title: 'Context title',
-        height: 777,
-        html: '<html><head></head><body>From Context</body></html>',
-      },
-    })
+  it('inlines a single stylesheet that uses most of the page CSS budget', async () => {
+    /* One big bundled sheet is how real sites ship CSS; a per-sheet cap below
+       the page budget used to turn it away. */
+    const bundled = `body { color: red } ${'/* padding */'.repeat(120_000)}`
+    publicUrlMocks.fetchPinned.mockResolvedValue(css(bundled))
+    const page = stubContextPageWithSheets(['https://example.com/app.css'])
 
     const imported = await importPage('https://example.com')
 
-    expect(bundled.length).toBeGreaterThan(600_000)
+    expect(bundled.length).toBeGreaterThan(1_500_000)
     expect(imported.html).toContain('body { color: red }')
     expect(page.close).toHaveBeenCalledOnce()
   })
 
-  it('blames its own budget, not the site, when a stylesheet is oversized', async () => {
-    contextMocks.configured.mockReturnValue(true)
-    contextMocks.scrape.mockResolvedValue({
-      html: '<!doctype html><html><head><link rel="stylesheet" href="/app.css"></head><body>From Context</body></html>',
-      finalUrl: 'https://example.com/final',
-      title: 'Context title',
-      description: '',
-    })
+  it('blames its own budget, not the site, when a declared stylesheet size exceeds it', async () => {
     publicUrlMocks.fetchPinned.mockResolvedValue(
-      new Response('body { color: red }', {
-        headers: { 'content-type': 'text/css', 'content-length': '2500000' },
-      }),
+      new Response('body { color: red }', { headers: { 'content-type': 'text/css', 'content-length': '2500000' } }),
     )
-    const page = stubPage({
-      finalUrl: 'about:blank',
-      contextPath: true,
-      snapshot: {
-        sheets: ['https://example.com/app.css'],
-        title: 'Context title',
-        height: 777,
-        html: '<html><head></head><body>From Context</body></html>',
-      },
-    })
+    const page = stubContextPageWithSheets(['https://example.com/app.css'])
 
-    await expect(importPage('https://example.com')).rejects.toThrow('per-stylesheet import limit')
+    await expect(importPage('https://example.com')).rejects.toThrow('2 MB import limit')
+    expect(page.close).toHaveBeenCalledOnce()
+  })
+
+  it('stops reading a streamed stylesheet without content-length once it passes the budget', async () => {
+    publicUrlMocks.fetchPinned.mockResolvedValue(css('x'.repeat(2_100_000)))
+    const page = stubContextPageWithSheets(['https://example.com/app.css'])
+
+    await expect(importPage('https://example.com')).rejects.toThrow('2 MB import limit')
+    expect(page.close).toHaveBeenCalledOnce()
+  })
+
+  it('charges every sheet against one page budget', async () => {
+    publicUrlMocks.fetchPinned
+      .mockResolvedValueOnce(css('a'.repeat(1_200_000)))
+      .mockResolvedValueOnce(css('b'.repeat(1_200_000)))
+    const page = stubContextPageWithSheets(['https://example.com/vendor.css', 'https://example.com/app.css'])
+
+    await expect(importPage('https://example.com')).rejects.toThrow('2 MB import limit')
     expect(page.close).toHaveBeenCalledOnce()
   })
 
   it('does not call a small stylesheet oversized when a nested @import is dropped', async () => {
-    contextMocks.configured.mockReturnValue(true)
-    contextMocks.scrape.mockResolvedValue({
-      html: '<!doctype html><html><head><link rel="stylesheet" href="/app.css"></head><body>From Context</body></html>',
-      finalUrl: 'https://example.com/final',
-      title: 'Context title',
-      description: '',
-    })
     /* app.css → mid.css → deep.css. The third level is past the supported
        import depth, so the capture is incomplete — but nothing here is big,
        and the error must not claim a size limit. */
     publicUrlMocks.fetchPinned
-      .mockResolvedValueOnce(new Response("@import url('/mid.css');", { headers: { 'content-type': 'text/css' } }))
-      .mockResolvedValueOnce(new Response("@import url('/deep.css');", { headers: { 'content-type': 'text/css' } }))
-    const page = stubPage({
-      finalUrl: 'about:blank',
-      contextPath: true,
-      snapshot: {
-        sheets: ['https://example.com/app.css'],
-        title: 'Context title',
-        height: 777,
-        html: '<html><head></head><body>From Context</body></html>',
-      },
-    })
+      .mockResolvedValueOnce(css("@import url('/mid.css');"))
+      .mockResolvedValueOnce(css("@import url('/deep.css');"))
+    const page = stubContextPageWithSheets(['https://example.com/app.css'])
 
-    let message = ''
-    try {
-      await importPage('https://example.com')
-    } catch (thrown) {
-      message = (thrown as Error).message
-    }
+    const error = await importPage('https://example.com').catch((thrown: Error) => thrown)
 
-    expect(message).toContain('could not be fully loaded')
-    expect(message).not.toContain('import limit')
+    expect(error).toBeInstanceOf(Error)
+    expect((error as Error).message).toContain('could not be fully loaded')
+    expect((error as Error).message).not.toContain('import limit')
+    expect(publicUrlMocks.fetchPinned).toHaveBeenCalledTimes(2)
+    expect(page.close).toHaveBeenCalledOnce()
+  })
+
+  it('stops fetching @imports after the first one fails', async () => {
+    publicUrlMocks.fetchPinned
+      .mockResolvedValueOnce(css("@import url('/a.css'); @import url('/b.css');"))
+      .mockResolvedValueOnce(blocked(403))
+    const page = stubContextPageWithSheets(['https://example.com/app.css'])
+
+    await expect(importPage('https://example.com')).rejects.toThrow('could not be fully loaded')
     expect(publicUrlMocks.fetchPinned).toHaveBeenCalledTimes(2)
     expect(page.close).toHaveBeenCalledOnce()
   })

--- a/tests/importer.test.ts
+++ b/tests/importer.test.ts
@@ -297,6 +297,64 @@ describe('webpage capture', () => {
     expect(page.close).toHaveBeenCalledOnce()
   })
 
+  it('inlines a single stylesheet that fits the total style budget', async () => {
+    contextMocks.configured.mockReturnValue(true)
+    contextMocks.scrape.mockResolvedValue({
+      html: '<!doctype html><html><head><link rel="stylesheet" href="/app.css"></head><body>From Context</body></html>',
+      finalUrl: 'https://example.com/final',
+      title: 'Context title',
+      description: '',
+    })
+    /* One big bundled sheet is how real sites ship CSS; it used to be turned
+       away by a per-sheet cap stricter than the budget it fits inside. */
+    const bundled = `body { color: red } ${'/* padding */'.repeat(60_000)}`
+    publicUrlMocks.fetchPinned.mockResolvedValue(new Response(bundled, { headers: { 'content-type': 'text/css' } }))
+    const page = stubPage({
+      finalUrl: 'about:blank',
+      contextPath: true,
+      snapshot: {
+        sheets: ['https://example.com/app.css'],
+        title: 'Context title',
+        height: 777,
+        html: '<html><head></head><body>From Context</body></html>',
+      },
+    })
+
+    const imported = await importPage('https://example.com')
+
+    expect(bundled.length).toBeGreaterThan(600_000)
+    expect(imported.html).toContain('body { color: red }')
+    expect(page.close).toHaveBeenCalledOnce()
+  })
+
+  it('blames its own budget, not the site, when a stylesheet is oversized', async () => {
+    contextMocks.configured.mockReturnValue(true)
+    contextMocks.scrape.mockResolvedValue({
+      html: '<!doctype html><html><head><link rel="stylesheet" href="/app.css"></head><body>From Context</body></html>',
+      finalUrl: 'https://example.com/final',
+      title: 'Context title',
+      description: '',
+    })
+    publicUrlMocks.fetchPinned.mockResolvedValue(
+      new Response('body { color: red }', {
+        headers: { 'content-type': 'text/css', 'content-length': '2500000' },
+      }),
+    )
+    const page = stubPage({
+      finalUrl: 'about:blank',
+      contextPath: true,
+      snapshot: {
+        sheets: ['https://example.com/app.css'],
+        title: 'Context title',
+        height: 777,
+        html: '<html><head></head><body>From Context</body></html>',
+      },
+    })
+
+    await expect(importPage('https://example.com')).rejects.toThrow('per-stylesheet import limit')
+    expect(page.close).toHaveBeenCalledOnce()
+  })
+
   it('returns a bounded screenshot and text preview when requested', async () => {
     const screenshot = Buffer.from('agent-preview')
     const page = stubPage({

--- a/tests/importer.test.ts
+++ b/tests/importer.test.ts
@@ -355,6 +355,44 @@ describe('webpage capture', () => {
     expect(page.close).toHaveBeenCalledOnce()
   })
 
+  it('does not call a small stylesheet oversized when a nested @import is dropped', async () => {
+    contextMocks.configured.mockReturnValue(true)
+    contextMocks.scrape.mockResolvedValue({
+      html: '<!doctype html><html><head><link rel="stylesheet" href="/app.css"></head><body>From Context</body></html>',
+      finalUrl: 'https://example.com/final',
+      title: 'Context title',
+      description: '',
+    })
+    /* app.css → mid.css → deep.css. The third level is past the supported
+       import depth, so the capture is incomplete — but nothing here is big,
+       and the error must not claim a size limit. */
+    publicUrlMocks.fetchPinned
+      .mockResolvedValueOnce(new Response("@import url('/mid.css');", { headers: { 'content-type': 'text/css' } }))
+      .mockResolvedValueOnce(new Response("@import url('/deep.css');", { headers: { 'content-type': 'text/css' } }))
+    const page = stubPage({
+      finalUrl: 'about:blank',
+      contextPath: true,
+      snapshot: {
+        sheets: ['https://example.com/app.css'],
+        title: 'Context title',
+        height: 777,
+        html: '<html><head></head><body>From Context</body></html>',
+      },
+    })
+
+    let message = ''
+    try {
+      await importPage('https://example.com')
+    } catch (thrown) {
+      message = (thrown as Error).message
+    }
+
+    expect(message).toContain('could not be fully loaded')
+    expect(message).not.toContain('import limit')
+    expect(publicUrlMocks.fetchPinned).toHaveBeenCalledTimes(2)
+    expect(page.close).toHaveBeenCalledOnce()
+  })
+
   it('returns a bounded screenshot and text preview when requested', async () => {
     const screenshot = Buffer.from('agent-preview')
     const page = stubPage({


### PR DESCRIPTION
This PR fixes [odoo.com](https://www.odoo.com) failing to import.

### Before

The importer allows 2 MB of CSS per page, but capped each single stylesheet at 600 KB. odoo.com has one 1.7 MB stylesheet, so it got rejected even though it fits. The error blamed the site, but it was us refusing it.

<img width="731" height="505" alt="image" src="https://github.com/user-attachments/assets/d9025124-6d87-4cd6-9129-8d34d88dab78" />
<img width="731" height="505" alt="image" src="https://github.com/user-attachments/assets/e5728432-2c4a-43d9-8b92-b9773dba7e12" />


### After

One stylesheet can use the full 2 MB. [odoo.com](https://www.odoo.com) imports.


https://github.com/user-attachments/assets/1746820b-f1a2-4d63-8672-4c3c4d47050f



If a page is genuinely too big, the error now says that instead of blaming the site. [discord.com](https://discord.com) has 3.3 MB of CSS and is still rejected, correctly.

<img width="731" height="505" alt="image" src="https://github.com/user-attachments/assets/5d8c8661-0afd-4f69-b3a7-80cfdc287c69" />

### Testing

Added two tests. Checked [odoo.com](https://www.odoo.com) and [discord.com](https://discord.com) for real.