### PR TITLE
refactor(server): load deployment-private extras through server/private

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -1,6 +1,6 @@
 import http from 'node:http'
 import { createHash } from 'node:crypto'
-import { readFileSync } from 'node:fs'
+import { existsSync, readFileSync } from 'node:fs'
 import path from 'node:path'
 import express from 'express'
 import { eq, inArray } from 'drizzle-orm'
@@ -1492,25 +1492,24 @@ app.get('/.well-known/oauth-protected-resource', protectedResourceMetadata)
 /* path-aware variant some clients probe for a resource at /mcp */
 app.get('/.well-known/oauth-protected-resource/mcp', protectedResourceMetadata)
 
-/* Internal-deployment extras, loaded only when configured: a server-rendered
-   /blog (headless WordPress) and a marketing-site proxy for signed-out `/`.
-   Both must precede the SPA catch-all. The module paths go through variables
-   because the open-source export ships without these files — an unresolved
-   static import would break its typecheck, an unexecuted dynamic one can't. */
-if (process.env.WORDPRESS_API_URL) {
-  const blogModule = './blog/index.ts'
-  const { mountBlog } = (await import(blogModule)) as { mountBlog: (a: express.Express) => void }
-  mountBlog(app)
-}
-if (process.env.MARKETING_ORIGIN) {
-  const marketingModule = './marketing.ts'
-  const { mountMarketing } = (await import(marketingModule)) as { mountMarketing: (a: express.Express) => void }
-  mountMarketing(app)
+/* Deployment-private extras: whatever the hosted instance mounts that the
+   open-source tree does not ship (marketing-site proxy, founder outreach).
+   The hook is server/private/index.ts, present only in that private checkout,
+   so the path goes through a variable — an unresolved static import would
+   break the typecheck here, an unexecuted dynamic one can't — and the
+   existence check keeps the import from throwing where the file is absent.
+   Must precede the SPA catch-all so the hook can claim routes. */
+const privateModule = './private/index.ts'
+if (existsSync(new URL(privateModule, import.meta.url))) {
+  const { mountPrivate } = (await import(privateModule)) as {
+    mountPrivate: (a: express.Express) => void | Promise<void>
+  }
+  await mountPrivate(app)
 }
 
-/* robots + minimal sitemap for every deployment. Registered after the blog
-   mount on purpose: a configured blog registered its richer, WP-aware
-   sitemap above, and the first matching route wins. */
+/* robots + minimal sitemap for every deployment. Registered after the
+   private hook on purpose: a hosted deployment may register a richer sitemap
+   there, and the first matching route wins. */
 app.get('/robots.txt', (_req, res) => {
   res
     .type('text/plain')


### PR DESCRIPTION
## Why

`server/index.ts` carried a dynamic import of `./blog/index.ts`, a module that no longer exists in any checkout, plus an inline mount for a marketing proxy that only the hosted deployment has. Both made the file differ from the private repo for no product reason.

## What

One guarded dynamic import of `server/private/index.ts`, which exists only in the private checkout. The path goes through a variable so the typecheck never resolves it, and an `existsSync` check skips it where absent. The file is now byte-identical in both repos, and private-only mounts live behind a single `mountPrivate(app)` hook.

No behaviour change for open-source deployments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WhraE9SrNdHURijbz6yznC