### PR TITLE
feat: add frame presentation with zoom and viewing controls

### DIFF
--- a/src/components/FrameContextMenu.tsx
+++ b/src/components/FrameContextMenu.tsx
@@ -20,6 +20,8 @@ export function FrameContextMenu({ frame, at }: { frame: Frame; at: MutableRefOb
   }
   return (
     <ContextMenuContent>
+      <ContextMenuItem onSelect={() => useStore.getState().presentFrame(frame.id)}>Present frame</ContextMenuItem>
+      <ContextMenuSeparator />
       <ContextMenuItem onSelect={() => copyFrame(frame)}>
         Copy
         <MenuHint>{MOD_KEY}C</MenuHint>

--- a/src/components/FramePresentation.tsx
+++ b/src/components/FramePresentation.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useLayoutEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
 import type { Frame } from '../../shared/types'
 import { FRAME_BOOTSTRAP } from '../lib/frameRuntime'
 import { useStore } from '../lib/store'
+import { presentationScale, presentationZoomLimits, zoomedScroll, type PresentationMode } from '../lib/presentationView'
 import { Button } from './ui/button'
 import { Modal, ModalTitle } from './ui/modal'
 
@@ -26,7 +27,15 @@ function Presentation({ frame }: { frame: Frame }) {
   const stage = useRef<HTMLDivElement>(null)
   const iframe = useRef<HTMLIFrameElement>(null)
   const [ready, setReady] = useState(false)
-  const [scale, setScale] = useState(0)
+  const [size, setSize] = useState({ width: 0, height: 0 })
+  const [view, setView] = useState<{ mode: PresentationMode; zoom: number }>({ mode: 'fit', zoom: 1 })
+  const [pan, setPan] = useState(true)
+  const [dragging, setDragging] = useState(false)
+  const drag = useRef<{ id: number; x: number; y: number; left: number; top: number } | null>(null)
+  const pendingScroll = useRef<{ left: number; top: number } | null>(null)
+  const leavingFullscreen = useRef(false)
+  const scale = presentationScale(view.mode, view.zoom, size, frame)
+  const limits = presentationZoomLimits(size, frame)
   const [fullscreen, setFullscreen] = useState(false)
   const close = () => presentFrame(null)
 
@@ -34,12 +43,59 @@ function Presentation({ frame }: { frame: Frame }) {
      rotation changes it. The iframe keeps its design viewport at every size. */
   useLayoutEffect(() => {
     const el = stage.current!
-    const observer = new ResizeObserver(([entry]) => {
-      setScale(Math.min(entry.contentRect.width / frame.width, entry.contentRect.height / frame.height))
+    const observer = new ResizeObserver(() => {
+      setSize({ width: el.clientWidth, height: el.clientHeight })
     })
     observer.observe(el)
     return () => observer.disconnect()
-  }, [frame.width, frame.height])
+  }, [])
+
+  useLayoutEffect(() => {
+    if (pendingScroll.current && stage.current) {
+      stage.current.scrollTo(pendingScroll.current)
+      pendingScroll.current = null
+    }
+  })
+
+  useEffect(() => {
+    // Moving the view must also keep keyboard focus out of embedded controls.
+    iframe.current?.toggleAttribute('inert', pan)
+  }, [pan])
+
+  const chooseView = (mode: PresentationMode) => {
+    pendingScroll.current = { left: 0, top: 0 }
+    setView({ mode, zoom: 1 })
+  }
+
+  const zoomTo = useCallback(
+    (next: number, anchor?: { x: number; y: number }) => {
+      const el = stage.current
+      if (!el || scale <= 0) return
+      const zoom = Math.min(limits.max, Math.max(limits.min, next))
+      pendingScroll.current = {
+        left: zoomedScroll(el.scrollLeft, anchor?.x ?? el.clientWidth / 2, el.clientWidth, frame.width, scale, zoom),
+        top: zoomedScroll(el.scrollTop, anchor?.y ?? el.clientHeight / 2, el.clientHeight, frame.height, scale, zoom),
+      }
+      setView({ mode: 'custom', zoom })
+    },
+    [scale, limits.min, limits.max, frame.width, frame.height],
+  )
+
+  useEffect(() => {
+    const el = stage.current!
+    function onWheel(event: WheelEvent) {
+      if (!event.ctrlKey && !event.metaKey) return
+      event.preventDefault()
+      const rect = el.getBoundingClientRect()
+      const delta = event.deltaY * (event.deltaMode === 1 ? 16 : event.deltaMode === 2 ? el.clientHeight : 1)
+      zoomTo(scale * Math.exp(-delta * 0.01), {
+        x: event.clientX - rect.left - el.clientLeft,
+        y: event.clientY - rect.top,
+      })
+    }
+    el.addEventListener('wheel', onWheel, { passive: false })
+    return () => el.removeEventListener('wheel', onWheel)
+  }, [scale, zoomTo])
 
   useEffect(() => {
     function onMessage(event: MessageEvent) {
@@ -64,7 +120,8 @@ function Presentation({ frame }: { frame: Frame }) {
       setFullscreen(active)
       /* The browser consumes Escape in native fullscreen. Its exit event
          must close the presentation too, so one Escape always returns. */
-      if (entered && !active) presentFrame(null)
+      if (entered && !active && !leavingFullscreen.current) presentFrame(null)
+      leavingFullscreen.current = false
       entered = active
     }
     document.addEventListener('fullscreenchange', onFullscreenChange)
@@ -75,40 +132,204 @@ function Presentation({ frame }: { frame: Frame }) {
   }, [presentFrame])
 
   return (
-    <div ref={surface} className="flex h-full w-full flex-col bg-ink text-white">
+    <div
+      ref={surface}
+      className="flex h-full w-full flex-col bg-ink text-white"
+      onKeyDown={(event) => {
+        if (event.altKey || event.ctrlKey || event.metaKey) return
+        if (event.key === '+' || event.key === '=') {
+          event.preventDefault()
+          zoomTo(scale * 1.25)
+        }
+        if (event.key === '-') {
+          event.preventDefault()
+          zoomTo(scale / 1.25)
+        }
+        if (event.key === '0') {
+          event.preventDefault()
+          chooseView('fit')
+        }
+      }}
+    >
       <div className="flex shrink-0 items-center gap-3 px-4 py-3">
         <ModalTitle className="min-w-0 flex-1 truncate font-sans text-sm sm:text-sm">{frame.name}</ModalTitle>
-        {document.fullscreenEnabled && !fullscreen && (
+        {document.fullscreenEnabled && (
           <Button
             variant="inverse"
             size="sm"
             onClick={() => {
               /* Embedded browsers may deny native fullscreen; the window-
                    filling presentation remains usable without permission. */
-              void surface.current?.requestFullscreen().catch(() => {})
+              if (fullscreen) {
+                leavingFullscreen.current = true
+                void document.exitFullscreen().catch(() => {
+                  leavingFullscreen.current = false
+                })
+              } else {
+                void surface.current?.requestFullscreen().catch(() => {})
+              }
             }}
           >
-            Fullscreen
+            {fullscreen ? 'Exit fullscreen' : 'Fullscreen'}
           </Button>
         )}
         <Button variant="inverse" size="sm" onClick={close} aria-label="Close presentation">
           <span aria-hidden="true">✕</span> Close <span className="font-mono text-xs opacity-60">Esc</span>
         </Button>
       </div>
-      <div className="min-h-0 flex-1 px-4 pb-4">
-        <div ref={stage} className="flex h-full w-full items-center justify-center overflow-hidden">
-          <div className="relative shrink-0" style={{ width: frame.width * scale, height: frame.height * scale }}>
-            <iframe
-              ref={iframe}
-              title={`Presentation: ${frame.name}`}
-              sandbox="allow-scripts"
-              srcDoc={FRAME_BOOTSTRAP}
-              className="absolute left-0 top-0 origin-top-left border-0 bg-white"
-              style={{ width: frame.width, height: frame.height, transform: `scale(${scale})` }}
-            />
+      <div
+        className="flex shrink-0 flex-wrap items-center justify-center gap-1 border-y border-white/15 px-3 py-2"
+        role="group"
+        aria-label="Presentation viewing controls"
+      >
+        <Button
+          variant="inverse"
+          size="sm"
+          aria-pressed={view.mode === 'fit'}
+          className={view.mode === 'fit' ? 'bg-white/15' : ''}
+          onClick={() => chooseView('fit')}
+          title="Fit entire frame (0)"
+        >
+          Fit
+        </Button>
+        <Button
+          variant="inverse"
+          size="sm"
+          aria-pressed={view.mode === 'width'}
+          className={view.mode === 'width' ? 'bg-white/15' : ''}
+          onClick={() => chooseView('width')}
+        >
+          Fit width
+        </Button>
+        <Button
+          variant="inverse"
+          size="sm"
+          aria-pressed={view.mode === 'custom' && scale === 1}
+          className={view.mode === 'custom' && scale === 1 ? 'bg-white/15' : ''}
+          onClick={() => chooseView('custom')}
+          title="Actual size"
+        >
+          100%
+        </Button>
+        <span className="mx-1 h-4 w-px bg-white/20" aria-hidden="true" />
+        <Button
+          variant="inverse"
+          size="icon-sm"
+          aria-label="Zoom out"
+          title="Zoom out (-)"
+          disabled={scale <= limits.min}
+          onClick={() => zoomTo(scale / 1.25)}
+        >
+          −
+        </Button>
+        <output className="w-14 text-center font-mono text-xs" aria-label="Zoom level">
+          {Math.round(scale * 100)}%
+        </output>
+        <Button
+          variant="inverse"
+          size="icon-sm"
+          aria-label="Zoom in"
+          title="Zoom in (+)"
+          disabled={scale >= limits.max}
+          onClick={() => zoomTo(scale * 1.25)}
+        >
+          +
+        </Button>
+        <span className="mx-1 h-4 w-px bg-white/20" aria-hidden="true" />
+        <Button
+          variant="inverse"
+          size="sm"
+          aria-pressed={pan}
+          className={pan ? 'bg-white/15' : ''}
+          onClick={() => setPan(true)}
+        >
+          Move view
+        </Button>
+        <Button
+          variant="inverse"
+          size="sm"
+          aria-pressed={!pan}
+          className={!pan ? 'bg-white/15' : ''}
+          onClick={() => setPan(false)}
+        >
+          Interact
+        </Button>
+      </div>
+      <div className="min-h-0 flex-1 px-3 pt-3">
+        <div
+          ref={stage}
+          role="region"
+          aria-label="Frame viewport"
+          aria-describedby="presentation-view-help"
+          tabIndex={0}
+          className="h-full w-full overflow-auto overscroll-contain outline-none focus-visible:ring-2 focus-visible:ring-white/40"
+          style={{
+            scrollbarGutter: 'stable both-edges',
+            touchAction: pan ? 'none' : 'auto',
+            cursor: pan ? (dragging ? 'grabbing' : 'grab') : undefined,
+          }}
+          onPointerDown={(event) => {
+            if (!pan || event.button !== 0 || !event.isPrimary) return
+            const el = event.currentTarget
+            const rect = el.getBoundingClientRect()
+            const x = event.clientX - rect.left - el.clientLeft
+            const y = event.clientY - rect.top - el.clientTop
+            // Leave native scrollbar dragging to the browser.
+            if (x < 0 || x >= el.clientWidth || y < 0 || y >= el.clientHeight) return
+            el.focus()
+            el.setPointerCapture(event.pointerId)
+            drag.current = {
+              id: event.pointerId,
+              x: event.clientX,
+              y: event.clientY,
+              left: el.scrollLeft,
+              top: el.scrollTop,
+            }
+            setDragging(true)
+            event.preventDefault()
+          }}
+          onPointerMove={(event) => {
+            const start = drag.current
+            if (!start || start.id !== event.pointerId) return
+            event.currentTarget.scrollTo(start.left + start.x - event.clientX, start.top + start.y - event.clientY)
+          }}
+          onPointerUp={(event) => {
+            if (event.currentTarget.hasPointerCapture(event.pointerId))
+              event.currentTarget.releasePointerCapture(event.pointerId)
+          }}
+          onLostPointerCapture={() => {
+            drag.current = null
+            setDragging(false)
+          }}
+        >
+          <div
+            className="grid min-h-full min-w-full place-items-center"
+            style={{ width: frame.width * scale, height: frame.height * scale }}
+          >
+            <div className="relative shrink-0" style={{ width: frame.width * scale, height: frame.height * scale }}>
+              <iframe
+                ref={iframe}
+                title={`Presentation: ${frame.name}`}
+                sandbox="allow-scripts"
+                srcDoc={FRAME_BOOTSTRAP}
+                tabIndex={pan ? -1 : 0}
+                className="absolute left-0 top-0 origin-top-left border-0 bg-white"
+                style={{
+                  width: frame.width,
+                  height: frame.height,
+                  transform: `scale(${scale})`,
+                  pointerEvents: pan ? 'none' : 'auto',
+                }}
+              />
+            </div>
           </div>
         </div>
       </div>
+      <p id="presentation-view-help" className="shrink-0 px-3 py-2 text-center text-xs text-white/60">
+        {pan
+          ? 'Drag or scroll to move · Ctrl/⌘ + scroll to zoom · + / − to zoom · 0 to fit'
+          : 'Use the page’s links and controls · Switch to Move view to pan and zoom'}
+      </p>
     </div>
   )
 }

--- a/src/components/FramePresentation.tsx
+++ b/src/components/FramePresentation.tsx
@@ -1,0 +1,114 @@
+import { useEffect, useLayoutEffect, useRef, useState } from 'react'
+import type { Frame } from '../../shared/types'
+import { FRAME_BOOTSTRAP } from '../lib/frameRuntime'
+import { useStore } from '../lib/store'
+import { Button } from './ui/button'
+import { Modal, ModalTitle } from './ui/modal'
+
+export function FramePresentation() {
+  const frame = useStore((s) => s.canvas?.frames.find((f) => f.id === s.presentedFrameId))
+  return frame ? (
+    <Modal
+      size="fullscreen"
+      onClose={() => useStore.getState().presentFrame(null)}
+      aria-describedby={undefined}
+      onKeyDown={(event) => event.stopPropagation()}
+      onPaste={(event) => event.stopPropagation()}
+    >
+      <Presentation key={frame.id} frame={frame} />
+    </Modal>
+  ) : null
+}
+
+function Presentation({ frame }: { frame: Frame }) {
+  const presentFrame = useStore((s) => s.presentFrame)
+  const surface = useRef<HTMLDivElement>(null)
+  const stage = useRef<HTMLDivElement>(null)
+  const iframe = useRef<HTMLIFrameElement>(null)
+  const [ready, setReady] = useState(false)
+  const [scale, setScale] = useState(0)
+  const [fullscreen, setFullscreen] = useState(false)
+  const close = () => presentFrame(null)
+
+  /* Measure the available stage, including when browser fullscreen or device
+     rotation changes it. The iframe keeps its design viewport at every size. */
+  useLayoutEffect(() => {
+    const el = stage.current!
+    const observer = new ResizeObserver(([entry]) => {
+      setScale(Math.min(entry.contentRect.width / frame.width, entry.contentRect.height / frame.height))
+    })
+    observer.observe(el)
+    return () => observer.disconnect()
+  }, [frame.width, frame.height])
+
+  useEffect(() => {
+    function onMessage(event: MessageEvent) {
+      if (event.source !== iframe.current?.contentWindow) return
+      if (event.data?.type === 'doop:frame-ready') setReady(true)
+      /* Keyboard events in a sandboxed iframe do not bubble to the dialog. */
+      if (event.data?.type === 'doop:frame-esc') presentFrame(null)
+    }
+    window.addEventListener('message', onMessage)
+    return () => window.removeEventListener('message', onMessage)
+  }, [presentFrame])
+
+  useEffect(() => {
+    if (ready) iframe.current?.contentWindow?.postMessage({ type: 'doop:html', html: frame.html }, '*')
+  }, [ready, frame.html])
+
+  useEffect(() => {
+    const el = surface.current!
+    let entered = false
+    function onFullscreenChange() {
+      const active = document.fullscreenElement === el
+      setFullscreen(active)
+      /* The browser consumes Escape in native fullscreen. Its exit event
+         must close the presentation too, so one Escape always returns. */
+      if (entered && !active) presentFrame(null)
+      entered = active
+    }
+    document.addEventListener('fullscreenchange', onFullscreenChange)
+    return () => {
+      document.removeEventListener('fullscreenchange', onFullscreenChange)
+      if (document.fullscreenElement === el) void document.exitFullscreen().catch(() => {})
+    }
+  }, [presentFrame])
+
+  return (
+    <div ref={surface} className="flex h-full w-full flex-col bg-ink text-white">
+      <div className="flex shrink-0 items-center gap-3 px-4 py-3">
+        <ModalTitle className="min-w-0 flex-1 truncate font-sans text-sm sm:text-sm">{frame.name}</ModalTitle>
+        {document.fullscreenEnabled && !fullscreen && (
+          <Button
+            variant="inverse"
+            size="sm"
+            onClick={() => {
+              /* Embedded browsers may deny native fullscreen; the window-
+                   filling presentation remains usable without permission. */
+              void surface.current?.requestFullscreen().catch(() => {})
+            }}
+          >
+            Fullscreen
+          </Button>
+        )}
+        <Button variant="inverse" size="sm" onClick={close} aria-label="Close presentation">
+          <span aria-hidden="true">✕</span> Close <span className="font-mono text-xs opacity-60">Esc</span>
+        </Button>
+      </div>
+      <div className="min-h-0 flex-1 px-4 pb-4">
+        <div ref={stage} className="flex h-full w-full items-center justify-center overflow-hidden">
+          <div className="relative shrink-0" style={{ width: frame.width * scale, height: frame.height * scale }}>
+            <iframe
+              ref={iframe}
+              title={`Presentation: ${frame.name}`}
+              sandbox="allow-scripts"
+              srcDoc={FRAME_BOOTSTRAP}
+              className="absolute left-0 top-0 origin-top-left border-0 bg-white"
+              style={{ width: frame.width, height: frame.height, transform: `scale(${scale})` }}
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/FrameView.tsx
+++ b/src/components/FrameView.tsx
@@ -555,6 +555,20 @@ export const FrameView = memo(function FrameView({ frame, raster }: { frame: Fra
               </Tooltip>
             )}
             <span className="overflow-hidden text-ellipsis">{frame.name}</span>
+            <Tooltip label="Present frame">
+              <Button
+                variant="bare"
+                size="icon-sm"
+                className="size-5"
+                aria-label={`Present ${frame.name}`}
+                onPointerDown={(e) => e.stopPropagation()}
+                onClick={() => useStore.getState().presentFrame(frame.id)}
+              >
+                <svg viewBox="0 0 16 16" fill="none" aria-hidden="true">
+                  <path d="m5 3 8 5-8 5V3Z" stroke="currentColor" strokeLinejoin="round" />
+                </svg>
+              </Button>
+            </Tooltip>
             <span className="flex gap-1">
               {stream && (
                 <span className={EDITOR_CHIP} style={{ background: stream.color }}>

--- a/src/components/Stage.tsx
+++ b/src/components/Stage.tsx
@@ -108,6 +108,7 @@ export function Stage({ onAddFrame }: { onAddFrame: () => void }) {
     const DURATION = 700
     const ease = (t: number) => (t < 0.5 ? 4 * t * t * t : 1 - Math.pow(-2 * t + 2, 3) / 2)
     let raf = requestAnimationFrame(function step(now: number) {
+      if (useStore.getState().presentedFrameId) return
       const k = ease(Math.min(1, (now - start) / DURATION))
       setViewport({
         x: from.x + (target.x - from.x) * k,
@@ -303,6 +304,7 @@ export function Stage({ onAddFrame }: { onAddFrame: () => void }) {
       })
     }
     function onKey(e: KeyboardEvent) {
+      if (useStore.getState().presentedFrameId) return
       if (!(e.metaKey || e.ctrlKey) || e.altKey) return
       const t = e.target as HTMLElement
       if (t.tagName === 'INPUT' || t.tagName === 'TEXTAREA' || t.isContentEditable) return
@@ -337,6 +339,7 @@ export function Stage({ onAddFrame }: { onAddFrame: () => void }) {
       return t.tagName === 'INPUT' || t.tagName === 'TEXTAREA' || t.isContentEditable
     }
     function onDown(e: KeyboardEvent) {
+      if (useStore.getState().presentedFrameId) return
       if (e.key !== ' ' || isTyping(e)) return
       e.preventDefault()
       if (!useStore.getState().panMode) useStore.getState().setPanMode(true)

--- a/src/components/Stage.tsx
+++ b/src/components/Stage.tsx
@@ -108,6 +108,9 @@ export function Stage({ onAddFrame }: { onAddFrame: () => void }) {
     const DURATION = 700
     const ease = (t: number) => (t < 0.5 ? 4 * t * t * t : 1 - Math.pow(-2 * t + 2, 3) / 2)
     let raf = requestAnimationFrame(function step(now: number) {
+      /* Presentation cancels this camera request, rather than pausing it:
+         closing must retain the exact viewport at entry, with no delayed
+         glide or snap. A new request after closing can navigate normally. */
       if (useStore.getState().presentedFrameId) return
       const k = ease(Math.min(1, (now - start) / DURATION))
       setViewport({

--- a/src/components/ui/modal.tsx
+++ b/src/components/ui/modal.tsx
@@ -23,6 +23,8 @@ const modalVariants = cva(
         md: 'max-w-[min(520px,calc(100vw-24px))]',
         lg: 'max-w-[min(620px,calc(100vw-24px))] sm:max-w-[660px]',
         xl: 'max-w-[min(760px,calc(100vw-24px))]',
+        fullscreen:
+          'inset-0 h-dvh max-h-none max-w-none translate-x-0 translate-y-0 overflow-hidden rounded-none border-0 p-0 animate-none sm:max-h-none sm:rounded-none sm:p-0',
       },
     },
     defaultVariants: { size: 'md' },

--- a/src/lib/frameRuntime.ts
+++ b/src/lib/frameRuntime.ts
@@ -255,6 +255,7 @@ export const FRAME_BOOTSTRAP = `<!doctype html>
   })
 
   document.addEventListener('keydown', function (ev) {
+    if (ev.key === 'Escape') parent.postMessage({ type: 'doop:frame-esc' }, '*')
     if (editing && ev.key === 'Escape') {
       setEdit(false)
       parent.postMessage({ type: 'doop:edit-esc' }, '*')

--- a/src/lib/presentationView.ts
+++ b/src/lib/presentationView.ts
@@ -1,0 +1,36 @@
+export type PresentationSize = { width: number; height: number }
+export type PresentationMode = 'fit' | 'width' | 'custom'
+
+export function presentationScale(
+  mode: PresentationMode,
+  zoom: number,
+  stage: PresentationSize,
+  frame: PresentationSize,
+) {
+  if (mode === 'custom') return zoom
+  const widthScale = stage.width / frame.width
+  return mode === 'width' ? widthScale : Math.min(widthScale, stage.height / frame.height)
+}
+
+/** Keep automatic fit sizes reachable even for unusually large or small frames. */
+export function presentationZoomLimits(stage: PresentationSize, frame: PresentationSize) {
+  return {
+    min: Math.min(0.1, presentationScale('fit', 1, stage, frame)),
+    max: Math.max(4, presentationScale('width', 1, stage, frame)),
+  }
+}
+
+/** Preserve the design point under the cursor (or viewport centre) during zoom. */
+export function zoomedScroll(
+  scroll: number,
+  anchor: number,
+  viewport: number,
+  design: number,
+  before: number,
+  after: number,
+) {
+  const oldMargin = Math.max(0, (viewport - design * before) / 2)
+  const newMargin = Math.max(0, (viewport - design * after) / 2)
+  const point = (scroll + anchor - oldMargin) / before
+  return Math.max(0, Math.min(design * after - viewport, point * after + newMargin - anchor))
+}

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -52,6 +52,8 @@ interface State {
   /** open frame context menu; deferPanel hides the Inspector until it closes
    *  (right-click selecting a frame must not slide a panel in under the menu) */
   ctxMenu: { frameId: string; deferPanel: boolean } | null
+  /** frame shown in the presentation overlay; the canvas stays mounted */
+  presentedFrameId: string | null
   viewport: Viewport
   /** live alignment guide lines while a frame drag is snapped to a neighbour */
   snapGuides: SnapGuide[]
@@ -114,6 +116,7 @@ interface State {
   setInspectorOpen(v: boolean): void
   openCtxMenu(menu: { frameId: string; deferPanel: boolean }): void
   closeCtxMenu(): void
+  presentFrame(id: string | null): void
   setViewport(v: Viewport): void
   setSnapGuides(guides: SnapGuide[]): void
   flash(frameId: string, color: string): void
@@ -139,6 +142,7 @@ export const useStore = create<State>((set, get) => ({
   panMode: false,
   inspectorOpen: false,
   ctxMenu: null,
+  presentedFrameId: null,
   viewport: { x: 0, y: 0, zoom: 1 },
   snapGuides: [],
   connected: false,
@@ -146,7 +150,11 @@ export const useStore = create<State>((set, get) => ({
   flashes: {},
   streams: {},
 
-  setCanvas: (canvas) => set({ canvas }),
+  setCanvas: (canvas) =>
+    set((s) => ({
+      canvas,
+      presentedFrameId: canvas?.frames.some((f) => f.id === s.presentedFrameId) ? s.presentedFrameId : null,
+    })),
   setConnected: (connected) => set({ connected }),
   setUpdateReady: (updateReady) => set({ updateReady }),
   setPresences: (list) => set({ presences: Object.fromEntries(list.map((p) => [p.clientId, p])) }),
@@ -230,6 +238,7 @@ export const useStore = create<State>((set, get) => ({
         /* an open Inspector must not silently retarget onto the promoted frame */
         inspectorOpen: s.selectedId === frameId ? false : s.inspectorOpen,
         ctxMenu: s.ctxMenu?.frameId === frameId ? null : s.ctxMenu,
+        presentedFrameId: s.presentedFrameId === frameId ? null : s.presentedFrameId,
       }
     }),
   renameCanvasLocal: (name) => set((s) => (s.canvas ? { canvas: { ...s.canvas, name } } : {})),
@@ -297,7 +306,13 @@ export const useStore = create<State>((set, get) => ({
   setInspectorOpen: (inspectorOpen) => set({ inspectorOpen }),
   openCtxMenu: (ctxMenu) => set({ ctxMenu }),
   closeCtxMenu: () => set({ ctxMenu: null }),
-  setViewport: (viewport) => set({ viewport }),
+  presentFrame: (id) =>
+    set((s) => ({
+      presentedFrameId: s.canvas?.frames.some((f) => f.id === id) ? id : null,
+      panMode: false,
+    })),
+  /* Freeze pending wheel ticks and agent camera requests as well as input. */
+  setViewport: (viewport) => set((s) => (s.presentedFrameId ? s : { viewport })),
   /* fires on every pointermove during a drag — skip the no-op transitions
      so unsnapped drags don't render the (empty) guide layer each frame */
   setSnapGuides: (snapGuides) =>

--- a/src/pages/CanvasPage.tsx
+++ b/src/pages/CanvasPage.tsx
@@ -15,6 +15,7 @@ import { navigate } from '../App'
 import { Logo } from '../components/Logo'
 import { ensureTab } from '../lib/desktop'
 import { Stage } from '../components/Stage'
+import { FramePresentation } from '../components/FramePresentation'
 import { Board } from '../components/Board'
 import { Inspector } from '../components/Inspector'
 import { ActivityPanel } from '../components/ActivityPanel'
@@ -129,6 +130,7 @@ export function CanvasPage({ canvasId }: { canvasId: string }) {
   /* frame keyboard shortcuts: delete, copy/paste/duplicate, undo/redo */
   useEffect(() => {
     function onKey(e: KeyboardEvent) {
+      if (useStore.getState().presentedFrameId) return
       const t = e.target as HTMLElement
       if (t.tagName === 'INPUT' || t.tagName === 'TEXTAREA' || t.isContentEditable) return
       const sel = useStore.getState().selectedId
@@ -170,6 +172,7 @@ export function CanvasPage({ canvasId }: { canvasId: string }) {
      without a permission prompt. */
   useEffect(() => {
     function onPaste(e: ClipboardEvent) {
+      if (useStore.getState().presentedFrameId) return
       const t = e.target as HTMLElement
       if (t.tagName === 'INPUT' || t.tagName === 'TEXTAREA' || t.isContentEditable) return
       const images = [...(e.clipboardData?.files ?? [])].filter((f) => f.type.startsWith('image/'))
@@ -478,6 +481,7 @@ export function CanvasPage({ canvasId }: { canvasId: string }) {
         </>
       )}
 
+      <FramePresentation />
       {renaming && <RenameSelfModal current={me.name} onClose={() => setRenaming(false)} />}
       {showConnect && <ConnectModal canvasId={canvasId} onClose={() => setShowConnect(false)} />}
       {showShare && canvas && (

--- a/tests/framePresentation.test.ts
+++ b/tests/framePresentation.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import type { Canvas, Frame } from '../shared/types'
+import { useStore } from '../src/lib/store'
+
+const frame: Frame = {
+  id: 'f1',
+  canvasId: 'c1',
+  name: 'Desktop',
+  x: 100,
+  y: 200,
+  width: 1440,
+  height: 900,
+  html: '<h1>Hello</h1>',
+  createdAt: 1,
+  updatedAt: 1,
+  updatedBy: 'test',
+}
+const canvas: Canvas = { id: 'c1', name: 'Designs', createdAt: 1, updatedAt: 1, frames: [frame] }
+const viewport = { x: -173, y: 81, zoom: 0.65 }
+
+beforeEach(() => {
+  const s = useStore.getState()
+  s.presentFrame(null)
+  s.setCanvas(canvas)
+  s.select(frame.id)
+  s.setInspectorOpen(true)
+  s.setViewport(viewport)
+})
+
+describe('frame presentation', () => {
+  it('preserves the viewport and selection, ignoring camera updates until closed', () => {
+    const s = useStore.getState()
+    s.setPanMode(true)
+    s.presentFrame(frame.id)
+    expect(useStore.getState().panMode).toBe(false)
+    s.setViewport({ x: 0, y: 0, zoom: 1 })
+    expect(useStore.getState().viewport).toEqual(viewport)
+    s.presentFrame(null)
+    expect(useStore.getState()).toMatchObject({ viewport, selectedIds: [frame.id], inspectorOpen: true })
+    s.setViewport({ x: 20, y: 30, zoom: 1.2 })
+    expect(useStore.getState().viewport).toEqual({ x: 20, y: 30, zoom: 1.2 })
+  })
+
+  it('keeps presenting through live edits and a reconnect', () => {
+    const s = useStore.getState()
+    s.presentFrame(frame.id)
+    s.patchFrameLocal(frame.id, { html: '<h1>Updated</h1>', height: 1800 })
+    s.setCanvas(useStore.getState().canvas)
+    expect(useStore.getState().presentedFrameId).toBe(frame.id)
+    expect(useStore.getState().canvas?.frames[0].height).toBe(1800)
+  })
+
+  it('closes when the presented frame is deleted remotely', () => {
+    const s = useStore.getState()
+    s.presentFrame(frame.id)
+    s.removeFrame(frame.id)
+    expect(useStore.getState().presentedFrameId).toBeNull()
+    expect(useStore.getState().viewport).toEqual(viewport)
+  })
+
+  it('closes when leaving the canvas or reconnecting without the frame', () => {
+    const s = useStore.getState()
+    s.presentFrame(frame.id)
+    s.setCanvas({ ...canvas, frames: [] })
+    expect(useStore.getState().presentedFrameId).toBeNull()
+    s.setCanvas(canvas)
+    s.presentFrame(frame.id)
+    s.setCanvas(null)
+    expect(useStore.getState().presentedFrameId).toBeNull()
+  })
+
+  it('does not freeze the canvas for an unknown frame', () => {
+    const s = useStore.getState()
+    s.presentFrame('missing')
+    expect(useStore.getState().presentedFrameId).toBeNull()
+    s.setViewport({ x: 10, y: 20, zoom: 1 })
+    expect(useStore.getState().viewport.zoom).toBe(1)
+  })
+})

--- a/tests/presentationView.test.ts
+++ b/tests/presentationView.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+import { presentationScale, presentationZoomLimits, zoomedScroll } from '../src/lib/presentationView'
+
+const stage = { width: 1200, height: 800 }
+const tall = { width: 1440, height: 3600 }
+
+describe('presentation viewing geometry', () => {
+  it('fits the whole tall page or its width without changing its design viewport', () => {
+    expect(presentationScale('fit', 1, stage, tall)).toBeCloseTo(800 / 3600)
+    expect(presentationScale('width', 1, stage, tall)).toBeCloseTo(1200 / 1440)
+    expect(presentationScale('custom', 1, stage, tall)).toBe(1)
+  })
+
+  it('adapts fit modes to rotation while keeping manual zoom unchanged', () => {
+    const portrait = { width: 390, height: 700 }
+    expect(presentationScale('fit', 1, portrait, tall)).toBeCloseTo(700 / 3600)
+    expect(presentationScale('width', 1, portrait, tall)).toBeCloseTo(390 / 1440)
+    expect(presentationScale('custom', 1.5, portrait, tall)).toBe(1.5)
+  })
+
+  it('allows stepping out of automatic fit even beyond the normal zoom limits', () => {
+    expect(presentationZoomLimits(stage, { width: 100, height: 100 }).max).toBe(12)
+    expect(presentationZoomLimits(stage, { width: 20000, height: 20000 }).min).toBe(0.04)
+  })
+
+  it('keeps the design point beneath the cursor when zooming a scrolled page', () => {
+    // The cursor is over design y=700 before zoom, and y=1400 afterwards.
+    expect(zoomedScroll(400, 300, 800, 3600, 1, 2)).toBe(1100)
+  })
+
+  it('accounts for centred letterboxing when zooming into an overflowing frame', () => {
+    expect(zoomedScroll(0, 600, 1200, 1440, 0.5, 1)).toBe(120)
+    expect(zoomedScroll(120, 600, 1200, 1440, 1, 0.5)).toBe(0)
+  })
+
+  it('clamps panning to the edges without leaving blank space', () => {
+    expect(zoomedScroll(0, 50, 1200, 1440, 0.5, 1)).toBe(0)
+    expect(zoomedScroll(240, 1200, 1200, 1440, 1, 2)).toBe(1680)
+  })
+})


### PR DESCRIPTION
Frames can now be presented without the canvas chrome using the play button beside a frame name or **Present frame** in its context menu. The viewer preserves the frame's original HTML layout and aspect ratio, follows live HTML/size updates, and closes if the frame is deleted.

The viewer opens in **Fit** mode and offers **Fit width**, **100%**, zoom buttons, and a zoom percentage. **Move view** supports scrolling, mouse/touch dragging, cursor-centred Ctrl/⌘ + wheel zoom, and keyboard zoom (`+`, `−`, `0` to fit). **Interact** enables the embedded page's links and controls. Fit width starts at the top so tall designs are readable. The controls wrap on small screens, and automatic fit modes adapt to viewport and frame resizing.

Native fullscreen has an explicit **Exit fullscreen** control that returns to the viewer. Escape or **Close** returns to the exact canvas position and zoom from entry, including after interacting inside the sandboxed frame. Presentation intentionally cancels pending camera movement and ignores camera requests while open; fresh requests after closing still work normally.

Validation:
- Chrome checks cover fit/width/actual size, scrolling, mouse/touch panning, button/wheel/keyboard zoom, embedded interaction, fullscreen entry/exit, mobile layout, live resizing, Escape, and canvas viewport preservation.
- All 21 focused presentation, viewing-geometry, and selection tests pass.
- Type checking, lint, formatting, and production build pass on the PR tree (existing lint and bundle-size warnings only).
- The earlier full-suite run passed 255 tests; the partial-OIDC-configuration startup test timed out locally and reproduced on unchanged upstream main.

Implemented with Codex and reviewed interactively by the contributor.
