### PR TITLE
fix: make Anthropic client timeout configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,20 +187,21 @@ authenticate over OAuth and drive the canvas from outside, on your own subscript
 Three paths, same canvas: the Doop Agent on our key (free tier), the Doop Agent on your key, or your
 own agent over MCP.
 
-| Variable                        | Default                     | What it does                                                                         |
-| ------------------------------- | --------------------------- | ------------------------------------------------------------------------------------ |
-| `DOOP_AGENT_PROVIDER`           | `anthropic`                 | What the free tier runs on: `anthropic` \| `azure`                                   |
-| `ANTHROPIC_API_KEY`             | _unset_                     | Pays for the free Doop Agent tier (default provider) and the distiller               |
-| `AZURE_OPENAI_ENDPOINT`         | _unset_                     | The free tier's Azure OpenAI resource, when `DOOP_AGENT_PROVIDER=azure`              |
-| `AZURE_OPENAI_API_KEY`          | _unset_                     | A key of that resource                                                               |
-| `AZURE_OPENAI_DEPLOYMENT`       | _unset_                     | The deployment the free tier runs on                                                 |
-| `AZURE_OPENAI_API_VERSION`      | _unset_                     | Pins an `api-version` query parameter; the v1 surface needs none                     |
-| `AZURE_OPENAI_REASONING_EFFORT` | _unset_                     | Reasoning effort on Azure runs; unset sends none (non-reasoning-safe)                |
-| `RESIDENT_TASK_LIMIT`           | `0`                         | Free Doop Agent tasks per account; `0` means a connected account from the first task |
-| `DOOP_AGENT_MODEL`              | `claude-opus-5`             | Model for the Doop Agent on the server's Anthropic key                               |
-| `DOOP_AGENT_OPENAI_MODEL`       | `gpt-5.6-terra`             | Default tier on a user's account; each user can pick another in Settings             |
-| `CHATGPT_CONNECT_DISABLED`      | _unset_                     | `1` hides the ChatGPT flow, leaving the API-key path                                 |
-| `DOOP_DISTILL_MODEL`            | `claude-haiku-4-5-20251001` | Model for the guideline distiller                                                    |
+| Variable                        | Default                     | What it does                                                                                                                                          |
+| ------------------------------- | --------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `DOOP_AGENT_PROVIDER`           | `anthropic`                 | What the free tier runs on: `anthropic` \| `azure`                                                                                                    |
+| `ANTHROPIC_API_KEY`             | _unset_                     | Pays for the free Doop Agent tier (default provider) and the distiller                                                                                |
+| `ANTHROPIC_TIMEOUT_MS`          | `900000` (15 min)           | Timeout for every Anthropic SDK client, so a large `max_tokens` run (e.g. GitHub recon) does not fail the SDK's default 10-minute non-streaming check |
+| `AZURE_OPENAI_ENDPOINT`         | _unset_                     | The free tier's Azure OpenAI resource, when `DOOP_AGENT_PROVIDER=azure`                                                                               |
+| `AZURE_OPENAI_API_KEY`          | _unset_                     | A key of that resource                                                                                                                                |
+| `AZURE_OPENAI_DEPLOYMENT`       | _unset_                     | The deployment the free tier runs on                                                                                                                  |
+| `AZURE_OPENAI_API_VERSION`      | _unset_                     | Pins an `api-version` query parameter; the v1 surface needs none                                                                                      |
+| `AZURE_OPENAI_REASONING_EFFORT` | _unset_                     | Reasoning effort on Azure runs; unset sends none (non-reasoning-safe)                                                                                 |
+| `RESIDENT_TASK_LIMIT`           | `0`                         | Free Doop Agent tasks per account; `0` means a connected account from the first task                                                                  |
+| `DOOP_AGENT_MODEL`              | `claude-opus-5`             | Model for the Doop Agent on the server's Anthropic key                                                                                                |
+| `DOOP_AGENT_OPENAI_MODEL`       | `gpt-5.6-terra`             | Default tier on a user's account; each user can pick another in Settings                                                                              |
+| `CHATGPT_CONNECT_DISABLED`      | _unset_                     | `1` hides the ChatGPT flow, leaving the API-key path                                                                                                  |
+| `DOOP_DISTILL_MODEL`            | `claude-haiku-4-5-20251001` | Model for the guideline distiller                                                                                                                     |
 
 `RESIDENT_TASK_LIMIT` is the free-tier meter. By default it is `0`: the Doop Agent only runs once
 the user connects a model account (their ChatGPT subscription or an OpenAI key) — a connected

--- a/server/agentModel.ts
+++ b/server/agentModel.ts
@@ -1,4 +1,5 @@
 import Anthropic from '@anthropic-ai/sdk'
+import { ANTHROPIC_TIMEOUT_MS } from './anthropicTimeout.ts'
 import { getAccount, withFreshToken } from './modelAccounts.ts'
 import type { AccountKind, ModelAccount } from './modelAccounts.ts'
 import { modelFor, ModelAuthError, runAzureTurn, runOpenAiTurn } from './openaiAgent.ts'
@@ -64,7 +65,7 @@ function anthropicTier(): AgentModel | null {
     )
     return null
   }
-  if (!anthropic) anthropic = new Anthropic()
+  if (!anthropic) anthropic = new Anthropic({ timeout: ANTHROPIC_TIMEOUT_MS })
   const client = anthropic
   return {
     provider: 'anthropic',

--- a/server/anthropicTimeout.ts
+++ b/server/anthropicTimeout.ts
@@ -1,0 +1,25 @@
+/**
+ * Shared timeout for every `@anthropic-ai/sdk` client the server creates.
+ *
+ * The SDK rejects a non-streaming request up front once its max_tokens
+ * implies a generation time past its default 10-minute timeout ("Streaming
+ * is required for operations that may take longer than 10 minutes."). The
+ * Doop Agent's GitHub-recon pass asks for up to 32k output tokens, which
+ * trips that default. `ANTHROPIC_TIMEOUT_MS` raises the client's own timeout
+ * so the SDK's estimate clears it instead.
+ */
+export const DEFAULT_ANTHROPIC_TIMEOUT_MS = 15 * 60 * 1000
+
+/** Pure so it's testable without mocking process.env / module state. */
+export function resolveAnthropicTimeoutMs(env: Record<string, string | undefined>): number {
+  const raw = env.ANTHROPIC_TIMEOUT_MS
+  if (!raw) return DEFAULT_ANTHROPIC_TIMEOUT_MS
+  const parsed = Number(raw)
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    console.error(`[anthropic] ignoring invalid ANTHROPIC_TIMEOUT_MS=${raw}, using default`)
+    return DEFAULT_ANTHROPIC_TIMEOUT_MS
+  }
+  return parsed
+}
+
+export const ANTHROPIC_TIMEOUT_MS = resolveAnthropicTimeoutMs(process.env)

--- a/server/distill.ts
+++ b/server/distill.ts
@@ -1,4 +1,5 @@
 import Anthropic from '@anthropic-ai/sdk'
+import { ANTHROPIC_TIMEOUT_MS } from './anthropicTimeout.ts'
 import { store } from './store.ts'
 import * as actions from './actions.ts'
 
@@ -22,7 +23,7 @@ let client: Anthropic | null = null
 
 function getClient(): Anthropic | null {
   if (!process.env.ANTHROPIC_API_KEY) return null
-  if (!client) client = new Anthropic()
+  if (!client) client = new Anthropic({ timeout: ANTHROPIC_TIMEOUT_MS })
   return client
 }
 

--- a/tests/anthropicTimeout.test.ts
+++ b/tests/anthropicTimeout.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest'
+import { DEFAULT_ANTHROPIC_TIMEOUT_MS, resolveAnthropicTimeoutMs } from '../server/anthropicTimeout.ts'
+
+describe('resolveAnthropicTimeoutMs', () => {
+  it('defaults to 15 minutes when unset', () => {
+    expect(resolveAnthropicTimeoutMs({})).toBe(DEFAULT_ANTHROPIC_TIMEOUT_MS)
+    expect(DEFAULT_ANTHROPIC_TIMEOUT_MS).toBe(15 * 60 * 1000)
+  })
+
+  it('uses ANTHROPIC_TIMEOUT_MS when it is a positive number', () => {
+    expect(resolveAnthropicTimeoutMs({ ANTHROPIC_TIMEOUT_MS: '600000' })).toBe(600_000)
+  })
+
+  it('falls back to the default for empty, non-numeric, zero, or negative values', () => {
+    expect(resolveAnthropicTimeoutMs({ ANTHROPIC_TIMEOUT_MS: '' })).toBe(DEFAULT_ANTHROPIC_TIMEOUT_MS)
+    expect(resolveAnthropicTimeoutMs({ ANTHROPIC_TIMEOUT_MS: 'not-a-number' })).toBe(DEFAULT_ANTHROPIC_TIMEOUT_MS)
+    expect(resolveAnthropicTimeoutMs({ ANTHROPIC_TIMEOUT_MS: '0' })).toBe(DEFAULT_ANTHROPIC_TIMEOUT_MS)
+    expect(resolveAnthropicTimeoutMs({ ANTHROPIC_TIMEOUT_MS: '-5' })).toBe(DEFAULT_ANTHROPIC_TIMEOUT_MS)
+  })
+})


### PR DESCRIPTION
Part of #115 (the timeout half only — extractHtml resilience is a separate PR, coming after this one).

## Problem

`githubRecon.ts` runs the model with `max_tokens: 32_000` (`MODEL_MAX_TOKENS`). The Anthropic SDK check the requested `max_tokens` before sending and estimate it can take more than 10 minutes, so it throw:

```
Streaming is required for operations that may take longer than 10 minutes.
```

before the request go out at all. Both `agentModel.ts` and `distill.ts` create their `Anthropic` client with no options, so they get the SDK's own default timeout, which is what trip this check.

## Fix

- New `server/anthropicTimeout.ts` reads `ANTHROPIC_TIMEOUT_MS` from env (default 15 minutes = `900000`), with a pure `resolveAnthropicTimeoutMs()` function so it is testable without mocking env/module state.
- Both places that build an `Anthropic` client (`agentModel.ts`'s server tier, `distill.ts`) now pass `{ timeout: ANTHROPIC_TIMEOUT_MS }`, applied consistently like the issue asks.
- Documented the new var in the README env table.

## Testing

- `tests/anthropicTimeout.test.ts` — default value, a valid override, and fallback to default for empty/non-numeric/zero/negative values.
- `bun run test` — 250/250 pass.
- `bun run typecheck` and `bun run lint` — clean (only pre-existing warnings unrelated to this change).
- `bun run format:check` — clean.

I am not a native English speaker, sorry for any strange wording in the commit/PR text.