### PR TITLE
fix(agent): stream Anthropic turns so long recon runs are not refused

### DIFF
--- a/server/agentModel.ts
+++ b/server/agentModel.ts
@@ -69,29 +69,49 @@ function anthropicTier(): AgentModel | null {
   return {
     provider: 'anthropic',
     label: `Doop (${ANTHROPIC_MODEL})`,
-    async run(req) {
-      const res = await client.messages.create({
-        model: ANTHROPIC_MODEL,
-        max_tokens: req.maxTokens,
-        system: req.system.map((block) => ({
-          type: 'text' as const,
-          text: block.text,
-          ...(block.cache ? { cache_control: { type: 'ephemeral' as const } } : {}),
-        })),
-        tools: req.tools,
-        messages: req.messages,
-      })
-      const stop: StopReason =
-        res.stop_reason === 'refusal'
-          ? 'refusal'
-          : res.stop_reason === 'max_tokens'
-            ? 'max_tokens'
-            : res.stop_reason === 'tool_use'
-              ? 'tool_use'
-              : 'end_turn'
-      return { content: res.content as TurnBlock[], stop_reason: stop }
-    },
+    run: (req) => runAnthropicTurn(client, ANTHROPIC_MODEL, req),
   }
+}
+
+/**
+ * One Anthropic turn, streamed and collected into a message.
+ *
+ * Streaming is not for show here: it is what lets a turn run long. The SDK
+ * refuses a non-streaming request whose max_tokens implies more than ten
+ * minutes of generation ("Streaming is required for operations that may take
+ * longer than 10 minutes"), and GitHub recon asks for 32k tokens per turn. A
+ * bigger client timeout would silence that check but leave a silent HTTP
+ * connection open for the whole generation, which proxies drop. Over SSE the
+ * SDK's timeout only guards the wait for headers; the response itself stays
+ * alive on the API's ping events until the message is complete.
+ */
+export async function runAnthropicTurn(
+  client: Anthropic,
+  model: string,
+  req: AgentTurnRequest,
+): Promise<AgentTurnResult> {
+  const res = await client.messages
+    .stream({
+      model,
+      max_tokens: req.maxTokens,
+      system: req.system.map((block) => ({
+        type: 'text' as const,
+        text: block.text,
+        ...(block.cache ? { cache_control: { type: 'ephemeral' as const } } : {}),
+      })),
+      tools: req.tools,
+      messages: req.messages,
+    })
+    .finalMessage()
+  const stop: StopReason =
+    res.stop_reason === 'refusal'
+      ? 'refusal'
+      : res.stop_reason === 'max_tokens'
+        ? 'max_tokens'
+        : res.stop_reason === 'tool_use'
+          ? 'tool_use'
+          : 'end_turn'
+  return { content: res.content as TurnBlock[], stop_reason: stop }
 }
 
 function azureTier(): AgentModel | null {

--- a/tests/anthropicTurn.test.ts
+++ b/tests/anthropicTurn.test.ts
@@ -1,0 +1,112 @@
+import http from 'node:http'
+import type { AddressInfo } from 'node:net'
+import Anthropic from '@anthropic-ai/sdk'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { runAnthropicTurn } from '../server/agentModel.ts'
+
+/**
+ * The server tier's Anthropic turn must stream. GitHub recon asks for 32k
+ * output tokens per turn, and the SDK refuses a NON-streaming request that
+ * large up front ("Streaming is required for operations that may take longer
+ * than 10 minutes"). These tests stand in a fake Messages endpoint and pin
+ * both halves: the request goes out as a stream, and the collected message
+ * comes back in the shape the agent loop expects.
+ */
+
+type Event = { type: string; [key: string]: unknown }
+
+const sse = (event: Event) => `event: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`
+
+const CONTENT = [
+  { type: 'text', text: 'Pulling the theme first.' },
+  { type: 'tool_use', id: 'toolu_1', name: 'request_files', input: { paths: ['src/theme.ts'] } },
+]
+
+/** Streams CONTENT as a message that ends in a tool call. */
+function serveStream(res: http.ServerResponse) {
+  res.writeHead(200, { 'content-type': 'text/event-stream' })
+  const message = { id: 'msg_1', type: 'message', role: 'assistant', model: 'fake', content: [], stop_reason: null }
+  res.write(sse({ type: 'message_start', message: { ...message, usage: { input_tokens: 1, output_tokens: 0 } } }))
+  res.write(sse({ type: 'content_block_start', index: 0, content_block: { type: 'text', text: '' } }))
+  res.write(sse({ type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text: CONTENT[0]!.text } }))
+  res.write(sse({ type: 'content_block_stop', index: 0 }))
+  res.write(
+    sse({
+      type: 'content_block_start',
+      index: 1,
+      content_block: { type: 'tool_use', id: 'toolu_1', name: 'request_files', input: {} },
+    }),
+  )
+  res.write(
+    sse({
+      type: 'content_block_delta',
+      index: 1,
+      delta: { type: 'input_json_delta', partial_json: JSON.stringify(CONTENT[1]!.input) },
+    }),
+  )
+  res.write(sse({ type: 'content_block_stop', index: 1 }))
+  res.write(
+    sse({
+      type: 'message_delta',
+      delta: { stop_reason: 'tool_use', stop_sequence: null },
+      usage: { output_tokens: 9 },
+    }),
+  )
+  res.write(sse({ type: 'message_stop' }))
+  res.end()
+}
+
+let server: http.Server
+let client: Anthropic
+const requests: { stream?: boolean; max_tokens?: number; system?: unknown }[] = []
+
+beforeAll(async () => {
+  server = http.createServer((req, res) => {
+    let body = ''
+    req.on('data', (chunk: Buffer) => (body += chunk))
+    req.on('end', () => {
+      const parsed = JSON.parse(body) as (typeof requests)[number]
+      requests.push(parsed)
+      if (!parsed.stream) {
+        res.writeHead(400, { 'content-type': 'application/json' })
+        res.end(
+          JSON.stringify({ type: 'error', error: { type: 'invalid_request_error', message: 'expected a stream' } }),
+        )
+        return
+      }
+      serveStream(res)
+    })
+  })
+  await new Promise<void>((resolve) => server.listen(0, resolve))
+  const { port } = server.address() as AddressInfo
+  client = new Anthropic({ apiKey: 'test', baseURL: `http://127.0.0.1:${port}`, maxRetries: 0 })
+})
+
+afterAll(() => server.close())
+
+describe('runAnthropicTurn', () => {
+  it('streams a 32k-token turn (a non-streaming request that size is refused by the SDK)', async () => {
+    const result = await runAnthropicTurn(client, 'fake', {
+      system: [{ text: 'You are the recon model.', cache: true }],
+      tools: [],
+      messages: [{ role: 'user', content: 'Reconstruct the settings screen.' }],
+      maxTokens: 32_000,
+    })
+    expect(requests.at(-1)).toMatchObject({ stream: true, max_tokens: 32_000 })
+    expect(result.stop_reason).toBe('tool_use')
+    expect(result.content).toEqual(CONTENT)
+  })
+
+  it('keeps the cache breakpoint on the system block', async () => {
+    await runAnthropicTurn(client, 'fake', {
+      system: [{ text: 'cached', cache: true }, { text: 'fresh' }],
+      tools: [],
+      messages: [{ role: 'user', content: 'hi' }],
+      maxTokens: 1000,
+    })
+    expect(requests.at(-1)?.system).toEqual([
+      { type: 'text', text: 'cached', cache_control: { type: 'ephemeral' } },
+      { type: 'text', text: 'fresh' },
+    ])
+  })
+})


### PR DESCRIPTION
Timeout half of #115. Supersedes #118 (thanks @bluzername for the diagnosis — the fix takes a different route, see below).

## Problem

GitHub recon runs the model with `max_tokens: 32_000`. The Anthropic SDK estimates 60 minutes per 128k tokens, so it refuses a **non-streaming** request that large before sending it:

```
Streaming is required for operations that may take longer than 10 minutes.
```

Every recon on the server tier failed on the first turn.

## Fix

Switch the server tier's Anthropic turn from `messages.create()` to `messages.stream(...).finalMessage()`. The precheck does not apply to streams, and once the response is streamed the SDK's timeout only guards the wait for headers — the generation itself stays alive on the API's `ping` events. No env var, no timeout to tune.

Why not raise the client timeout (#118's approach)? Verified against a fake Messages endpoint with the pinned SDK:

| Case | Result |
|---|---|
| non-streaming, 32k tokens, no timeout | throws the precheck error |
| non-streaming, timeout 2s, server answers after 4s | `APIConnectionTimeoutError` |
| streaming, timeout 2s, generation takes 5s | completes |

A bigger timeout silences the check but keeps a silent HTTP connection open for the whole run, which is exactly what proxies drop, and if the run outlasts the value the whole turn is lost. Streaming is what the SDK asks for, and it matches the OpenAI path, which already consumes an SSE stream.

The turn is pulled into an exported `runAnthropicTurn(client, model, req)` so it can be tested with an injected client. The distiller keeps `create()`: its turns are 100 and 1000 tokens.

## Testing

- `tests/anthropicTurn.test.ts` — a fake Messages endpoint that only accepts streams; asserts a 32k-token turn goes out as a stream and the collected message maps back to the agent loop's shape (content blocks, `tool_use` stop reason, cache breakpoint on the system block). Swapping back to `create()` fails both tests with the precheck error.
- `bun run typecheck`, `lint`, `format:check`, `test` (295/295) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013vUYiB9zedCuV9tJ4sRAkQ
