### PR TITLE
feat(mcp): add read-only access to canvas comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,6 +401,7 @@ Steering happens at three layers (the same architecture paper.design uses, plus 
 | `get_guide`            | The agent playbook — agents are instructed to load this first                                                       |
 | `set_status`           | Broadcast a one-line "what I'm working on" — shown live in the working-now strip, avatar tooltip, and activity feed |
 | `get_feedback`         | Fetch & claim open human feedback requests — for agents whose job is to poll the canvas periodically                |
+| `get_comments`         | Read element-pinned comments and replies, optionally filtered by frame or resolution state, without claiming work   |
 | `list_canvases`        | List all canvases                                                                                                   |
 | `create_canvas`        | Create a canvas, returns its shareable id                                                                           |
 | `get_canvas`           | Canvas layout: every frame's position/size/meta                                                                     |
@@ -446,7 +447,7 @@ leaving and is sent to late joiners.
 Hover any task in the Tasks tab and hit **↩** to leave feedback (e.g. _"make the accent warmer"_).
 Each note becomes an **open request on the canvas** — a work item, not mail for the agent whose
 task it was. MCP is pull-based, so delivery rides the result-nudge layer: the **next identified
-agent call** on the canvas (any tool carrying an `agent_name`, whoever it is) returns a
+agent call** on the canvas that supports feedback delivery (carrying an `agent_name`, whoever it is) returns a
 `HUMAN FEEDBACK` block quoting the note, saying whose work it concerns, and instructing the agent
 to address it before continuing — including editing another agent's frame (a human request
 overrides the don't-touch etiquette). Picking it up claims it: the UI flips from _"→ waiting for
@@ -458,6 +459,19 @@ already on the canvas, or a fresh one you spawn (_"check in on canvas ⟨id⟩"_
 caretaker, point an agent at `get_feedback` — a non-blocking fetch-and-claim designed for a
 "check the canvas every few minutes, address whatever humans requested" loop.
 REST equivalent: `POST /api/tasks/:id/feedback` with `{ text, from }`.
+
+### Reading element comments through MCP
+
+Call `get_comments({ canvas_id })` to read the canvas's retained element comments and replies
+(up to 100 entries, newest first). Each entry includes its ID, frame ID, author, text, timestamp,
+CSS selector, HTML snippet, and any claim, failure, or resolution metadata. Replies carry a
+`parentId` pointing to their root comment.
+
+Pass `frame_id` to read only comments on a frame belonging to that canvas, or
+`include_resolved: false` to exclude resolved entries. Resolved entries are included by default
+so conversation context remains available. An empty result is `[]`. The tool enforces the same
+canvas access permissions as other MCP reads; optional `agent_name` announces presence.
+It does not claim task feedback or comments, or mark anything resolved.
 
 ## What's in the box
 

--- a/server/guide.ts
+++ b/server/guide.ts
@@ -88,6 +88,13 @@ that @mentions them, or feedback on a task they ran. Anything left unaddressed i
 to you. If a human asks you for something one of these roles owns, just do it — the
 routing is for their benefit, not a lock on your work.
 
+Use get_comments({ canvas_id }) to read element-pinned comments and replies, including
+their frame, selector, snippet, author, thread links, and claim/failure/resolution state.
+Add frame_id to focus on one frame. Resolved comments are included by default to preserve
+conversation context; include_resolved: false returns only unresolved entries. The result
+is newest first and covers the retained history (up to 100 entries per canvas). Reading
+comments does not claim work or resolve it; task feedback is separate (get_feedback).
+
 ## Narrate your work — set_status
 
 People watching the canvas cannot see your reasoning, only your edits. Bridge that gap

--- a/server/mcp.ts
+++ b/server/mcp.ts
@@ -34,6 +34,7 @@ You MUST call get_guide({ topic: "doop-instructions" }) once before using other 
 - Images: real imagery makes designs. search_images finds stock photos (you SEE thumbnails and pick), search_icons finds 200k+ UI icons as hotlinkable SVGs, search_logos finds real company logos by brand name or domain, upload_asset stores your own file (remote file → source_url; local file → local_file=true, returns a curl command) and returns a permanent URL. Never inline images as data: URIs.
 - Websites: when a request names an existing site or URL — a redesign of it, or "like acme.com" — call import_webpage FIRST so an editable HTML snapshot lands on the canvas. Leave that source frame unchanged and design in a separate frame. view_website is only for read-only inspection when the page should not be added. If Doop cannot capture the site, do not retry with view_website because it uses the same capture path. Use your own browser or web tool and work only from content you actually observe; if that is unavailable, ask the user for screenshots or an HTML export rather than inventing content.
 - Feedback: humans reply to your tasks; their notes arrive inside your tool results as HUMAN FEEDBACK blocks — address them before continuing.
+- Comments: call get_comments to read element-pinned comments and replies on a canvas, optionally filtered by frame. This does not claim feedback or resolve comments.
 - Guidelines: canvases can carry named style guides (brand rules, style recipes). get_canvas lists them with one-line summaries — read the relevant ones with get_guidelines BEFORE designing and follow them.
 - Memory: canvases can also carry pinned style references — exemplar designs humans marked as "more like this". get_canvas lists them; read the relevant one with get_reference and match its look. When your human gives you design feedback in conversation and you address it, record it with save_decision so the canvas remembers their taste.`
 
@@ -565,6 +566,35 @@ export function buildMcpServer(owner?: string, ownerId?: string): McpServer {
       if (!canvasFor(canvas_id)) return noCanvas(canvas_id)
       actions.setAgentStatus(canvas_id, actorFrom(agent_name), status)
       return withFeedback(text({ ok: true, status: status.trim() || null }), canvas_id, actorFrom(agent_name))
+    },
+  )
+
+  server.registerTool(
+    'get_comments',
+    {
+      description:
+        'Read element-pinned comments and replies on a canvas, newest first, including author, text, frame, CSS selector, HTML snippet, parentId thread links, and claim/failure/resolution metadata. Includes resolved comments by default so complete conversations remain readable; set include_resolved to false for unresolved comments only. Returns the retained comment history (up to 100 entries per canvas), not an archive. Reading does not claim feedback or comments, or mark them resolved.',
+      annotations: { readOnlyHint: true },
+      inputSchema: {
+        canvas_id: z.string(),
+        frame_id: z.string().optional().describe('Only comments on this frame; it must belong to the canvas.'),
+        include_resolved: z.boolean().default(true).describe('Include resolved comments and replies. Default true.'),
+        agent_name: agentName.optional(),
+      },
+    },
+    async ({ canvas_id, frame_id, include_resolved, agent_name }) => {
+      if (!canvasFor(canvas_id)) return noCanvas(canvas_id)
+      if (frame_id !== undefined) {
+        const frame = frameFor(frame_id)
+        if (!frame || frame.canvasId !== canvas_id) return noFrame(frame_id)
+      }
+      arrive(canvas_id, agent_name)
+      const comments = actions
+        .getComments(canvas_id)
+        .filter((comment) => frame_id === undefined || comment.frameId === frame_id)
+        .filter((comment) => include_resolved || comment.resolvedAt === undefined)
+      // Deliberately omit withFeedback: inspecting comments must not claim work.
+      return text(comments)
     },
   )
 

--- a/tests/mcp-comments.test.ts
+++ b/tests/mcp-comments.test.ts
@@ -1,0 +1,289 @@
+import { Client } from '@modelcontextprotocol/sdk/client/index.js'
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import * as actions from '../server/actions.ts'
+import { buildMcpServer } from '../server/mcp.ts'
+import { store } from '../server/store.ts'
+import type { Canvas, ElementComment, Frame } from '../shared/types.ts'
+
+const OWNER_ID = 'owner-1'
+
+const CANVAS: Canvas = {
+  id: 'c1',
+  name: 'Comments',
+  ownerId: OWNER_ID,
+  createdAt: 0,
+  updatedAt: 0,
+  frames: [],
+}
+
+const FRAME_A: Frame = {
+  id: 'f1',
+  canvasId: CANVAS.id,
+  name: 'Hero',
+  html: '<h1>Hi</h1>',
+  x: 0,
+  y: 0,
+  width: 640,
+  height: 480,
+  createdAt: 0,
+  updatedAt: 0,
+  updatedBy: 'alice',
+}
+
+const FRAME_B: Frame = {
+  id: 'f2',
+  canvasId: CANVAS.id,
+  name: 'Pricing',
+  html: '<p>$</p>',
+  x: 700,
+  y: 0,
+  width: 640,
+  height: 480,
+  createdAt: 0,
+  updatedAt: 0,
+  updatedBy: 'alice',
+}
+
+function comment(overrides: Partial<ElementComment> & { id: string }): ElementComment {
+  return {
+    canvasId: CANVAS.id,
+    frameId: FRAME_A.id,
+    selector: '.hero h1',
+    snippet: '<h1>Hi</h1>',
+    from: 'alice',
+    text: 'note',
+    at: 1,
+    ...overrides,
+  }
+}
+
+interface CallResult {
+  content: Array<{ type: string; text?: string }>
+  isError?: boolean
+}
+
+async function connect(ownerId: string | undefined = OWNER_ID) {
+  const server = buildMcpServer('Test Owner', ownerId)
+  const client = new Client({ name: 'doop-comments-test', version: '1.0.0' })
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair()
+  await server.connect(serverTransport)
+  await client.connect(clientTransport)
+  return {
+    client,
+    close: async () => {
+      await client.close()
+      await server.close()
+    },
+  }
+}
+
+async function callComments(
+  client: Client,
+  args: Record<string, unknown>,
+): Promise<{ parsed: unknown; raw: string; isError?: boolean }> {
+  const result = (await client.callTool({ name: 'get_comments', arguments: args })) as unknown as CallResult
+  const raw = result.content.find((block) => block.type === 'text')?.text ?? ''
+  let parsed: unknown = raw
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    /* error strings are not JSON — leave the raw text for assertions */
+  }
+  return { parsed, raw, isError: result.isError }
+}
+
+function stubStore(canvases: Canvas[], frames: Frame[]) {
+  vi.spyOn(store, 'getCanvas').mockImplementation((id: string) => canvases.find((c) => c.id === id))
+  vi.spyOn(store, 'getFrame').mockImplementation((id: string) => frames.find((f) => f.id === id))
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks()
+  stubStore([CANVAS], [FRAME_A, FRAME_B])
+})
+
+describe('get_comments MCP tool', () => {
+  it('is read-only with canvas_id required and frame/include_resolved/agent_name optional', async () => {
+    const { client, close } = await connect()
+    try {
+      const { tools } = await client.listTools()
+      const tool = tools.find((t) => t.name === 'get_comments')
+      expect(tool).toBeDefined()
+      expect(tool!.annotations?.readOnlyHint).toBe(true)
+      const schema = tool!.inputSchema as unknown as {
+        properties?: Record<string, { default?: unknown }>
+        required?: string[]
+      }
+      expect(Object.keys(schema.properties ?? {})).toEqual(
+        expect.arrayContaining(['canvas_id', 'frame_id', 'include_resolved', 'agent_name']),
+      )
+      expect(schema.required).toEqual(['canvas_id'])
+      expect(schema.properties?.include_resolved?.default).toBe(true)
+    } finally {
+      await close()
+    }
+  })
+
+  it('returns stored comments newest first with full metadata and replies', async () => {
+    const reply = comment({ id: 'm2', text: 'Agreed', from: 'bob', at: 2, parentId: 'm1' })
+    const root = comment({
+      id: 'm1',
+      text: 'Too small',
+      at: 1,
+      forAgent: true,
+      targetAgent: 'Doop',
+      claimedBy: 'Doop',
+      claimedAt: 3,
+    })
+    const stored = [reply, root]
+    const spy = vi.spyOn(actions, 'getComments').mockReturnValue(stored)
+    const { client, close } = await connect()
+    try {
+      const { parsed, isError } = await callComments(client, { canvas_id: CANVAS.id })
+      expect(isError).toBeFalsy()
+      expect(spy).toHaveBeenCalledWith(CANVAS.id)
+      expect(parsed).toEqual(stored)
+      expect(parsed).toEqual([reply, root])
+    } finally {
+      await close()
+    }
+  })
+
+  it('filters by frame_id', async () => {
+    const stored = [
+      comment({ id: 'm3', frameId: FRAME_B.id, at: 3, text: 'on pricing' }),
+      comment({ id: 'm1', frameId: FRAME_A.id, at: 1, text: 'on hero' }),
+    ]
+    vi.spyOn(actions, 'getComments').mockReturnValue(stored)
+    const { client, close } = await connect()
+    try {
+      const { parsed } = await callComments(client, { canvas_id: CANVAS.id, frame_id: FRAME_B.id })
+      expect(parsed).toEqual([stored[0]])
+    } finally {
+      await close()
+    }
+  })
+
+  it('includes resolved comments by default and excludes them with include_resolved false', async () => {
+    const resolved = comment({ id: 'm2', at: 2, text: 'fixed', resolvedAt: 5, resolvedBy: 'alice' })
+    const open = comment({ id: 'm1', at: 1, text: 'open' })
+    vi.spyOn(actions, 'getComments').mockReturnValue([resolved, open])
+    const { client, close } = await connect()
+    try {
+      const withDefault = await callComments(client, { canvas_id: CANVAS.id })
+      expect(withDefault.parsed).toHaveLength(2)
+      const unresolvedOnly = await callComments(client, { canvas_id: CANVAS.id, include_resolved: false })
+      expect(unresolvedOnly.parsed).toEqual([open])
+    } finally {
+      await close()
+    }
+  })
+
+  it('returns an empty array when there are no comments', async () => {
+    vi.spyOn(actions, 'getComments').mockReturnValue([])
+    const { client, close } = await connect()
+    try {
+      const { parsed, isError } = await callComments(client, { canvas_id: CANVAS.id })
+      expect(isError).toBeFalsy()
+      expect(parsed).toEqual([])
+    } finally {
+      await close()
+    }
+  })
+
+  it('rejects unknown and unauthorized canvases with the existing noCanvas error', async () => {
+    vi.spyOn(actions, 'getComments')
+    const { client, close } = await connect()
+    try {
+      const unknown = await callComments(client, { canvas_id: 'missing' })
+      expect(unknown.isError).toBe(true)
+      expect(unknown.raw).toContain('no canvas with id missing')
+
+      stubStore([{ ...CANVAS, id: 'private', ownerId: 'someone-else', memberIds: [], linkAccess: 'none' }], [FRAME_A])
+      const denied = await callComments(client, { canvas_id: 'private' })
+      expect(denied.isError).toBe(true)
+      expect(denied.raw).toContain('no canvas with id private')
+    } finally {
+      await close()
+    }
+  })
+
+  it('allows owner, invited member, and link-edit access', async () => {
+    const stored = [comment({ id: 'm1', text: 'hi' })]
+    vi.spyOn(actions, 'getComments').mockReturnValue(stored)
+    for (const canvas of [
+      { ...CANVAS, ownerId: OWNER_ID },
+      { ...CANVAS, ownerId: 'someone-else', memberIds: [OWNER_ID] },
+      { ...CANVAS, ownerId: 'someone-else', memberIds: [], linkAccess: 'edit' as const },
+    ]) {
+      stubStore([canvas], [FRAME_A])
+      const { client, close } = await connect(OWNER_ID)
+      try {
+        const { parsed, isError } = await callComments(client, { canvas_id: CANVAS.id })
+        expect(isError).toBeFalsy()
+        expect(parsed).toEqual(stored)
+      } finally {
+        await close()
+      }
+    }
+  })
+
+  it('rejects a frame from another canvas and unknown frames with the existing noFrame error', async () => {
+    vi.spyOn(actions, 'getComments')
+    const otherCanvas: Canvas = { ...CANVAS, id: 'c2', ownerId: OWNER_ID }
+    const foreign: Frame = { ...FRAME_A, id: 'fx', canvasId: 'c2' }
+    stubStore([CANVAS, otherCanvas], [FRAME_A, foreign])
+    const { client, close } = await connect()
+    try {
+      const cross = await callComments(client, { canvas_id: CANVAS.id, frame_id: foreign.id })
+      expect(cross.isError).toBe(true)
+      expect(cross.raw).toContain(`no frame with id ${foreign.id}`)
+      const missing = await callComments(client, { canvas_id: CANVAS.id, frame_id: 'nope' })
+      expect(missing.isError).toBe(true)
+      expect(missing.raw).toContain('no frame with id nope')
+    } finally {
+      await close()
+    }
+  })
+
+  it('does not claim or resolve anything while reading', async () => {
+    const stored = [comment({ id: 'm1', forAgent: true, targetAgent: 'Doop', text: '@Doop bigger' })]
+    vi.spyOn(actions, 'getComments').mockReturnValue(stored)
+    const takeFeedback = vi.spyOn(actions, 'takeFeedbackFor')
+    const takeComments = vi.spyOn(actions, 'takeAgentCommentsFor')
+    const resolve = vi.spyOn(actions, 'resolveComment')
+    const before = JSON.parse(JSON.stringify(stored))
+    const { client, close } = await connect()
+    try {
+      await callComments(client, { canvas_id: CANVAS.id, agent_name: 'Claude' })
+      expect(takeFeedback).not.toHaveBeenCalled()
+      expect(takeComments).not.toHaveBeenCalled()
+      expect(resolve).not.toHaveBeenCalled()
+      expect(stored).toEqual(before)
+      expect(stored[0].claimedBy).toBeUndefined()
+      expect(stored[0].resolvedAt).toBeUndefined()
+    } finally {
+      await close()
+    }
+  })
+
+  it('heartbeats for agent_name without delivering feedback', async () => {
+    vi.spyOn(actions, 'getComments').mockReturnValue([])
+    const heartbeat = vi.spyOn(actions, 'heartbeatAgent').mockImplementation(() => {})
+    const takeFeedback = vi.spyOn(actions, 'takeFeedbackFor')
+    const { client, close } = await connect()
+    try {
+      await callComments(client, { canvas_id: CANVAS.id, agent_name: 'Claude' })
+      expect(heartbeat).toHaveBeenCalledTimes(1)
+      expect(heartbeat.mock.calls[0][0]).toBe(CANVAS.id)
+      expect(takeFeedback).not.toHaveBeenCalled()
+
+      heartbeat.mockClear()
+      await callComments(client, { canvas_id: CANVAS.id })
+      expect(heartbeat).not.toHaveBeenCalled()
+    } finally {
+      await close()
+    }
+  })
+})


### PR DESCRIPTION
## Summary

Add a `get_comments` MCP tool so external agents can read element-pinned
comments and replies. Currently, MCP exposes task feedback through
`get_feedback`, but does not expose element comments.

### Tool behavior

- Requires `canvas_id`, with optional `frame_id`, `include_resolved`, and
  `agent_name`.
- Returns retained comments newest first, including author, text, element
  anchors, parent-comment links, and claim/failure/resolution metadata.
- Includes resolved comments by default to preserve conversation context;
  `include_resolved: false` returns only unresolved entries.
- Enforces existing canvas access permissions and verifies that a requested
  frame belongs to the canvas.
- Does not claim feedback or comments, or mark them resolved.
- Uses the existing retained history, capped at 100 entries per canvas.

Also updates the MCP instructions, agent guide, and README to document the tool.

## Validation

- Added 10 MCP tests covering the tool schema, comment and reply data,
  filtering, empty results, access permissions, and read-only behavior.
- All 257 tests passed with `bun run test --maxWorkers=2`.
- Type-checking, lint, formatting, documentation checks, and production
  build passed, with non-blocking warnings.
- The initial unrestricted test run hit an ingest-server startup timeout;
  that suite passed independently and in the bounded full run.

Additionally verified against a local copy of an 86-frame design canvas:
created test comments and a reply through REST, read them through the MCP
SDK's in-memory transport against real server state, and confirmed filtering,
unchanged comment state, and results after database rehydration.

The local verification used synthetic test comments, not existing hosted
comments. Its design data and temporary test artifacts are not included
in this PR.