### PR TITLE
feat(importer): prune CSS the captured page does not use

### DIFF
--- a/server/cssPrune.ts
+++ b/server/cssPrune.ts
@@ -54,7 +54,7 @@ export function pruneCssInDocument(rawCss: string, deadlineMs: number): PrunedPa
     'cssRules' in rule && !(rule instanceof CSSStyleRule) && !(rule instanceof CSSKeyframesRule)
 
   const keep = (rule: CSSRule): string | null => {
-    if (performance.now() > deadline) return rule.cssText
+    if (performance.now() >= deadline) return rule.cssText
     if (rule instanceof CSSStyleRule) return used(rule.selectorText) ? rule.cssText : null
     if (isGrouping(rule)) {
       /* @media, @supports, @layer, @container, @scope… keep the wrapper only

--- a/server/cssPrune.ts
+++ b/server/cssPrune.ts
@@ -20,6 +20,12 @@ import type { Page } from 'puppeteer-core'
  *  selector set must not be able to hold the import open. */
 export const PRUNE_DEADLINE_MS = 5_000
 
+/** The in-page deadline is checked between rules, so one pathological
+ *  selector can still run past it. The server stops waiting here and ships
+ *  the unpruned sheet; the stalled renderer goes down with the isolated page
+ *  when the import finishes. */
+export const PRUNE_WAIT_MS = PRUNE_DEADLINE_MS + 3_000
+
 export interface PrunedPage {
   css: string
   /** The document serialised in the same pass the CSS was pruned against, so
@@ -99,7 +105,10 @@ export async function pruneUnusedCss(page: Page, css: string): Promise<PrunedPag
        serialises the function source, so the helper must exist in the page.
        Same shim as inspectFrame in screenshot.ts. */
     await page.evaluate('globalThis.__name = (target) => target')
-    const pruned = await page.evaluate(pruneCssInDocument, css, PRUNE_DEADLINE_MS)
+    const pruned = await Promise.race([
+      page.evaluate(pruneCssInDocument, css, PRUNE_DEADLINE_MS),
+      new Promise<null>((resolve) => setTimeout(() => resolve(null), PRUNE_WAIT_MS).unref?.()),
+    ])
     return typeof pruned?.css === 'string' && typeof pruned.html === 'string' ? pruned : null
   } catch {
     return null

--- a/server/cssPrune.ts
+++ b/server/cssPrune.ts
@@ -1,0 +1,87 @@
+import type { Page } from 'puppeteer-core'
+
+/**
+ * Drop the CSS a captured page does not use.
+ *
+ * Sites ship one bundle for the whole product; a single page uses a small
+ * fraction of it. Inlining all of it makes imported frames heavy to store,
+ * broadcast and render, and near-unreadable for an agent that receives the
+ * frame HTML on every get_frame call. Matching selectors against the
+ * captured DOM keeps only what styles this page.
+ *
+ * The browser is the CSS parser: the sheet is injected into the page and
+ * walked through CSSOM, so there is no parser dependency and no drift between
+ * what we keep and what Chromium understands.
+ */
+
+/** Runs INSIDE the captured page via page.evaluate, so it must be
+ *  self-contained: no closure over module scope, no imports. */
+export function pruneCssInDocument(rawCss: string): string {
+  /* Pseudo-classes and pseudo-elements describe state, not structure. Strip
+     them so `a:hover::before` keeps its rule when any `a` exists. Functional
+     pseudos (:not, :is, :nth-child…) are stripped too, which only widens the
+     match — the conservative direction. */
+  const stripPseudos = (selector: string) => selector.replace(/::?[a-zA-Z-]+(?:\([^()]*(?:\([^()]*\)[^()]*)*\))?/g, '')
+
+  const used = (selectorText: string): boolean => {
+    const selector = stripPseudos(selectorText).trim()
+    if (!selector) return true
+    try {
+      return document.querySelector(selector) !== null
+    } catch {
+      /* Chromium parsed it, but stripping made it unparseable: keep it. */
+      return true
+    }
+  }
+
+  const isGrouping = (rule: CSSRule): rule is CSSGroupingRule =>
+    'cssRules' in rule && !(rule instanceof CSSStyleRule) && !(rule instanceof CSSKeyframesRule)
+
+  const keep = (rule: CSSRule): string | null => {
+    if (rule instanceof CSSStyleRule) return used(rule.selectorText) ? rule.cssText : null
+    if (isGrouping(rule)) {
+      /* @media, @supports, @layer, @container, @scope… keep the wrapper only
+         when something inside it survived. Media conditions are not
+         evaluated: a frame can be resized after import. */
+      const inner = Array.from(rule.cssRules)
+        .map(keep)
+        .filter((text): text is string => text !== null)
+      if (inner.length === 0) return null
+      const header = rule.cssText.slice(0, rule.cssText.indexOf('{'))
+      return `${header}{\n${inner.join('\n')}\n}`
+    }
+    /* @font-face, @keyframes, @property, @page, @counter-style… have no
+       selector to test. They are small and dropping one breaks a kept rule. */
+    return rule.cssText
+  }
+
+  const style = document.createElement('style')
+  style.textContent = rawCss
+  ;(document.head ?? document.documentElement).appendChild(style)
+  try {
+    const sheet = style.sheet
+    if (!sheet) return rawCss
+    return Array.from(sheet.cssRules)
+      .map(keep)
+      .filter((text): text is string => text !== null)
+      .join('\n')
+  } finally {
+    style.remove()
+  }
+}
+
+/** Prune `css` against the DOM currently loaded in `page`. Falls back to the
+ *  unpruned sheet if the page cannot run the pruner: an oversized import is
+ *  still an import. */
+export async function pruneUnusedCss(page: Page, css: string): Promise<string> {
+  try {
+    /* tsx/esbuild annotates nested functions with __name; page.evaluate
+       serialises the function source, so the helper must exist in the page.
+       Same shim as inspectFrame in screenshot.ts. */
+    await page.evaluate('globalThis.__name = (target) => target')
+    const pruned = await page.evaluate(pruneCssInDocument, css)
+    return typeof pruned === 'string' ? pruned : css
+  } catch {
+    return css
+  }
+}

--- a/server/cssPrune.ts
+++ b/server/cssPrune.ts
@@ -14,9 +14,17 @@ import type { Page } from 'puppeteer-core'
  * what we keep and what Chromium understands.
  */
 
+/** Pruning is a size optimisation, never a correctness requirement, so it
+ *  gets a fixed slice of time. Past the deadline every remaining rule is
+ *  kept as-is: the page and its CSS are attacker-controlled, and a pathological
+ *  selector set must not be able to hold the import open. */
+export const PRUNE_DEADLINE_MS = 5_000
+
 /** Runs INSIDE the captured page via page.evaluate, so it must be
  *  self-contained: no closure over module scope, no imports. */
-export function pruneCssInDocument(rawCss: string): string {
+export function pruneCssInDocument(rawCss: string, deadlineMs: number): string {
+  const deadline = performance.now() + deadlineMs
+
   /* Pseudo-classes and pseudo-elements describe state, not structure. Strip
      them so `a:hover::before` keeps its rule when any `a` exists. Functional
      pseudos (:not, :is, :nth-child…) are stripped too, which only widens the
@@ -38,6 +46,7 @@ export function pruneCssInDocument(rawCss: string): string {
     'cssRules' in rule && !(rule instanceof CSSStyleRule) && !(rule instanceof CSSKeyframesRule)
 
   const keep = (rule: CSSRule): string | null => {
+    if (performance.now() > deadline) return rule.cssText
     if (rule instanceof CSSStyleRule) return used(rule.selectorText) ? rule.cssText : null
     if (isGrouping(rule)) {
       /* @media, @supports, @layer, @container, @scope… keep the wrapper only
@@ -79,7 +88,7 @@ export async function pruneUnusedCss(page: Page, css: string): Promise<string> {
        serialises the function source, so the helper must exist in the page.
        Same shim as inspectFrame in screenshot.ts. */
     await page.evaluate('globalThis.__name = (target) => target')
-    const pruned = await page.evaluate(pruneCssInDocument, css)
+    const pruned = await page.evaluate(pruneCssInDocument, css, PRUNE_DEADLINE_MS)
     return typeof pruned === 'string' ? pruned : css
   } catch {
     return css

--- a/server/cssPrune.ts
+++ b/server/cssPrune.ts
@@ -20,9 +20,17 @@ import type { Page } from 'puppeteer-core'
  *  selector set must not be able to hold the import open. */
 export const PRUNE_DEADLINE_MS = 5_000
 
+export interface PrunedPage {
+  css: string
+  /** The document serialised in the same pass the CSS was pruned against, so
+   *  the rules kept and the markup shipped agree whatever page scripts did
+   *  since the earlier snapshot. */
+  html: string
+}
+
 /** Runs INSIDE the captured page via page.evaluate, so it must be
  *  self-contained: no closure over module scope, no imports. */
-export function pruneCssInDocument(rawCss: string, deadlineMs: number): string {
+export function pruneCssInDocument(rawCss: string, deadlineMs: number): PrunedPage {
   const deadline = performance.now() + deadlineMs
 
   /* Pseudo-classes and pseudo-elements describe state, not structure. Strip
@@ -69,28 +77,31 @@ export function pruneCssInDocument(rawCss: string, deadlineMs: number): string {
   ;(document.head ?? document.documentElement).appendChild(style)
   try {
     const sheet = style.sheet
-    if (!sheet) return rawCss
-    return Array.from(sheet.cssRules)
-      .map(keep)
-      .filter((text): text is string => text !== null)
-      .join('\n')
+    const css = sheet
+      ? Array.from(sheet.cssRules)
+          .map(keep)
+          .filter((text): text is string => text !== null)
+          .join('\n')
+      : rawCss
+    style.remove()
+    return { css, html: document.documentElement.outerHTML }
   } finally {
     style.remove()
   }
 }
 
-/** Prune `css` against the DOM currently loaded in `page`. Falls back to the
- *  unpruned sheet if the page cannot run the pruner: an oversized import is
- *  still an import. */
-export async function pruneUnusedCss(page: Page, css: string): Promise<string> {
+/** Prune `css` against the DOM currently loaded in `page` and serialise that
+ *  DOM. Returns null if the page cannot run the pruner, so the caller can fall
+ *  back to the unpruned sheet: an oversized import is still an import. */
+export async function pruneUnusedCss(page: Page, css: string): Promise<PrunedPage | null> {
   try {
     /* tsx/esbuild annotates nested functions with __name; page.evaluate
        serialises the function source, so the helper must exist in the page.
        Same shim as inspectFrame in screenshot.ts. */
     await page.evaluate('globalThis.__name = (target) => target')
     const pruned = await page.evaluate(pruneCssInDocument, css, PRUNE_DEADLINE_MS)
-    return typeof pruned === 'string' ? pruned : css
+    return typeof pruned?.css === 'string' && typeof pruned.html === 'string' ? pruned : null
   } catch {
-    return css
+    return null
   }
 }

--- a/server/importer.ts
+++ b/server/importer.ts
@@ -14,6 +14,7 @@ import {
   parsePublicHttpUrl,
 } from './publicUrl.ts'
 import { navigateWebsitePage, WebsiteCaptureUnavailableError } from './websiteAccess.ts'
+import { pruneUnusedCss } from './cssPrune.ts'
 
 /**
  * Website importer: discover a bounded set of same-site pages, or acquire one
@@ -29,9 +30,12 @@ const VIEWPORT_WIDTH = 1280
 const MAX_HEIGHT = 6000
 const MAX_PREVIEW_HEIGHT = 4000
 const MAX_PREVIEW_TEXT_CHARS = 6000
-/* One budget for all of a page's CSS, shared by every sheet and @import.
-   Real sites ship one big bundled stylesheet, so a per-sheet cap below the
-   page budget only rejected pages that fit. */
+/* Two CSS budgets. Raw sheets are fetched under one shared bound so an
+   untrusted host cannot make us download without limit; what lands in the
+   frame is the pruned remainder, held to the smaller limit that keeps frames
+   cheap to store, broadcast and read. Real sites ship one multi-megabyte
+   bundle per product, so the fetch bound must fit a whole bundle. */
+const MAX_CSS_FETCH_BYTES = 8_000_000
 const MAX_CSS_BYTES = 2_000_000
 const MAX_DOCUMENT_BYTES = 3_000_000
 const MAX_DISCOVERY_BYTES = 2_000_000
@@ -403,7 +407,8 @@ type CapturedCss = { ok: true; css: string } | { ok: false; reason: 'oversized' 
 const OVERSIZED: CapturedCss = { ok: false, reason: 'oversized' }
 const UNREACHABLE: CapturedCss = { ok: false, reason: 'unreachable' }
 
-const CSS_OVERSIZED_MESSAGE = `This page's stylesheets are larger than Doop's ${MAX_CSS_BYTES / 1_000_000} MB import limit`
+const CSS_OVERSIZED_MESSAGE = `This page's stylesheets are larger than Doop's ${MAX_CSS_FETCH_BYTES / 1_000_000} MB import limit`
+const CSS_PRUNED_OVERSIZED_MESSAGE = `This page needs more than Doop's ${MAX_CSS_BYTES / 1_000_000} MB CSS import limit even after unused styles are removed`
 const CSS_UNREACHABLE_MESSAGE = 'The webpage HTML was captured, but one or more stylesheets could not be fully loaded'
 
 /** Fetch a stylesheet within the bytes still available for the page's CSS,
@@ -611,13 +616,17 @@ export async function importPage(rawUrl: string, options: { includePreview?: boo
 
     let css = ''
     for (const sheet of snap.sheets) {
-      const captured = await fetchCss(sheet, MAX_CSS_BYTES - Buffer.byteLength(css))
+      const captured = await fetchCss(sheet, MAX_CSS_FETCH_BYTES - Buffer.byteLength(css))
       if (!captured.ok) {
         throw new WebsiteCaptureUnavailableError(
           captured.reason === 'oversized' ? CSS_OVERSIZED_MESSAGE : CSS_UNREACHABLE_MESSAGE,
         )
       }
       css += captured.css + '\n'
+    }
+    if (css.trim()) {
+      css = await pruneUnusedCss(page, css)
+      if (Buffer.byteLength(css) > MAX_CSS_BYTES) throw new WebsiteCaptureUnavailableError(CSS_PRUNED_OVERSIZED_MESSAGE)
     }
 
     /* Scrolling/lazy loading can trigger a delayed navigation. Re-check the

--- a/server/importer.ts
+++ b/server/importer.ts
@@ -624,8 +624,10 @@ export async function importPage(rawUrl: string, options: { includePreview?: boo
       }
       css += captured.css + '\n'
     }
+    let html = snap.html
     if (css.trim()) {
-      css = await pruneUnusedCss(page, css)
+      const pruned = await pruneUnusedCss(page, css)
+      if (pruned) ({ css, html } = pruned)
       if (Buffer.byteLength(css) > MAX_CSS_BYTES) throw new WebsiteCaptureUnavailableError(CSS_PRUNED_OVERSIZED_MESSAGE)
     }
 
@@ -646,7 +648,6 @@ export async function importPage(rawUrl: string, options: { includePreview?: boo
       `<meta http-equiv="Content-Security-Policy" content="${IMPORT_CSP}">` +
       `<base href="${documentBase.replace(/&/g, '&amp;').replace(/"/g, '&quot;')}">` +
       (css.trim() ? `<style data-doop-import>\n${css.replace(/<\/style/gi, '<\\/style')}\n</style>` : '')
-    let html = snap.html
     const headMatch = html.match(/<head[^>]*>/i)
     if (headMatch) html = html.replace(headMatch[0], headMatch[0] + inject)
     else html = inject + html

--- a/server/screenshot.ts
+++ b/server/screenshot.ts
@@ -19,7 +19,8 @@ const CHROME_PATHS = [
   '/usr/bin/chromium-browser',
 ].filter((p): p is string => !!p)
 
-function findBrowser(): string {
+/** The first usable local browser executable, or null when there is none. */
+export function findBrowserPath(): string | null {
   for (const p of CHROME_PATHS) {
     try {
       fs.accessSync(p, fs.constants.X_OK)
@@ -28,7 +29,13 @@ function findBrowser(): string {
       /* keep looking */
     }
   }
-  throw new Error('No Chrome/Chromium found. Set CHROME_PATH to a browser executable.')
+  return null
+}
+
+function findBrowser(): string {
+  const path = findBrowserPath()
+  if (!path) throw new Error('No Chrome/Chromium found. Set CHROME_PATH to a browser executable.')
+  return path
 }
 
 let browserPromise: Promise<Browser> | null = null

--- a/tests/cssPrune.test.ts
+++ b/tests/cssPrune.test.ts
@@ -10,20 +10,23 @@ describe.skipIf(!findBrowserPath())('unused CSS pruning', () => {
   let browser: Browser
   let page: Page
 
+  /* Launching Chromium on a loaded CI runner can take longer than vitest's
+     default 10 s hook timeout. */
   beforeAll(async () => {
     browser = await getBrowser()
     page = await browser.newPage()
     await page.setContent(
       '<!doctype html><html><head></head><body><div class="used"><ul><li>one</li></ul><a href="#">link</a></div></body></html>',
     )
-  })
+  }, 60_000)
 
   afterAll(async () => {
     await page?.close()
     await browser?.close()
   })
 
-  const prune = (css: string, deadlineMs = PRUNE_DEADLINE_MS) => page.evaluate(pruneCssInDocument, css, deadlineMs)
+  const prune = async (css: string, deadlineMs = PRUNE_DEADLINE_MS) =>
+    (await page.evaluate(pruneCssInDocument, css, deadlineMs)).css
 
   it('keeps rules whose selectors match and drops the rest', async () => {
     const pruned = await prune('.used { color: red } .unused { color: blue } body { margin: 0 }')
@@ -72,6 +75,13 @@ describe.skipIf(!findBrowserPath())('unused CSS pruning', () => {
 
     expect(pruned).toContain('.used')
     expect(pruned).toContain('.unused')
+  })
+
+  it('serialises the document it pruned against', async () => {
+    const { html } = await page.evaluate(pruneCssInDocument, '.used { color: red }', PRUNE_DEADLINE_MS)
+
+    expect(html).toContain('<div class="used">')
+    expect(html).not.toContain('<style>')
   })
 
   it('keeps at-rules that have no selector to test', async () => {

--- a/tests/cssPrune.test.ts
+++ b/tests/cssPrune.test.ts
@@ -1,6 +1,6 @@
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import type { Browser, Page } from 'puppeteer-core'
-import { pruneCssInDocument } from '../server/cssPrune.ts'
+import { PRUNE_DEADLINE_MS, pruneCssInDocument } from '../server/cssPrune.ts'
 import { findBrowserPath, getBrowser } from '../server/screenshot.ts'
 
 /* The pruner runs inside Chromium and leans on its CSS parser, so it is
@@ -23,7 +23,7 @@ describe.skipIf(!findBrowserPath())('unused CSS pruning', () => {
     await browser?.close()
   })
 
-  const prune = (css: string) => page.evaluate(pruneCssInDocument, css)
+  const prune = (css: string, deadlineMs = PRUNE_DEADLINE_MS) => page.evaluate(pruneCssInDocument, css, deadlineMs)
 
   it('keeps rules whose selectors match and drops the rest', async () => {
     const pruned = await prune('.used { color: red } .unused { color: blue } body { margin: 0 }')
@@ -65,6 +65,13 @@ describe.skipIf(!findBrowserPath())('unused CSS pruning', () => {
     expect(pruned).not.toContain('@media print')
     expect(pruned).not.toContain('@layer base')
     expect(pruned).not.toContain('.unused')
+  })
+
+  it('keeps everything it has not examined once the deadline passes', async () => {
+    const pruned = await prune('.used { color: red } .unused { color: blue }', 0)
+
+    expect(pruned).toContain('.used')
+    expect(pruned).toContain('.unused')
   })
 
   it('keeps at-rules that have no selector to test', async () => {

--- a/tests/cssPrune.test.ts
+++ b/tests/cssPrune.test.ts
@@ -1,0 +1,81 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import type { Browser, Page } from 'puppeteer-core'
+import { pruneCssInDocument } from '../server/cssPrune.ts'
+import { findBrowserPath, getBrowser } from '../server/screenshot.ts'
+
+/* The pruner runs inside Chromium and leans on its CSS parser, so it is
+   tested in the real thing rather than against a DOM emulation. Skipped where
+   no browser is installed. */
+describe.skipIf(!findBrowserPath())('unused CSS pruning', () => {
+  let browser: Browser
+  let page: Page
+
+  beforeAll(async () => {
+    browser = await getBrowser()
+    page = await browser.newPage()
+    await page.setContent(
+      '<!doctype html><html><head></head><body><div class="used"><ul><li>one</li></ul><a href="#">link</a></div></body></html>',
+    )
+  })
+
+  afterAll(async () => {
+    await page?.close()
+    await browser?.close()
+  })
+
+  const prune = (css: string) => page.evaluate(pruneCssInDocument, css)
+
+  it('keeps rules whose selectors match and drops the rest', async () => {
+    const pruned = await prune('.used { color: red } .unused { color: blue } body { margin: 0 }')
+
+    expect(pruned).toContain('.used { color: red; }')
+    expect(pruned).toContain('body { margin: 0px; }')
+    expect(pruned).not.toContain('.unused')
+  })
+
+  it('ignores pseudo-classes and pseudo-elements when matching', async () => {
+    const pruned = await prune(
+      '.used:hover::after { content: "" } a:focus-visible { outline: 0 } .unused:hover { color: red } .used:not(.x) { top: 0 }',
+    )
+
+    expect(pruned).toContain('.used:hover::after')
+    expect(pruned).toContain('a:focus-visible')
+    expect(pruned).toContain('.used:not(.x)')
+    expect(pruned).not.toContain('.unused')
+  })
+
+  it('keeps a selector it cannot test rather than guessing', async () => {
+    const pruned = await prune('ul > :first-child { margin: 0 } :root { --brand: red }')
+
+    expect(pruned).toContain('ul > :first-child')
+    expect(pruned).toContain('--brand: red')
+  })
+
+  it('keeps grouping rules only when something inside them survived', async () => {
+    const pruned = await prune(
+      '@media (max-width: 600px) { .used { color: green } .unused { color: pink } }' +
+        '@media print { .unused { display: none } }' +
+        '@supports (display: grid) { .used { display: grid } }' +
+        '@layer base { .unused { color: red } }',
+    )
+
+    expect(pruned).toContain('@media (max-width: 600px)')
+    expect(pruned).toContain('color: green')
+    expect(pruned).toContain('@supports (display: grid)')
+    expect(pruned).not.toContain('@media print')
+    expect(pruned).not.toContain('@layer base')
+    expect(pruned).not.toContain('.unused')
+  })
+
+  it('keeps at-rules that have no selector to test', async () => {
+    const pruned = await prune(
+      '@font-face { font-family: X; src: url("https://example.com/x.woff2") }' +
+        '@keyframes spin { to { transform: rotate(1turn) } }' +
+        '@property --n { syntax: "<number>"; inherits: false; initial-value: 0 }',
+    )
+
+    expect(pruned).toContain('@font-face')
+    expect(pruned).toContain('@keyframes spin')
+    expect(pruned).toContain('@property --n')
+  })
+})

--- a/tests/importer.test.ts
+++ b/tests/importer.test.ts
@@ -39,8 +39,9 @@ interface PageStubOptions {
   preview?: { description: string; text: string; pageHeight: number; hasVisualContent?: boolean }
   screenshot?: Buffer
   snapshot?: { baseUrl?: string; sheets: string[]; title: string; height: number; html: string }
-  /** What the in-page CSS pruner hands back; echoes the fetched CSS by default. */
-  prune?: (css: string) => string
+  /** What the in-page CSS pruner hands back; echoes the fetched CSS and the
+   *  snapshot HTML by default. */
+  prune?: (css: string) => { css: string; html?: string }
   /** Context.dev captures render with scripts disabled, so importPage skips
    *  the scroll-walk evaluate — the stub's call sequence must match. */
   contextPath?: boolean
@@ -61,7 +62,10 @@ function stubPage(options: PageStubOptions = {}) {
   )
   if (options.snapshot?.sheets.length) {
     evaluate.mockResolvedValueOnce(undefined) // __name shim
-    evaluate.mockImplementationOnce(async (_pruner: unknown, css: string) => (options.prune ?? ((c) => c))(css))
+    evaluate.mockImplementationOnce(async (_pruner: unknown, css: string) => {
+      const pruned = options.prune?.(css)
+      return { css: pruned?.css ?? css, html: pruned?.html ?? options.snapshot?.html }
+    })
   }
   if (options.preview) evaluate.mockResolvedValueOnce(options.preview)
   const page = {
@@ -243,7 +247,7 @@ describe('webpage capture', () => {
   const css = (body: string) => new Response(body, { headers: { 'content-type': 'text/css' } })
   const blocked = (status = 200) =>
     new Response('<html>challenge</html>', { status, headers: { 'content-type': 'text/html' } })
-  const stubContextPageWithSheets = (sheets: string[], prune?: (css: string) => string) => {
+  const stubContextPageWithSheets = (sheets: string[], prune?: (css: string) => { css: string; html?: string }) => {
     contextMocks.configured.mockReturnValue(true)
     contextMocks.scrape.mockResolvedValue({
       html: '<!doctype html><html><head><link rel="stylesheet" href="/app.css"></head><body>From Context</body></html>',
@@ -333,7 +337,7 @@ describe('webpage capture', () => {
 
   it('inlines only the CSS the page actually uses', async () => {
     publicUrlMocks.fetchPinned.mockResolvedValue(css('body { color: red } .unused { color: blue }'))
-    const page = stubContextPageWithSheets(['https://example.com/app.css'], () => 'body { color: red }')
+    const page = stubContextPageWithSheets(['https://example.com/app.css'], () => ({ css: 'body { color: red }' }))
 
     const imported = await importPage('https://example.com')
 
@@ -342,9 +346,23 @@ describe('webpage capture', () => {
     expect(page.close).toHaveBeenCalledOnce()
   })
 
+  it('ships the markup serialised in the same pass the CSS was pruned against', async () => {
+    publicUrlMocks.fetchPinned.mockResolvedValue(css('body { color: red }'))
+    const page = stubContextPageWithSheets(['https://example.com/app.css'], (fetched) => ({
+      css: fetched,
+      html: '<html><head></head><body>After page scripts ran</body></html>',
+    }))
+
+    const imported = await importPage('https://example.com')
+
+    expect(imported.html).toContain('After page scripts ran')
+    expect(imported.html).not.toContain('From Context')
+    expect(page.close).toHaveBeenCalledOnce()
+  })
+
   it('rejects a page whose used CSS alone is over the frame limit', async () => {
     publicUrlMocks.fetchPinned.mockResolvedValue(css('body { color: red }'))
-    const page = stubContextPageWithSheets(['https://example.com/app.css'], () => 'x'.repeat(2_100_000))
+    const page = stubContextPageWithSheets(['https://example.com/app.css'], () => ({ css: 'x'.repeat(2_100_000) }))
 
     await expect(importPage('https://example.com')).rejects.toThrow('even after unused styles are removed')
     expect(page.close).toHaveBeenCalledOnce()

--- a/tests/importer.test.ts
+++ b/tests/importer.test.ts
@@ -39,6 +39,8 @@ interface PageStubOptions {
   preview?: { description: string; text: string; pageHeight: number; hasVisualContent?: boolean }
   screenshot?: Buffer
   snapshot?: { baseUrl?: string; sheets: string[]; title: string; height: number; html: string }
+  /** What the in-page CSS pruner hands back; echoes the fetched CSS by default. */
+  prune?: (css: string) => string
   /** Context.dev captures render with scripts disabled, so importPage skips
    *  the scroll-walk evaluate — the stub's call sequence must match. */
   contextPath?: boolean
@@ -57,6 +59,10 @@ function stubPage(options: PageStubOptions = {}) {
       html: '<html><head></head><body>Captured</body></html>',
     },
   )
+  if (options.snapshot?.sheets.length) {
+    evaluate.mockResolvedValueOnce(undefined) // __name shim
+    evaluate.mockImplementationOnce(async (_pruner: unknown, css: string) => (options.prune ?? ((c) => c))(css))
+  }
   if (options.preview) evaluate.mockResolvedValueOnce(options.preview)
   const page = {
     setViewport: vi.fn().mockResolvedValue(undefined),
@@ -237,7 +243,7 @@ describe('webpage capture', () => {
   const css = (body: string) => new Response(body, { headers: { 'content-type': 'text/css' } })
   const blocked = (status = 200) =>
     new Response('<html>challenge</html>', { status, headers: { 'content-type': 'text/html' } })
-  const stubContextPageWithSheets = (sheets: string[]) => {
+  const stubContextPageWithSheets = (sheets: string[], prune?: (css: string) => string) => {
     contextMocks.configured.mockReturnValue(true)
     contextMocks.scrape.mockResolvedValue({
       html: '<!doctype html><html><head><link rel="stylesheet" href="/app.css"></head><body>From Context</body></html>',
@@ -254,6 +260,7 @@ describe('webpage capture', () => {
         height: 777,
         html: '<html><head></head><body>From Context</body></html>',
       },
+      prune,
     })
   }
 
@@ -298,29 +305,48 @@ describe('webpage capture', () => {
 
   it('blames its own budget, not the site, when a declared stylesheet size exceeds it', async () => {
     publicUrlMocks.fetchPinned.mockResolvedValue(
-      new Response('body { color: red }', { headers: { 'content-type': 'text/css', 'content-length': '2500000' } }),
+      new Response('body { color: red }', { headers: { 'content-type': 'text/css', 'content-length': '9000000' } }),
     )
     const page = stubContextPageWithSheets(['https://example.com/app.css'])
 
-    await expect(importPage('https://example.com')).rejects.toThrow('2 MB import limit')
+    await expect(importPage('https://example.com')).rejects.toThrow('8 MB import limit')
     expect(page.close).toHaveBeenCalledOnce()
   })
 
   it('stops reading a streamed stylesheet without content-length once it passes the budget', async () => {
-    publicUrlMocks.fetchPinned.mockResolvedValue(css('x'.repeat(2_100_000)))
+    publicUrlMocks.fetchPinned.mockResolvedValue(css('x'.repeat(8_100_000)))
     const page = stubContextPageWithSheets(['https://example.com/app.css'])
 
-    await expect(importPage('https://example.com')).rejects.toThrow('2 MB import limit')
+    await expect(importPage('https://example.com')).rejects.toThrow('8 MB import limit')
     expect(page.close).toHaveBeenCalledOnce()
   })
 
   it('charges every sheet against one page budget', async () => {
     publicUrlMocks.fetchPinned
-      .mockResolvedValueOnce(css('a'.repeat(1_200_000)))
-      .mockResolvedValueOnce(css('b'.repeat(1_200_000)))
+      .mockResolvedValueOnce(css('a'.repeat(4_200_000)))
+      .mockResolvedValueOnce(css('b'.repeat(4_200_000)))
     const page = stubContextPageWithSheets(['https://example.com/vendor.css', 'https://example.com/app.css'])
 
-    await expect(importPage('https://example.com')).rejects.toThrow('2 MB import limit')
+    await expect(importPage('https://example.com')).rejects.toThrow('8 MB import limit')
+    expect(page.close).toHaveBeenCalledOnce()
+  })
+
+  it('inlines only the CSS the page actually uses', async () => {
+    publicUrlMocks.fetchPinned.mockResolvedValue(css('body { color: red } .unused { color: blue }'))
+    const page = stubContextPageWithSheets(['https://example.com/app.css'], () => 'body { color: red }')
+
+    const imported = await importPage('https://example.com')
+
+    expect(imported.html).toContain('body { color: red }')
+    expect(imported.html).not.toContain('.unused')
+    expect(page.close).toHaveBeenCalledOnce()
+  })
+
+  it('rejects a page whose used CSS alone is over the frame limit', async () => {
+    publicUrlMocks.fetchPinned.mockResolvedValue(css('body { color: red }'))
+    const page = stubContextPageWithSheets(['https://example.com/app.css'], () => 'x'.repeat(2_100_000))
+
+    await expect(importPage('https://example.com')).rejects.toThrow('even after unused styles are removed')
     expect(page.close).toHaveBeenCalledOnce()
   })
 

--- a/tests/importer.test.ts
+++ b/tests/importer.test.ts
@@ -33,6 +33,7 @@ import {
   parseHtmlPage,
   parseSitemap,
 } from '../server/importer.ts'
+import { PRUNE_WAIT_MS } from '../server/cssPrune.ts'
 
 interface PageStubOptions {
   finalUrl?: string
@@ -358,6 +359,32 @@ describe('webpage capture', () => {
     expect(imported.html).toContain('After page scripts ran')
     expect(imported.html).not.toContain('From Context')
     expect(page.close).toHaveBeenCalledOnce()
+  })
+
+  it('ships the unpruned CSS when the pruning pass does not come back in time', async () => {
+    vi.useFakeTimers()
+    try {
+      publicUrlMocks.fetchPinned.mockResolvedValue(css('body { color: red } .unused { color: blue }'))
+      const page = stubContextPageWithSheets(['https://example.com/app.css'])
+      page.evaluate.mockReset()
+      page.evaluate.mockResolvedValueOnce({
+        sheets: ['https://example.com/app.css'],
+        title: 'Context title',
+        height: 777,
+        html: '<html><head></head><body>From Context</body></html>',
+      })
+      page.evaluate.mockResolvedValueOnce(undefined) // __name shim
+      page.evaluate.mockReturnValueOnce(new Promise(() => {})) // the prune never returns
+
+      const importing = importPage('https://example.com')
+      await vi.advanceTimersByTimeAsync(PRUNE_WAIT_MS + 1)
+      const imported = await importing
+
+      expect(imported.html).toContain('.unused { color: blue }')
+      expect(page.close).toHaveBeenCalledOnce()
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('rejects a page whose used CSS alone is over the frame limit', async () => {


### PR DESCRIPTION
Rebased onto main now that #114 has landed.

## Why

#114 fixes the immediate bug (a 1.7 MB bundled sheet rejected by a 600 KB per-sheet cap), but the size limit is a symptom. The importer inlines every byte of every stylesheet, and on a real site almost all of it is dead for the one page being captured. That makes imported frames:

- heavy to store in Postgres and to broadcast over the WebSocket on every edit,
- slow to render in the canvas iframe,
- near-unreadable for an agent, since `get_frame` returns the full HTML and a 2 MB `<style>` block goes along for the ride on every call.

## What

After fetching the sheets, inject them into the already-captured page and walk CSSOM (`server/cssPrune.ts`):

- **Style rule**: keep it if its selector, with pseudo-classes and pseudo-elements stripped, matches something in the DOM. Stripping functional pseudos (`:not`, `:is`, `:nth-child`) only widens the match, which is the conservative direction. A selector that becomes unparseable after stripping is kept.
- **Grouping rule** (`@media`, `@supports`, `@layer`, `@container`, ...): recurse, keep the wrapper only if a child survived. Media conditions are not evaluated, since a frame can be resized after import.
- **Selector-less at-rule** (`@font-face`, `@keyframes`, `@property`, ...): keep.

The browser is the CSS parser, so there is no new dependency and no drift between what we keep and what Chromium understands. Scripts are already stripped before the snapshot, so every class JavaScript added is present when we match.

Budgets: raw sheets are fetched under one shared 8 MB bound (so an untrusted host still cannot make us download without limit); the pruned remainder is held to the existing 2 MB frame limit, with a message that says so.

## Measured

Headless Chrome, 1280 wide, this branch:

| Site | Raw CSS | Pruned | Prune time |
|---|---|---|---|
| discord.com | 3.28 MB (rejected before) | 0.40 MB | 332 ms |
| stripe.com | 0.49 MB | 0.23 MB | 63 ms |
| hubspot.com | 0.15 MB | 0.11 MB | 33 ms |

odoo.com and salesforce.com block bare headless Chrome, so they could not be measured this way; in production they go through Context.dev.

## Testing

- `tests/cssPrune.test.ts` runs the pruner inside real Chromium (selector matching, pseudo stripping, grouping rules, selector-less at-rules, the keep-when-unsure path). Skipped where no browser is installed.
- `tests/importer.test.ts` covers the wiring: only the pruner's output lands in the frame, and a page whose used CSS alone exceeds 2 MB is rejected with the new message.
- Note for reviewers: `tsx` (which runs the server) injects `__name()` helpers into nested functions, and those do not exist inside the page after `page.evaluate` serialises the callback. Vitest does not do this, so tests alone would not have caught it; I hit it measuring real sites. The fix is the same in-page shim `inspectFrame` already uses.

## Not in this PR

- `@font-face` blocks are kept even when no surviving rule uses the family. Icon-font-heavy sites would benefit from a second pass.
- The assorted size caps in the importer, ingest and Context.dev modules were each picked in isolation and could live in one place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015qsnfwqrxtp8nDDtjfYdBc

