### PR TITLE
fix(canvas): element click no longer re-selects previous

### DIFF
--- a/src/components/FrameView.tsx
+++ b/src/components/FrameView.tsx
@@ -399,13 +399,14 @@ export const FrameView = memo(function FrameView({ frame, raster }: { frame: Fra
   const wantedSel = useStore((s) => (s.selectedElement?.frameId === frame.id ? s.selectedElement.selector : null))
   const selectReq = useRef(0)
   useEffect(() => {
-    if (!runtimeReady || !wantedSel || wantedSel === probeSel) return
+    const cur = useStore.getState().selectedElement
+    if (!runtimeReady || cur?.frameId !== frame.id || cur.selector === probeSel) return
     selectReq.current += 1
     iframeRef.current?.contentWindow?.postMessage(
-      { type: 'doop:select', reqId: selectReq.current, selector: wantedSel },
+      { type: 'doop:select', reqId: selectReq.current, selector: cur.selector },
       '*',
     )
-  }, [runtimeReady, wantedSel, probeSel])
+  }, [runtimeReady, wantedSel, probeSel, frame.id])
 
   useEffect(() => {
     function onMsg(ev: MessageEvent) {


### PR DESCRIPTION
This PR fixes clicking another element while one is already selected: the old selection stayed and the new click was dropped until you clicked outside the frame first.


before -


https://github.com/user-attachments/assets/2d7c01bb-02ca-4cac-ac54-a610873babd7




after -


https://github.com/user-attachments/assets/ba50226a-0179-4eb6-b7a8-8c959bdd9982

