### PR TITLE
fix(github-recon): handle Anthropic timeout and improve HTML extraction resilience

### DIFF
--- a/server/agentModel.ts
+++ b/server/agentModel.ts
@@ -54,6 +54,7 @@ export { ModelAuthError }
 /* ---------------------------------------------------------------- */
 
 const ANTHROPIC_MODEL = process.env.DOOP_AGENT_MODEL || 'claude-opus-5'
+const ANTHROPIC_TIMEOUT_MS = Number(process.env.ANTHROPIC_TIMEOUT_MS) || 15 * 60 * 1000
 
 let anthropic: Anthropic | null = null
 
@@ -64,7 +65,7 @@ function anthropicTier(): AgentModel | null {
     )
     return null
   }
-  if (!anthropic) anthropic = new Anthropic()
+  if (!anthropic) anthropic = new Anthropic({ timeout: ANTHROPIC_TIMEOUT_MS })
   const client = anthropic
   return {
     provider: 'anthropic',

--- a/server/agentModel.ts
+++ b/server/agentModel.ts
@@ -54,7 +54,18 @@ export { ModelAuthError }
 /* ---------------------------------------------------------------- */
 
 const ANTHROPIC_MODEL = process.env.DOOP_AGENT_MODEL || 'claude-opus-5'
-const ANTHROPIC_TIMEOUT_MS = Number(process.env.ANTHROPIC_TIMEOUT_MS) || 15 * 60 * 1000
+
+export function parseTimeoutMs(raw: string | undefined, defaultMs = 15 * 60 * 1000): number {
+  if (!raw) return defaultMs
+  const parsed = Number(raw)
+  if (!Number.isFinite(parsed) || parsed <= 0 || !Number.isInteger(parsed)) {
+    console.warn(`[anthropic] Invalid ANTHROPIC_TIMEOUT_MS="${raw}"; using default ${defaultMs}ms`)
+    return defaultMs
+  }
+  return parsed
+}
+
+const ANTHROPIC_TIMEOUT_MS = parseTimeoutMs(process.env.ANTHROPIC_TIMEOUT_MS)
 
 let anthropic: Anthropic | null = null
 

--- a/server/distill.ts
+++ b/server/distill.ts
@@ -18,11 +18,13 @@ const MODEL = process.env.DOOP_DISTILL_MODEL || 'claude-haiku-4-5-20251001'
 /** most recent unconsumed decisions the judge sees per run */
 const MAX_WINDOW = 15
 
+const ANTHROPIC_TIMEOUT_MS = Number(process.env.ANTHROPIC_TIMEOUT_MS) || 15 * 60 * 1000
+
 let client: Anthropic | null = null
 
 function getClient(): Anthropic | null {
   if (!process.env.ANTHROPIC_API_KEY) return null
-  if (!client) client = new Anthropic()
+  if (!client) client = new Anthropic({ timeout: ANTHROPIC_TIMEOUT_MS })
   return client
 }
 

--- a/server/distill.ts
+++ b/server/distill.ts
@@ -1,4 +1,5 @@
 import Anthropic from '@anthropic-ai/sdk'
+import { parseTimeoutMs } from './agentModel.ts'
 import { store } from './store.ts'
 import * as actions from './actions.ts'
 
@@ -18,7 +19,7 @@ const MODEL = process.env.DOOP_DISTILL_MODEL || 'claude-haiku-4-5-20251001'
 /** most recent unconsumed decisions the judge sees per run */
 const MAX_WINDOW = 15
 
-const ANTHROPIC_TIMEOUT_MS = Number(process.env.ANTHROPIC_TIMEOUT_MS) || 15 * 60 * 1000
+const ANTHROPIC_TIMEOUT_MS = parseTimeoutMs(process.env.ANTHROPIC_TIMEOUT_MS)
 
 let client: Anthropic | null = null
 

--- a/server/githubRecon.ts
+++ b/server/githubRecon.ts
@@ -205,11 +205,50 @@ export function extractHtml(blocks: { type: string; text?: string }[]): { html: 
     .filter((b) => b.type === 'text' && b.text)
     .map((b) => b.text)
     .join('\n')
-  const fenced = text.match(/```(?:html)?\s*([\s\S]*?)```/)
-  let html = (fenced ? fenced[1]! : text).trim()
-  const start = html.search(/<!doctype/i)
-  if (start === -1) throw new Error('the model returned no HTML document')
-  html = html.slice(start)
+
+  let candidate = text.trim()
+  // 1. Check for ```html ... ``` or ```xml ... ``` code fences
+  const htmlFence = text.match(/```(?:html|xml)?\s*([\s\S]*?)(?:```|$)/i)
+  if (htmlFence && (htmlFence[1].includes('<') || htmlFence[1].toLowerCase().includes('doctype'))) {
+    candidate = htmlFence[1].trim()
+  } else {
+    // 2. Check for any code fence containing HTML tags
+    const anyFence = text.match(/```\w*\s*([\s\S]*?)(?:```|$)/)
+    if (anyFence && /<(?:!doctype|html|div|main|section|style|body|header)/i.test(anyFence[1])) {
+      candidate = anyFence[1].trim()
+    }
+  }
+
+  let html: string
+  // 3. Locate standard <!doctype
+  const start = candidate.search(/<!doctype/i)
+  if (start !== -1) {
+    html = candidate.slice(start)
+  } else {
+    // 4. Maybe the raw text has <!doctype outside the matched fence
+    const rawDoctype = text.search(/<!doctype/i)
+    if (rawDoctype !== -1) {
+      html = text.slice(rawDoctype)
+    } else {
+      // 5. Maybe <html ...> without <!DOCTYPE
+      const htmlTag = candidate.search(/<html/i)
+      if (htmlTag !== -1) {
+        html = '<!DOCTYPE html>\n' + candidate.slice(htmlTag)
+      } else {
+        // 6. Maybe a component fragment (e.g. <div> or <style>)
+        const fragment = candidate.search(/<(?:div|main|section|style|body|header|svg)/i)
+        if (fragment !== -1) {
+          html = `<!DOCTYPE html>\n<html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"></head><body>\n${candidate.slice(fragment)}\n</body></html>`
+        } else {
+          console.error('[github-recon] extractHtml could not find HTML. Raw text preview:\n' + text.slice(0, 1000))
+          throw new Error('the model returned no HTML document')
+        }
+      }
+    }
+  }
+
+  // Clean trailing markdown fences or stray ticks
+  html = html.replace(/```\s*$/, '').trim()
   const height = Math.min(8000, Math.max(480, Number(html.match(/doop-height:\s*(\d+)/)?.[1]) || 900))
   return { html, height }
 }

--- a/server/githubRecon.ts
+++ b/server/githubRecon.ts
@@ -200,54 +200,78 @@ export function treeExcerpt(paths: string[], sourcePath: string): string {
     .join('\n')
 }
 
+function normalizeDocument(content: string): string | null {
+  const clean = content.replace(/```\s*$/, '').trim()
+
+  // 1. Full document with doctype
+  const doctypeIndex = clean.search(/<!doctype/i)
+  if (doctypeIndex !== -1) {
+    return clean.slice(doctypeIndex)
+  }
+
+  // 2. <html> tag without doctype
+  const htmlIndex = clean.search(/<html/i)
+  if (htmlIndex !== -1) {
+    return '<!DOCTYPE html>\n' + clean.slice(htmlIndex)
+  }
+
+  // 3. Renderable component or fragment
+  const fragmentIndex = clean.search(/<(?:div|main|section|style|body|header|svg|table|nav|article|aside|form)/i)
+  if (fragmentIndex !== -1) {
+    return `<!DOCTYPE html>\n<html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"></head><body>\n${clean.slice(fragmentIndex)}\n</body></html>`
+  }
+
+  return null
+}
+
 export function extractHtml(blocks: { type: string; text?: string }[]): { html: string; height: number } {
   const text = blocks
     .filter((b) => b.type === 'text' && b.text)
     .map((b) => b.text)
     .join('\n')
 
-  let candidate = text.trim()
-  // 1. Check for ```html ... ``` or ```xml ... ``` code fences
-  const htmlFence = text.match(/```(?:html|xml)?\s*([\s\S]*?)(?:```|$)/i)
-  if (htmlFence && (htmlFence[1].includes('<') || htmlFence[1].toLowerCase().includes('doctype'))) {
-    candidate = htmlFence[1].trim()
-  } else {
-    // 2. Check for any code fence containing HTML tags
-    const anyFence = text.match(/```\w*\s*([\s\S]*?)(?:```|$)/)
-    if (anyFence && /<(?:!doctype|html|div|main|section|style|body|header)/i.test(anyFence[1])) {
-      candidate = anyFence[1].trim()
+  // Find all code fences in the text
+  const fences = [...text.matchAll(/```([a-zA-Z0-9_-]*)\s*([\s\S]*?)(?:```|$)/g)].map((m) => ({
+    lang: (m[1] ?? '').toLowerCase(),
+    body: (m[2] ?? '').trim(),
+  }))
+
+  let html: string | null = null
+
+  // 1. First priority: any fence explicitly tagged ```html or ```htm
+  const htmlFences = fences.filter((f) => f.lang === 'html' || f.lang === 'htm')
+  for (const f of htmlFences) {
+    html = normalizeDocument(f.body)
+    if (html) break
+  }
+
+  // 2. Second priority: any fence containing a doctype or <html> tag
+  if (!html) {
+    const docFences = fences.filter((f) => /<!doctype|<html/i.test(f.body))
+    for (const f of docFences) {
+      html = normalizeDocument(f.body)
+      if (html) break
     }
   }
 
-  let html: string
-  // 3. Locate standard <!doctype
-  const start = candidate.search(/<!doctype/i)
-  if (start !== -1) {
-    html = candidate.slice(start)
-  } else {
-    // 4. Maybe the raw text has <!doctype outside the matched fence
-    const rawDoctype = text.search(/<!doctype/i)
-    if (rawDoctype !== -1) {
-      html = text.slice(rawDoctype)
-    } else {
-      // 5. Maybe <html ...> without <!DOCTYPE
-      const htmlTag = candidate.search(/<html/i)
-      if (htmlTag !== -1) {
-        html = '<!DOCTYPE html>\n' + candidate.slice(htmlTag)
-      } else {
-        // 6. Maybe a component fragment (e.g. <div> or <style>)
-        const fragment = candidate.search(/<(?:div|main|section|style|body|header|svg)/i)
-        if (fragment !== -1) {
-          html = `<!DOCTYPE html>\n<html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"></head><body>\n${candidate.slice(fragment)}\n</body></html>`
-        } else {
-          console.error('[github-recon] extractHtml could not find HTML. Raw text preview:\n' + text.slice(0, 1000))
-          throw new Error('the model returned no HTML document')
-        }
-      }
+  // 3. Third priority: any fence containing component/layout markup
+  if (!html) {
+    for (const f of fences) {
+      html = normalizeDocument(f.body)
+      if (html) break
     }
   }
 
-  // Clean trailing markdown fences or stray ticks
+  // 4. Fourth priority: raw response (handles unfenced markup, or markup after fences)
+  if (!html) {
+    html = normalizeDocument(text)
+  }
+
+  if (!html) {
+    console.error('[github-recon] extractHtml could not find HTML. Raw text preview:\n' + text.slice(0, 1000))
+    throw new Error('the model returned no HTML document')
+  }
+
   html = html.replace(/```\s*$/, '').trim()
   const height = Math.min(8000, Math.max(480, Number(html.match(/doop-height:\s*(\d+)/)?.[1]) || 900))
   return { html, height }

--- a/tests/githubRecon.test.ts
+++ b/tests/githubRecon.test.ts
@@ -55,6 +55,27 @@ describe('extractHtml', () => {
     expect(extractHtml([{ type: 'text', text: '<!doctype html><p>x</p>' }]).height).toBe(900)
     expect(() => extractHtml([{ type: 'text', text: 'sorry, no' }])).toThrow(/no HTML/)
   })
+
+  it('handles xml and generic code fences and unclosed markdown blocks', () => {
+    const xmlFenced = extractHtml([{ type: 'text', text: '```xml\n<!doctype html><div>x</div>\n```' }])
+    expect(xmlFenced.html).toContain('<!doctype html>')
+
+    const unclosed = extractHtml([
+      { type: 'text', text: '```html\n<!doctype html><div>unclosed\n<!-- doop-height: 1200 -->' },
+    ])
+    expect(unclosed.html).toContain('<!doctype html>')
+    expect(unclosed.height).toBe(1200)
+  })
+
+  it('normalizes html without doctype and component fragments into documents', () => {
+    const noDoctype = extractHtml([{ type: 'text', text: '<html><head></head><body><span>hello</span></body></html>' }])
+    expect(noDoctype.html.startsWith('<!DOCTYPE html>')).toBe(true)
+    expect(noDoctype.html).toContain('<span>hello</span>')
+
+    const fragment = extractHtml([{ type: 'text', text: '<div class="btn">Click me</div>' }])
+    expect(fragment.html.startsWith('<!DOCTYPE html>')).toBe(true)
+    expect(fragment.html).toContain('<div class="btn">Click me</div>')
+  })
 })
 
 describe('treeExcerpt', () => {

--- a/tests/githubRecon.test.ts
+++ b/tests/githubRecon.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest'
+import { parseTimeoutMs } from '../server/agentModel.ts'
 import {
   designSystemSlug,
   extractHtml,
@@ -75,6 +76,43 @@ describe('extractHtml', () => {
     const fragment = extractHtml([{ type: 'text', text: '<div class="btn">Click me</div>' }])
     expect(fragment.html.startsWith('<!DOCTYPE html>')).toBe(true)
     expect(fragment.html).toContain('<div class="btn">Click me</div>')
+  })
+
+  it('does not let an unrelated leading code fence shadow valid HTML', () => {
+    const responseWithLeadingJson = extractHtml([
+      {
+        type: 'text',
+        text: 'Here is the config:\n```json\n{ "title": "<Header>" }\n```\nAnd here is the screen:\n```html\n<div class="dashboard">Dashboard Content</div>\n```',
+      },
+    ])
+    expect(responseWithLeadingJson.html.startsWith('<!DOCTYPE html>')).toBe(true)
+    expect(responseWithLeadingJson.html).toContain('Dashboard Content')
+
+    const responseWithLeadingCodeAndUnfencedHtml = extractHtml([
+      {
+        type: 'text',
+        text: 'Reviewing code:\n```typescript\nconst tag = "<Component>";\n```\nResulting markup:\n<main class="page">Page Content</main>',
+      },
+    ])
+    expect(responseWithLeadingCodeAndUnfencedHtml.html.startsWith('<!DOCTYPE html>')).toBe(true)
+    expect(responseWithLeadingCodeAndUnfencedHtml.html).toContain('Page Content')
+  })
+})
+
+describe('parseTimeoutMs', () => {
+  it('accepts valid integer millisecond strings', () => {
+    expect(parseTimeoutMs('600000')).toBe(600000)
+    expect(parseTimeoutMs('900000')).toBe(900000)
+  })
+
+  it('falls back to default for missing, negative, float, or invalid values', () => {
+    expect(parseTimeoutMs(undefined)).toBe(900000)
+    expect(parseTimeoutMs('')).toBe(900000)
+    expect(parseTimeoutMs('-100')).toBe(900000)
+    expect(parseTimeoutMs('0')).toBe(900000)
+    expect(parseTimeoutMs('12.5')).toBe(900000)
+    expect(parseTimeoutMs('Infinity')).toBe(900000)
+    expect(parseTimeoutMs('not-a-number')).toBe(900000)
   })
 })
 


### PR DESCRIPTION

## Description

Addresses two reliability issues during GitHub repository recon (`sketchScreen`):

1. **Anthropic SDK Timeout**: Configures `ANTHROPIC_TIMEOUT_MS` (default: 15m) when instantiating the Anthropic client in `agentModel.ts` and `distill.ts` to prevent `@anthropic-ai/sdk` from throwing `Streaming is required for operations that may take longer than 10 minutes` on 32k `maxTokens` requests.
2. **HTML Extraction Resilience**: Updates `extractHtml()` in `githubRecon.ts` to handle generic/XML fences, unclosed fences, missing `<!DOCTYPE>`, and UI component fragments (wrapping them into a minimal renderable HTML document).

## Changes
- `server/agentModel.ts`: Pass `timeout: ANTHROPIC_TIMEOUT_MS` to `new Anthropic()`.
- `server/distill.ts`: Use `ANTHROPIC_TIMEOUT_MS` for consistency.
- `server/githubRecon.ts`: Robust HTML extraction & component fallback wrapping in `extractHtml()`.
- `tests/githubRecon.test.ts`: Added unit tests for edge cases.

## Testing
- Ran `bun test tests/githubRecon.test.ts` (all 14 tests pass).
- Verified typechecking (`tsc --noEmit`) and linting/formatting pass cleanly.

Closes #115