### PR TITLE
fix(importer): keep @font-face blocks when the font shorthand uses var()

### DIFF
--- a/server/cssPrune.ts
+++ b/server/cssPrune.ts
@@ -80,7 +80,9 @@ export function pruneCssInDocument(rawCss: string, deadlineMs: number): PrunedPa
   const noteFamilies = (rule: CSSRule) => {
     if (rule instanceof CSSStyleRule) {
       const value = rule.style.getPropertyValue('font-family')
-      if (value.includes('var(')) familiesUnknown = true
+      /* A var() in the font shorthand leaves the font-family longhand empty
+         in CSSOM, so the shorthand has to be checked as well. */
+      if (value.includes('var(') || rule.style.getPropertyValue('font').includes('var(')) familiesUnknown = true
       for (const family of value.split(',')) if (family.trim()) namedFamilies.add(normalizeFamily(family))
     }
     if ('cssRules' in rule) for (const child of Array.from((rule as CSSGroupingRule).cssRules)) noteFamilies(child)

--- a/tests/cssPrune.test.ts
+++ b/tests/cssPrune.test.ts
@@ -120,6 +120,15 @@ describe.skipIf(!findBrowserPath())('unused CSS pruning', () => {
     expect(pruned).toContain('font-family: Maybe')
   })
 
+  it('keeps every @font-face when a kept rule picks its family through var() in the font shorthand', async () => {
+    const pruned = await prune(
+      '@font-face { font-family: Shorthand; src: url("https://example.com/s.woff2") }' +
+        ':root { --heading: 700 2rem Shorthand } .used:hover { font: var(--heading) }',
+    )
+
+    expect(pruned).toContain('font-family: Shorthand')
+  })
+
   it('keeps at-rules that have no selector to test', async () => {
     const pruned = await prune(
       '@keyframes spin { to { transform: rotate(1turn) } }' +


### PR DESCRIPTION
Follow-up to #126, from Greptile's second-round finding there.

A `var()` in the `font` shorthand leaves the `font-family` longhand empty in CSSOM, so the guard that keeps every `@font-face` when families cannot be known never fired for it, and a face reached only through such a rule was dropped. The shorthand is now checked as well. Verified the new real-Chromium test fails without the fix and passes with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015qsnfwqrxtp8nDDtjfYdBc