### PR TITLE
refactor(server): keep every frame size limit in one place

### DIFF
--- a/public/doop-sync.js
+++ b/public/doop-sync.js
@@ -68,7 +68,7 @@
 
   var SETTLE_MS = 2500 // let data land and skeletons resolve before capturing
   var MIN_RESEND_MS = 30000 // floor between uploads of the same route (matches the server's)
-  var MAX_BYTES = 2400000 // server rejects above 2.5 MB — stay under
+  var MAX_BYTES = 2400000 // server rejects above 3 MB — stay under
   var MAX_ASSET_BYTES = 200000 // per-file cap for inlined fonts/images
   var ENDPOINT = HOST.replace(/\/$/, '') + '/ingest/' + KEY
 

--- a/server/contextDev.ts
+++ b/server/contextDev.ts
@@ -1,11 +1,11 @@
 import { parsePublicHttpUrl } from './publicUrl.ts'
 import { WebsiteCaptureUnavailableError } from './websiteAccess.ts'
+import { MAX_FRAME_HTML_BYTES } from './limits.ts'
 
 const CONTEXT_HTML_ENDPOINT = 'https://api.context.dev/v1/web/scrape/html'
 const CONTEXT_SITEMAP_ENDPOINT = 'https://api.context.dev/v1/web/scrape/sitemap'
 const CONTEXT_TIMEOUT_MS = 45_000
 const MAX_ERROR_MESSAGE_CHARS = 240
-const MAX_CONTEXT_HTML_CHARS = 3_000_000
 
 export interface ContextWebsiteHtml {
   html: string
@@ -113,7 +113,7 @@ export async function scrapeContextWebsiteHtml(
   if (body.success !== true || typeof body.html !== 'string' || !body.html.trim()) {
     throw new WebsiteCaptureUnavailableError('Context.dev returned no webpage HTML')
   }
-  if (body.html.length > MAX_CONTEXT_HTML_CHARS) {
+  if (body.html.length > MAX_FRAME_HTML_BYTES) {
     throw new WebsiteCaptureUnavailableError('Context.dev returned webpage HTML that is too large to import safely')
   }
   if (body.type !== 'html') {

--- a/server/contextDev.ts
+++ b/server/contextDev.ts
@@ -113,7 +113,7 @@ export async function scrapeContextWebsiteHtml(
   if (body.success !== true || typeof body.html !== 'string' || !body.html.trim()) {
     throw new WebsiteCaptureUnavailableError('Context.dev returned no webpage HTML')
   }
-  if (body.html.length > MAX_FRAME_HTML_BYTES) {
+  if (Buffer.byteLength(body.html) > MAX_FRAME_HTML_BYTES) {
     throw new WebsiteCaptureUnavailableError('Context.dev returned webpage HTML that is too large to import safely')
   }
   if (body.type !== 'html') {

--- a/server/importer.ts
+++ b/server/importer.ts
@@ -15,6 +15,12 @@ import {
 } from './publicUrl.ts'
 import { navigateWebsitePage, WebsiteCaptureUnavailableError } from './websiteAccess.ts'
 import { pruneUnusedCss } from './cssPrune.ts'
+import {
+  MAX_DISCOVERY_BYTES,
+  MAX_FRAME_HTML_BYTES,
+  MAX_IMPORT_CSS_BYTES,
+  MAX_IMPORT_CSS_FETCH_BYTES,
+} from './limits.ts'
 
 /**
  * Website importer: discover a bounded set of same-site pages, or acquire one
@@ -30,15 +36,6 @@ const VIEWPORT_WIDTH = 1280
 const MAX_HEIGHT = 6000
 const MAX_PREVIEW_HEIGHT = 4000
 const MAX_PREVIEW_TEXT_CHARS = 6000
-/* Two CSS budgets. Raw sheets are fetched under one shared bound so an
-   untrusted host cannot make us download without limit; what lands in the
-   frame is the pruned remainder, held to the smaller limit that keeps frames
-   cheap to store, broadcast and read. Real sites ship one multi-megabyte
-   bundle per product, so the fetch bound must fit a whole bundle. */
-const MAX_CSS_FETCH_BYTES = 8_000_000
-const MAX_CSS_BYTES = 2_000_000
-const MAX_DOCUMENT_BYTES = 3_000_000
-const MAX_DISCOVERY_BYTES = 2_000_000
 const MAX_SITEMAPS = 12
 const DISCOVERY_CONCURRENCY = 6
 const MAX_CSS_IMPORTS = 16
@@ -407,8 +404,8 @@ type CapturedCss = { ok: true; css: string } | { ok: false; reason: 'oversized' 
 const OVERSIZED: CapturedCss = { ok: false, reason: 'oversized' }
 const UNREACHABLE: CapturedCss = { ok: false, reason: 'unreachable' }
 
-const CSS_OVERSIZED_MESSAGE = `This page's stylesheets are larger than Doop's ${MAX_CSS_FETCH_BYTES / 1_000_000} MB import limit`
-const CSS_PRUNED_OVERSIZED_MESSAGE = `This page needs more than Doop's ${MAX_CSS_BYTES / 1_000_000} MB CSS import limit even after unused styles are removed`
+const CSS_OVERSIZED_MESSAGE = `This page's stylesheets are larger than Doop's ${MAX_IMPORT_CSS_FETCH_BYTES / 1_000_000} MB import limit`
+const CSS_PRUNED_OVERSIZED_MESSAGE = `This page needs more than Doop's ${MAX_IMPORT_CSS_BYTES / 1_000_000} MB CSS import limit even after unused styles are removed`
 const CSS_UNREACHABLE_MESSAGE = 'The webpage HTML was captured, but one or more stylesheets could not be fully loaded'
 
 /** Fetch a stylesheet within the bytes still available for the page's CSS,
@@ -616,7 +613,7 @@ export async function importPage(rawUrl: string, options: { includePreview?: boo
 
     let css = ''
     for (const sheet of snap.sheets) {
-      const captured = await fetchCss(sheet, MAX_CSS_FETCH_BYTES - Buffer.byteLength(css))
+      const captured = await fetchCss(sheet, MAX_IMPORT_CSS_FETCH_BYTES - Buffer.byteLength(css))
       if (!captured.ok) {
         throw new WebsiteCaptureUnavailableError(
           captured.reason === 'oversized' ? CSS_OVERSIZED_MESSAGE : CSS_UNREACHABLE_MESSAGE,
@@ -628,7 +625,8 @@ export async function importPage(rawUrl: string, options: { includePreview?: boo
     if (css.trim()) {
       const pruned = await pruneUnusedCss(page, css)
       if (pruned) ({ css, html } = pruned)
-      if (Buffer.byteLength(css) > MAX_CSS_BYTES) throw new WebsiteCaptureUnavailableError(CSS_PRUNED_OVERSIZED_MESSAGE)
+      if (Buffer.byteLength(css) > MAX_IMPORT_CSS_BYTES)
+        throw new WebsiteCaptureUnavailableError(CSS_PRUNED_OVERSIZED_MESSAGE)
     }
 
     /* Scrolling/lazy loading can trigger a delayed navigation. Re-check the
@@ -653,7 +651,7 @@ export async function importPage(rawUrl: string, options: { includePreview?: boo
     else html = inject + html
     html = '<!doctype html>\n' + html
 
-    if (html.length > MAX_DOCUMENT_BYTES) {
+    if (html.length > MAX_FRAME_HTML_BYTES) {
       throw new WebsiteCaptureUnavailableError('The captured webpage is too large to import safely')
     }
 

--- a/server/importer.ts
+++ b/server/importer.ts
@@ -651,7 +651,7 @@ export async function importPage(rawUrl: string, options: { includePreview?: boo
     else html = inject + html
     html = '<!doctype html>\n' + html
 
-    if (html.length > MAX_FRAME_HTML_BYTES) {
+    if (Buffer.byteLength(html) > MAX_FRAME_HTML_BYTES) {
       throw new WebsiteCaptureUnavailableError('The captured webpage is too large to import safely')
     }
 

--- a/server/ingest.ts
+++ b/server/ingest.ts
@@ -6,6 +6,7 @@ import { syncEdges, syncKeys, syncLinks } from './db/schema.ts'
 import { store } from './store.ts'
 import * as actions from './actions.ts'
 import type { Frame } from '../shared/types.ts'
+import { MAX_FRAME_HTML_BYTES } from './limits.ts'
 
 /**
  * Design sync: a PostHog-style snippet (public/doop-sync.js) embedded in an
@@ -144,7 +145,6 @@ export function wrapSnapshotHtml(html: string, marker: string, baseUrl: string |
 
 /* ------------------------------------------------------------------ */
 
-export const MAX_SNAPSHOT_BYTES = 2_500_000
 const INGESTS_PER_MIN = 30
 /** floor between rewrites of the SAME page — a busy app must not churn the
  *  canvas (and its websocket room) with a frame write per user interaction */
@@ -309,8 +309,10 @@ export async function handleIngest(req: express.Request, res: express.Response) 
     if (!edgesRecorded) return res.status(400).json({ error: 'html (or edges) required' })
     return res.json({ ok: true, edges: edgesRecorded })
   }
-  if (html.length > MAX_SNAPSHOT_BYTES) {
-    return res.status(413).json({ error: 'snapshot exceeds the 2.5 MB limit — mask or exclude heavy content' })
+  if (html.length > MAX_FRAME_HTML_BYTES) {
+    return res.status(413).json({
+      error: `snapshot exceeds the ${MAX_FRAME_HTML_BYTES / 1_000_000} MB limit — mask or exclude heavy content`,
+    })
   }
   /* hotspots persist only once the frame write they describe lands (below) —
      a 429'd snapshot must not leave coordinates for content nobody sees */

--- a/server/ingest.ts
+++ b/server/ingest.ts
@@ -309,7 +309,7 @@ export async function handleIngest(req: express.Request, res: express.Response) 
     if (!edgesRecorded) return res.status(400).json({ error: 'html (or edges) required' })
     return res.json({ ok: true, edges: edgesRecorded })
   }
-  if (html.length > MAX_FRAME_HTML_BYTES) {
+  if (Buffer.byteLength(html) > MAX_FRAME_HTML_BYTES) {
     return res.status(413).json({
       error: `snapshot exceeds the ${MAX_FRAME_HTML_BYTES / 1_000_000} MB limit — mask or exclude heavy content`,
     })

--- a/server/limits.ts
+++ b/server/limits.ts
@@ -1,0 +1,24 @@
+/**
+ * Size limits for content that becomes a frame.
+ *
+ * A frame is stored whole, broadcast whole to every viewer on each edit, and
+ * returned whole to agents on every get_frame call. Every path that turns
+ * outside content into a frame is bounded here, in one place, so the numbers
+ * are set against each other rather than picked in isolation.
+ */
+
+/** The largest HTML document any acquisition path turns into a frame: a
+ *  webpage import, a Context.dev capture, or a snippet snapshot. */
+export const MAX_FRAME_HTML_BYTES = 3_000_000
+
+/** CSS that stays in an imported frame after unused rules are pruned. Sized
+ *  to leave room for the page's own markup under MAX_FRAME_HTML_BYTES. */
+export const MAX_IMPORT_CSS_BYTES = 2_000_000
+
+/** Raw stylesheet bytes fetched from a site before pruning. Bounds what an
+ *  untrusted host can make the server download, and must fit one bundled
+ *  stylesheet since real sites ship one multi-megabyte sheet per product. */
+export const MAX_IMPORT_CSS_FETCH_BYTES = 8_000_000
+
+/** Sitemap and HTML bytes read per document while discovering a site's pages. */
+export const MAX_DISCOVERY_BYTES = 2_000_000

--- a/tests/ingest.test.ts
+++ b/tests/ingest.test.ts
@@ -242,7 +242,7 @@ describe('design sync ingest', () => {
       })
     expect((await post({ page: 'not-rooted', html: '<p>x</p>' })).status).toBe(400)
     expect((await post({ page: '/x' })).status).toBe(400)
-    expect((await post({ page: '/big', html: '<p>' + 'x'.repeat(2_600_000) + '</p>' })).status).toBe(413)
+    expect((await post({ page: '/big', html: '<p>' + 'x'.repeat(3_100_000) + '</p>' })).status).toBe(413)
   })
 
   it('link-edit visitors can edit frames but cannot touch sync keys', async () => {


### PR DESCRIPTION
Rebased onto main now that #125 has landed.

## Why

A frame is stored whole, broadcast whole to every viewer on each edit, and returned whole to agents on every `get_frame` call. Three paths turn outside content into a frame, and each capped the document with its own number picked in isolation: the webpage importer at 3 MB, the Context.dev capture at 3 MB, the snippet ingest at 2.5 MB. The importer's CSS budgets were set in the same file without reference to the document cap they have to fit under.

## What

`server/limits.ts` holds the numbers with one stated reason each:

- `MAX_FRAME_HTML_BYTES` (3 MB): the largest document any acquisition path turns into a frame. Used by the importer, Context.dev and ingest.
- `MAX_IMPORT_CSS_BYTES` (2 MB): CSS retained in an imported frame after pruning, sized to leave room for markup under the document cap.
- `MAX_IMPORT_CSS_FETCH_BYTES` (8 MB): raw stylesheet bytes fetched before pruning; bounds egress from untrusted hosts and must fit one bundled sheet.
- `MAX_DISCOVERY_BYTES` (2 MB): per-document read during site page discovery.

**Behaviour change:** ingest's cap moves from 2.5 MB to the shared 3 MB. The embeddable snippet still self-caps at 2.4 MB, so nothing it sends changes; its comment is updated. The ingest 413 message now derives from the constant.

Not touched: the 10 MB `express.json` body limit, which is a transport bound rather than a frame bound.

## Testing

The ingest size test moves its oversized payload above the new cap. Touched suites pass; full CI on the PR is the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015qsnfwqrxtp8nDDtjfYdBc


