### PR TITLE
feat(automations): scheduled pulls and agent tasks, with a Meta integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -160,6 +160,16 @@
 #DOOP_IMAGE_MODEL=
 #DOOP_IMAGE_ROUTER_MODEL=
 
+# ---------------------------------------------------------------- meta ads
+# The Meta integration (Integrations page): connect a Meta account with the
+# ads_read permission and automations can pull ad creatives onto a canvas.
+# Create an app at https://developers.facebook.com/apps (type: Business),
+# add the "Facebook Login for Business" product, and register
+# BETTER_AUTH_URL + /api/integrations/meta/callback as a valid OAuth redirect
+# URI. Both must be set together; unset hides the Connect button.
+#META_APP_ID=
+#META_APP_SECRET=
+
 # ------------------------------------------------------------ image search
 # Stock photo search for design agents (the search_images tool, MCP and
 # resident). Free key from https://www.pexels.com/api/ — unset disables photo

--- a/server/automations.ts
+++ b/server/automations.ts
@@ -1,0 +1,453 @@
+import express from 'express'
+import { and, desc, eq, inArray, isNotNull, lte } from 'drizzle-orm'
+import { nanoid } from 'nanoid'
+import { db } from './db/index.ts'
+import { automationRuns, automations } from './db/schema.ts'
+import { store } from './store.ts'
+import * as actions from './actions.ts'
+import * as allowance from './allowance.ts'
+import * as meta from './meta.ts'
+import { hasDurableCanvasAccess } from './access.ts'
+import { getUserName } from './auth.ts'
+import { roleName } from '../shared/agents.ts'
+import {
+  MAX_NAME,
+  incompleteReason,
+  nextRunAt,
+  normalizeSchedule,
+  normalizeSteps,
+  type Automation,
+  type AutomationRun,
+  type Step,
+} from '../shared/automations.ts'
+
+/**
+ * Automations: scheduled workflows of pull and agent-task steps (see
+ * shared/automations.ts for the model). This module owns the rows, the
+ * REST surface under /api/automations, running one automation end to end,
+ * and the scheduler tick that fires due ones.
+ *
+ * A run walks the steps in order. A pull step lands frames on its canvas
+ * right away. An agent step queues a board card for the resident team on
+ * its canvas, billed to the automation's owner exactly like a card they
+ * would write on the Board — the run is "ok" once the card is queued; the
+ * agent's own progress shows on that canvas. Concurrency is one run per
+ * automation; a tick that finds one still running leaves it alone.
+ */
+
+type AutomationRow = typeof automations.$inferSelect
+type RunRow = typeof automationRuns.$inferSelect
+
+const TICK_MS = 60_000
+const RUNS_PAGE = 20
+/** the number of runs kept per automation; older ones are pruned on write */
+const RUNS_KEEP = 100
+
+/* ------------------------------------------------------------------ */
+/* Rows                                                                */
+
+function toRun(row: RunRow): AutomationRun {
+  return {
+    id: row.id,
+    automationId: row.automationId,
+    startedAt: row.startedAt,
+    endedAt: row.endedAt,
+    status: row.status as AutomationRun['status'],
+    summary: row.summary,
+    error: row.error,
+    canvasId: row.canvasId,
+    failure: row.failure === 'reconnect' ? 'reconnect' : null,
+  }
+}
+
+async function lastRuns(ids: string[]): Promise<Map<string, RunRow>> {
+  const out = new Map<string, RunRow>()
+  if (ids.length === 0) return out
+  const rows = await db
+    .select()
+    .from(automationRuns)
+    .where(inArray(automationRuns.automationId, ids))
+    .orderBy(desc(automationRuns.startedAt))
+  for (const r of rows) if (!out.has(r.automationId)) out.set(r.automationId, r)
+  return out
+}
+
+function toAutomation(row: AutomationRow, last: RunRow | undefined): Automation {
+  return {
+    id: row.id,
+    name: row.name,
+    enabled: row.enabled,
+    schedule: row.schedule,
+    steps: row.steps,
+    nextRunAt: row.nextRunAt,
+    lastRun: last
+      ? {
+          id: last.id,
+          startedAt: last.startedAt,
+          status: last.status as AutomationRun['status'],
+          summary: last.summary,
+          failure: last.failure === 'reconnect' ? 'reconnect' : null,
+        }
+      : null,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  }
+}
+
+export async function listAutomations(ownerId: string): Promise<Automation[]> {
+  const rows = await db
+    .select()
+    .from(automations)
+    .where(eq(automations.ownerId, ownerId))
+    .orderBy(desc(automations.updatedAt))
+  const last = await lastRuns(rows.map((r) => r.id))
+  return rows.map((r) => toAutomation(r, last.get(r.id)))
+}
+
+async function getRow(ownerId: string, id: string): Promise<AutomationRow | undefined> {
+  const [row] = await db
+    .select()
+    .from(automations)
+    .where(and(eq(automations.id, id), eq(automations.ownerId, ownerId)))
+  return row ?? undefined
+}
+
+export async function getAutomation(ownerId: string, id: string): Promise<Automation | undefined> {
+  const row = await getRow(ownerId, id)
+  if (!row) return undefined
+  const last = await lastRuns([row.id])
+  return toAutomation(row, last.get(row.id))
+}
+
+/** When the scheduler should fire this row next — null while it can't run. */
+function scheduleNext(row: Pick<AutomationRow, 'enabled' | 'schedule' | 'steps'>, after = Date.now()): number | null {
+  if (!row.enabled || incompleteReason(row.steps)) return null
+  return nextRunAt(row.schedule, after)
+}
+
+/** Every step's canvas must be one the owner durably reaches — a share-link
+ *  visit is not a place to park an automation that outlives the visit. */
+function checkCanvases(ownerId: string, steps: Step[]): string | undefined {
+  for (const s of steps) {
+    if (!s.canvasId) continue
+    const c = store.getCanvas(s.canvasId)
+    if (!c || !hasDurableCanvasAccess(ownerId, c)) return 'one of the canvases is not yours'
+  }
+  return undefined
+}
+
+export interface AutomationInput {
+  name?: unknown
+  enabled?: unknown
+  schedule?: unknown
+  steps?: unknown
+}
+
+function parseInput(
+  body: AutomationInput,
+  ownerId: string,
+  current?: AutomationRow,
+): { name: string; enabled: boolean; schedule: AutomationRow['schedule']; steps: Step[] } | string {
+  const name =
+    body.name === undefined ? (current?.name ?? 'Untitled automation') : String(body.name).trim().slice(0, MAX_NAME)
+  if (!name) return 'name is required'
+  const enabled = body.enabled === undefined ? (current?.enabled ?? true) : !!body.enabled
+  const schedule =
+    body.schedule === undefined ? (current?.schedule ?? normalizeSchedule({})) : normalizeSchedule(body.schedule)
+  let steps: Step[]
+  if (body.steps === undefined) steps = current?.steps ?? []
+  else {
+    const parsed = normalizeSteps(body.steps)
+    if (typeof parsed === 'string') return parsed
+    steps = parsed
+  }
+  const bad = checkCanvases(ownerId, steps)
+  if (bad) return bad
+  return { name, enabled, schedule, steps }
+}
+
+export async function createAutomation(ownerId: string, body: AutomationInput): Promise<Automation | string> {
+  const parsed = parseInput(body, ownerId)
+  if (typeof parsed === 'string') return parsed
+  const now = Date.now()
+  const row: AutomationRow = {
+    id: nanoid(8),
+    ownerId,
+    ...parsed,
+    nextRunAt: scheduleNext(parsed, now),
+    createdAt: now,
+    updatedAt: now,
+  }
+  await db.insert(automations).values(row)
+  return toAutomation(row, undefined)
+}
+
+export async function updateAutomation(
+  ownerId: string,
+  id: string,
+  body: AutomationInput,
+): Promise<Automation | string | undefined> {
+  /* read, merge and write under a row lock: the next run is derived from
+     the row as it is AFTER this request, never from a copy another request
+     may already have changed */
+  const out = await db.transaction(async (tx) => {
+    const [current] = await tx
+      .select()
+      .from(automations)
+      .where(and(eq(automations.id, id), eq(automations.ownerId, ownerId)))
+      .for('update')
+    if (!current) return undefined
+    const parsed = parseInput(body, ownerId, current)
+    if (typeof parsed === 'string') return parsed
+    const now = Date.now()
+    /* write only what this request carries: a rename must not put another
+       request's field back the way it was */
+    const patch: Partial<AutomationRow> = { updatedAt: now, nextRunAt: scheduleNext(parsed, now) }
+    if (body.name !== undefined) patch.name = parsed.name
+    if (body.enabled !== undefined) patch.enabled = parsed.enabled
+    if (body.schedule !== undefined) patch.schedule = parsed.schedule
+    if (body.steps !== undefined) patch.steps = parsed.steps
+    const [row] = await tx.update(automations).set(patch).where(eq(automations.id, id)).returning()
+    return row
+  })
+  if (!out || typeof out === 'string') return out
+  const last = await lastRuns([id])
+  return toAutomation(out, last.get(id))
+}
+
+export async function deleteAutomation(ownerId: string, id: string): Promise<boolean> {
+  const gone = await db
+    .delete(automations)
+    .where(and(eq(automations.id, id), eq(automations.ownerId, ownerId)))
+    .returning({ id: automations.id })
+  if (gone.length === 0) return false
+  await db.delete(automationRuns).where(eq(automationRuns.automationId, id))
+  return true
+}
+
+export async function listRuns(ownerId: string, id: string, before?: number): Promise<AutomationRun[] | undefined> {
+  const row = await getRow(ownerId, id)
+  if (!row) return undefined
+  const rows = await db
+    .select()
+    .from(automationRuns)
+    .where(
+      before
+        ? and(eq(automationRuns.automationId, id), lte(automationRuns.startedAt, before - 1))
+        : eq(automationRuns.automationId, id),
+    )
+    .orderBy(desc(automationRuns.startedAt))
+    .limit(RUNS_PAGE)
+  return rows.map(toRun)
+}
+
+/* ------------------------------------------------------------------ */
+/* Running                                                             */
+
+const running = new Set<string>()
+
+class StepError extends Error {
+  failure: AutomationRun['failure']
+  constructor(message: string, failure: AutomationRun['failure'] = null) {
+    super(message)
+    this.failure = failure
+  }
+}
+
+async function runPull(row: AutomationRow, step: Extract<Step, { type: 'pull' }>, actorName: string): Promise<string> {
+  const connection = await meta.getConnection(row.ownerId)
+  if (!connection) throw new StepError('Meta is not connected', 'reconnect')
+  try {
+    const result = await meta.pullCreatives({
+      connection,
+      accountId: step.accountId,
+      filter: step.filter,
+      canvasId: step.canvasId,
+      ownerId: row.ownerId,
+      actor: actions.resolveActor({ name: actorName, kind: 'user' }),
+    })
+    const n = result.created.length
+    const noun = n === 1 ? 'creative' : 'creatives'
+    return result.skipped > 0 ? `${n} new ${noun} (${result.skipped} already here)` : `${n} ${noun} pulled`
+  } catch (err) {
+    if (err instanceof meta.MetaAuthError)
+      throw new StepError(`Meta rejected the connection: ${err.message}`, 'reconnect')
+    throw err
+  }
+}
+
+async function runAgent(
+  row: AutomationRow,
+  step: Extract<Step, { type: 'agent' }>,
+  actorName: string,
+): Promise<string> {
+  const gate = await allowance.consumeResidentTask(row.ownerId)
+  if (!gate.ok) throw new StepError('no model account connected — the Doop Agent has nothing to run on')
+  const card = actions.addQueuedCard(step.canvasId, step.prompt, actorName, step.roles, undefined, row.ownerId)
+  if (!card) {
+    await allowance.refundResidentTask(gate, row.ownerId)
+    throw new StepError('canvas not found')
+  }
+  return `card queued for ${roleName(step.roles[0])}`
+}
+
+/** Run one automation now. The row is re-read here, not carried in from
+ *  the caller: an automation deleted, disabled or edited since it was
+ *  picked runs as it is now — or, once switched off or gone, not at all.
+ *  Resolves to the run once every step has finished (or the first failing
+ *  one has); undefined when there was nothing to run. */
+export async function runAutomation(
+  id: string,
+  opts: { scheduled?: boolean } = {},
+): Promise<AutomationRun | undefined> {
+  if (running.has(id)) throw new Error('already running')
+  running.add(id)
+  const summaries: string[] = []
+  let run: RunRow | undefined
+  try {
+    const [row] = await db.select().from(automations).where(eq(automations.id, id))
+    if (!row || (opts.scheduled && !row.enabled)) return undefined
+    run = {
+      id: nanoid(8),
+      automationId: row.id,
+      startedAt: Date.now(),
+      endedAt: null,
+      status: 'running',
+      summary: null,
+      error: null,
+      canvasId: row.steps[0]?.canvasId ?? null,
+      failure: null,
+    }
+    await db.insert(automationRuns).values(run)
+    try {
+      const incomplete = incompleteReason(row.steps)
+      if (incomplete) throw new StepError(incomplete)
+      const bad = checkCanvases(row.ownerId, row.steps)
+      if (bad) throw new StepError(bad)
+      const actorName = `${(await getUserName(row.ownerId)) ?? 'Automation'} · ${row.name}`
+      for (const step of row.steps) {
+        summaries.push(
+          step.type === 'pull' ? await runPull(row, step, actorName) : await runAgent(row, step, actorName),
+        )
+      }
+      run.status = 'ok'
+      run.summary = summaries.join(' · ')
+    } catch (err) {
+      run.status = 'failed'
+      run.summary = summaries.length ? summaries.join(' · ') : null
+      run.error = err instanceof Error ? err.message : String(err)
+      run.failure = err instanceof StepError ? err.failure : null
+    }
+    run.endedAt = Date.now()
+    await db.update(automationRuns).set(run).where(eq(automationRuns.id, run.id))
+    void pruneRuns(row.id)
+    return toRun(run)
+  } finally {
+    running.delete(id)
+  }
+}
+
+async function pruneRuns(automationId: string): Promise<void> {
+  const rows = await db
+    .select({ id: automationRuns.id })
+    .from(automationRuns)
+    .where(eq(automationRuns.automationId, automationId))
+    .orderBy(desc(automationRuns.startedAt))
+    .offset(RUNS_KEEP)
+  if (rows.length > 0)
+    await db.delete(automationRuns).where(
+      inArray(
+        automationRuns.id,
+        rows.map((r) => r.id),
+      ),
+    )
+}
+
+/* ------------------------------------------------------------------ */
+/* Scheduler                                                           */
+
+/** Fire every automation whose time has come. The claim is one conditional
+ *  update — move `next_run_at` forward only if it still holds the value we
+ *  read — so with several server replicas on one database exactly one of
+ *  them runs each occurrence, and a crash mid-run costs that occurrence
+ *  rather than leaving a stuck row. */
+export async function tick(now = Date.now()): Promise<number> {
+  const due = await db
+    .select()
+    .from(automations)
+    .where(and(eq(automations.enabled, true), isNotNull(automations.nextRunAt), lte(automations.nextRunAt, now)))
+  let fired = 0
+  for (const row of due) {
+    if (row.nextRunAt === null) continue
+    const claimed = await db
+      .update(automations)
+      .set({ nextRunAt: scheduleNext(row, now) })
+      .where(and(eq(automations.id, row.id), eq(automations.nextRunAt, row.nextRunAt)))
+      .returning({ id: automations.id })
+    if (claimed.length === 0 || running.has(row.id)) continue
+    fired++
+    runAutomation(row.id, { scheduled: true }).catch((err) => console.error('[automations] run failed', row.id, err))
+  }
+  return fired
+}
+
+let timer: NodeJS.Timeout | undefined
+
+export function startScheduler(): void {
+  if (timer) return
+  timer = setInterval(() => {
+    tick().catch((err) => console.error('[automations] tick failed', err))
+  }, TICK_MS)
+  timer.unref()
+}
+
+/* ------------------------------------------------------------------ */
+/* REST                                                                */
+
+export const automationsRouter = express.Router()
+
+automationsRouter.get('/', async (req, res) => {
+  res.json(await listAutomations(req.user!.id))
+})
+
+automationsRouter.post('/', async (req, res) => {
+  const out = await createAutomation(req.user!.id, req.body ?? {})
+  if (typeof out === 'string') return res.status(400).json({ error: out })
+  res.json(out)
+})
+
+automationsRouter.get('/:id', async (req, res) => {
+  const out = await getAutomation(req.user!.id, req.params.id)
+  if (!out) return res.status(404).json({ error: 'not found' })
+  res.json(out)
+})
+
+automationsRouter.patch('/:id', async (req, res) => {
+  const out = await updateAutomation(req.user!.id, req.params.id, req.body ?? {})
+  if (!out) return res.status(404).json({ error: 'not found' })
+  if (typeof out === 'string') return res.status(400).json({ error: out })
+  res.json(out)
+})
+
+automationsRouter.delete('/:id', async (req, res) => {
+  if (!(await deleteAutomation(req.user!.id, req.params.id))) return res.status(404).json({ error: 'not found' })
+  res.json({ ok: true })
+})
+
+automationsRouter.get('/:id/runs', async (req, res) => {
+  const before = Number(req.query.before) || undefined
+  const out = await listRuns(req.user!.id, req.params.id, before)
+  if (!out) return res.status(404).json({ error: 'not found' })
+  res.json(out)
+})
+
+/* "Run now": the same run the schedule would start, on demand. Responds once
+   the run has finished — a pull is seconds, an agent step only queues. */
+automationsRouter.post('/:id/run', async (req, res) => {
+  const row = await getRow(req.user!.id, req.params.id)
+  if (!row) return res.status(404).json({ error: 'not found' })
+  if (running.has(row.id)) return res.status(409).json({ error: 'already running' })
+  const run = await runAutomation(row.id)
+  if (!run) return res.status(404).json({ error: 'not found' })
+  res.json(run)
+})

--- a/server/db/migrations/0012_automations.sql
+++ b/server/db/migrations/0012_automations.sql
@@ -1,0 +1,40 @@
+CREATE TABLE "automation_runs" (
+	"id" text PRIMARY KEY NOT NULL,
+	"automation_id" text NOT NULL,
+	"started_at" bigint NOT NULL,
+	"ended_at" bigint,
+	"status" text NOT NULL,
+	"summary" text,
+	"error" text,
+	"canvas_id" text,
+	"failure" text
+);
+--> statement-breakpoint
+CREATE TABLE "automations" (
+	"id" text PRIMARY KEY NOT NULL,
+	"owner_id" text NOT NULL,
+	"name" text NOT NULL,
+	"enabled" boolean DEFAULT true NOT NULL,
+	"schedule" jsonb NOT NULL,
+	"steps" jsonb NOT NULL,
+	"next_run_at" bigint,
+	"created_at" bigint NOT NULL,
+	"updated_at" bigint NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "integrations" (
+	"id" text PRIMARY KEY NOT NULL,
+	"user_id" text NOT NULL,
+	"provider" text NOT NULL,
+	"access_token" text NOT NULL,
+	"expires_at" bigint,
+	"account_name" text,
+	"accounts" jsonb NOT NULL,
+	"connected_at" bigint NOT NULL,
+	"updated_at" bigint NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX "automation_runs_automation_idx" ON "automation_runs" USING btree ("automation_id");--> statement-breakpoint
+CREATE INDEX "automations_owner_idx" ON "automations" USING btree ("owner_id");--> statement-breakpoint
+CREATE INDEX "automations_next_run_idx" ON "automations" USING btree ("next_run_at");--> statement-breakpoint
+CREATE INDEX "integrations_user_idx" ON "integrations" USING btree ("user_id");

--- a/server/db/migrations/0013_integrations_unique.sql
+++ b/server/db/migrations/0013_integrations_unique.sql
@@ -1,0 +1,2 @@
+DROP INDEX "integrations_user_idx";--> statement-breakpoint
+CREATE UNIQUE INDEX "integrations_user_provider_idx" ON "integrations" USING btree ("user_id","provider");

--- a/server/db/migrations/meta/0012_snapshot.json
+++ b/server/db/migrations/meta/0012_snapshot.json
@@ -1,0 +1,2587 @@
+{
+  "id": "ec99a43e-4869-4b57-9e4d-364f1815b769",
+  "prevId": "85578137-9efc-4036-82df-2433532dd603",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.activity": {
+      "name": "activity",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "canvas_id": {
+          "name": "canvas_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_kind": {
+          "name": "actor_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_color": {
+          "name": "actor_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frame_id": {
+          "name": "frame_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "at": {
+          "name": "at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "activity_canvas_idx": {
+          "name": "activity_canvas_idx",
+          "columns": [
+            {
+              "expression": "canvas_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.asset_refs": {
+      "name": "asset_refs",
+      "schema": "",
+      "columns": {
+        "asset_id": {
+          "name": "asset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frame_id": {
+          "name": "frame_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "asset_refs_frame_idx": {
+          "name": "asset_refs_frame_idx",
+          "columns": [
+            {
+              "expression": "frame_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "asset_refs_asset_id_frame_id_pk": {
+          "name": "asset_refs_asset_id_frame_id_pk",
+          "columns": ["asset_id", "frame_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.assets": {
+      "name": "assets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "canvas_id": {
+          "name": "canvas_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mime": {
+          "name": "mime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ext": {
+          "name": "ext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "assets_canvas_idx": {
+          "name": "assets_canvas_idx",
+          "columns": [
+            {
+              "expression": "canvas_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.automation_runs": {
+      "name": "automation_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "automation_id": {
+          "name": "automation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canvas_id": {
+          "name": "canvas_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure": {
+          "name": "failure",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "automation_runs_automation_idx": {
+          "name": "automation_runs_automation_idx",
+          "columns": [
+            {
+              "expression": "automation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.automations": {
+      "name": "automations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "schedule": {
+          "name": "schedule",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "steps": {
+          "name": "steps",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "automations_owner_idx": {
+          "name": "automations_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "automations_next_run_idx": {
+          "name": "automations_next_run_idx",
+          "columns": [
+            {
+              "expression": "next_run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.backgrounds": {
+      "name": "backgrounds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tone": {
+          "name": "tone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "style": {
+          "name": "style",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avg_color": {
+          "name": "avg_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "palette": {
+          "name": "palette",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slots": {
+          "name": "slots",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text_zone": {
+          "name": "text_zone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.canvas_members": {
+      "name": "canvas_members",
+      "schema": "",
+      "columns": {
+        "canvas_id": {
+          "name": "canvas_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "added_by": {
+          "name": "added_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "canvas_members_canvas_id_user_id_pk": {
+          "name": "canvas_members_canvas_id_user_id_pk",
+          "columns": ["canvas_id", "user_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.canvases": {
+      "name": "canvases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_access": {
+          "name": "link_access",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "copy_count": {
+          "name": "copy_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.comments": {
+      "name": "comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "canvas_id": {
+          "name": "canvas_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frame_id": {
+          "name": "frame_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "selector": {
+          "name": "selector",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snippet": {
+          "name": "snippet",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_name": {
+          "name": "from_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_user_id": {
+          "name": "from_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "at": {
+          "name": "at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "for_agent": {
+          "name": "for_agent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "target_agent": {
+          "name": "target_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_by": {
+          "name": "claimed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failed_at": {
+          "name": "failed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "comments_canvas_idx": {
+          "name": "comments_canvas_idx",
+          "columns": [
+            {
+              "expression": "canvas_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.decisions": {
+      "name": "decisions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "canvas_id": {
+          "name": "canvas_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frame_id": {
+          "name": "frame_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_name": {
+          "name": "from_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "at": {
+          "name": "at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "distilled_at": {
+          "name": "distilled_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "decisions_canvas_idx": {
+          "name": "decisions_canvas_idx",
+          "columns": [
+            {
+              "expression": "canvas_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feedback": {
+      "name": "feedback",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canvas_id": {
+          "name": "canvas_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_agent": {
+          "name": "target_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_name": {
+          "name": "from_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_user_id": {
+          "name": "from_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "at": {
+          "name": "at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_by": {
+          "name": "claimed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failed_at": {
+          "name": "failed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "feedback_canvas_idx": {
+          "name": "feedback_canvas_idx",
+          "columns": [
+            {
+              "expression": "canvas_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.frames": {
+      "name": "frames",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "canvas_id": {
+          "name": "canvas_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "x": {
+          "name": "x",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "y": {
+          "name": "y",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "width": {
+          "name": "width",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "height": {
+          "name": "height",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "html": {
+          "name": "html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "demo": {
+          "name": "demo",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "frames_canvas_idx": {
+          "name": "frames_canvas_idx",
+          "columns": [
+            {
+              "expression": "canvas_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_connections": {
+      "name": "github_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "canvas_id": {
+          "name": "canvas_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo": {
+          "name": "repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deploy_url": {
+          "name": "deploy_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "github_connections_canvas_idx": {
+          "name": "github_connections_canvas_idx",
+          "columns": [
+            {
+              "expression": "canvas_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.guideline_versions": {
+      "name": "guideline_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "canvas_id": {
+          "name": "canvas_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "markdown": {
+          "name": "markdown",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "saved_at": {
+          "name": "saved_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "saved_by": {
+          "name": "saved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "guideline_versions_doc_idx": {
+          "name": "guideline_versions_doc_idx",
+          "columns": [
+            {
+              "expression": "canvas_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.guidelines": {
+      "name": "guidelines",
+      "schema": "",
+      "columns": {
+        "canvas_id": {
+          "name": "canvas_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "markdown": {
+          "name": "markdown",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "x": {
+          "name": "x",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "y": {
+          "name": "y",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "guidelines_canvas_id_name_pk": {
+          "name": "guidelines_canvas_id_name_pk",
+          "columns": ["canvas_id", "name"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.integrations": {
+      "name": "integrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_name": {
+          "name": "account_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accounts": {
+          "name": "accounts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connected_at": {
+          "name": "connected_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "integrations_user_idx": {
+          "name": "integrations_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.memory_proposals": {
+      "name": "memory_proposals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "canvas_id": {
+          "name": "canvas_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guide_name": {
+          "name": "guide_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guide_title": {
+          "name": "guide_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rule": {
+          "name": "rule",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rationale": {
+          "name": "rationale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "based_on": {
+          "name": "based_on",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "at": {
+          "name": "at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "memory_proposals_canvas_idx": {
+          "name": "memory_proposals_canvas_idx",
+          "columns": [
+            {
+              "expression": "canvas_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.memory_references": {
+      "name": "memory_references",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "canvas_id": {
+          "name": "canvas_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frame_id": {
+          "name": "frame_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "html": {
+          "name": "html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "width": {
+          "name": "width",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "height": {
+          "name": "height",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pinned_by": {
+          "name": "pinned_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pinned_at": {
+          "name": "pinned_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "memory_references_canvas_idx": {
+          "name": "memory_references_canvas_idx",
+          "columns": [
+            {
+              "expression": "canvas_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.model_accounts": {
+      "name": "model_accounts",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan": {
+          "name": "plan",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connected_at": {
+          "name": "connected_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.resident_usage": {
+      "name": "resident_usage",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "used": {
+          "name": "used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sync_edges": {
+      "name": "sync_edges",
+      "schema": "",
+      "columns": {
+        "key_id": {
+          "name": "key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_page": {
+          "name": "from_page",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_page": {
+          "name": "to_page",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_at": {
+          "name": "last_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "sync_edges_key_id_from_page_to_page_pk": {
+          "name": "sync_edges_key_id_from_page_to_page_pk",
+          "columns": ["key_id", "from_page", "to_page"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sync_keys": {
+      "name": "sync_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canvas_id": {
+          "name": "canvas_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "sync_keys_canvas_idx": {
+          "name": "sync_keys_canvas_idx",
+          "columns": [
+            {
+              "expression": "canvas_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sync_keys_secret_idx": {
+          "name": "sync_keys_secret_idx",
+          "columns": [
+            {
+              "expression": "secret",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sync_links": {
+      "name": "sync_links",
+      "schema": "",
+      "columns": {
+        "key_id": {
+          "name": "key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "page": {
+          "name": "page",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_page": {
+          "name": "to_page",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "x": {
+          "name": "x",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "y": {
+          "name": "y",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "width": {
+          "name": "width",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "height": {
+          "name": "height",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "sync_links_page_idx": {
+          "name": "sync_links_page_idx",
+          "columns": [
+            {
+              "expression": "key_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "page",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tasks": {
+      "name": "tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "canvas_id": {
+          "name": "canvas_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto": {
+          "name": "auto",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "queued_by": {
+          "name": "queued_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failed_at": {
+          "name": "failed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pipeline": {
+          "name": "pipeline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stage": {
+          "name": "stage",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attachments": {
+          "name": "attachments",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "queued_by_user_id": {
+          "name": "queued_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "tasks_canvas_idx": {
+          "name": "tasks_canvas_idx",
+          "columns": [
+            {
+              "expression": "canvas_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_access_token": {
+      "name": "oauth_access_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_access_token_access_token_unique": {
+          "name": "oauth_access_token_access_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["access_token"]
+        },
+        "oauth_access_token_refresh_token_unique": {
+          "name": "oauth_access_token_refresh_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["refresh_token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_application": {
+      "name": "oauth_application",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_urls": {
+          "name": "redirect_urls",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_application_client_id_unique": {
+          "name": "oauth_application_client_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["client_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_consent": {
+      "name": "oauth_consent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "consent_given": {
+          "name": "consent_given",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/server/db/migrations/meta/0013_snapshot.json
+++ b/server/db/migrations/meta/0013_snapshot.json
@@ -1,0 +1,2593 @@
+{
+  "id": "f74908b1-e7e7-4fc4-908e-b94af994a109",
+  "prevId": "ec99a43e-4869-4b57-9e4d-364f1815b769",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.activity": {
+      "name": "activity",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "canvas_id": {
+          "name": "canvas_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_kind": {
+          "name": "actor_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_color": {
+          "name": "actor_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frame_id": {
+          "name": "frame_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "at": {
+          "name": "at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "activity_canvas_idx": {
+          "name": "activity_canvas_idx",
+          "columns": [
+            {
+              "expression": "canvas_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.asset_refs": {
+      "name": "asset_refs",
+      "schema": "",
+      "columns": {
+        "asset_id": {
+          "name": "asset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frame_id": {
+          "name": "frame_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "asset_refs_frame_idx": {
+          "name": "asset_refs_frame_idx",
+          "columns": [
+            {
+              "expression": "frame_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "asset_refs_asset_id_frame_id_pk": {
+          "name": "asset_refs_asset_id_frame_id_pk",
+          "columns": ["asset_id", "frame_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.assets": {
+      "name": "assets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "canvas_id": {
+          "name": "canvas_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mime": {
+          "name": "mime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ext": {
+          "name": "ext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "assets_canvas_idx": {
+          "name": "assets_canvas_idx",
+          "columns": [
+            {
+              "expression": "canvas_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.automation_runs": {
+      "name": "automation_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "automation_id": {
+          "name": "automation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canvas_id": {
+          "name": "canvas_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure": {
+          "name": "failure",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "automation_runs_automation_idx": {
+          "name": "automation_runs_automation_idx",
+          "columns": [
+            {
+              "expression": "automation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.automations": {
+      "name": "automations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "schedule": {
+          "name": "schedule",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "steps": {
+          "name": "steps",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "automations_owner_idx": {
+          "name": "automations_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "automations_next_run_idx": {
+          "name": "automations_next_run_idx",
+          "columns": [
+            {
+              "expression": "next_run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.backgrounds": {
+      "name": "backgrounds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tone": {
+          "name": "tone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "style": {
+          "name": "style",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avg_color": {
+          "name": "avg_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "palette": {
+          "name": "palette",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slots": {
+          "name": "slots",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text_zone": {
+          "name": "text_zone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.canvas_members": {
+      "name": "canvas_members",
+      "schema": "",
+      "columns": {
+        "canvas_id": {
+          "name": "canvas_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "added_by": {
+          "name": "added_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "canvas_members_canvas_id_user_id_pk": {
+          "name": "canvas_members_canvas_id_user_id_pk",
+          "columns": ["canvas_id", "user_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.canvases": {
+      "name": "canvases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_access": {
+          "name": "link_access",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "copy_count": {
+          "name": "copy_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.comments": {
+      "name": "comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "canvas_id": {
+          "name": "canvas_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frame_id": {
+          "name": "frame_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "selector": {
+          "name": "selector",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snippet": {
+          "name": "snippet",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_name": {
+          "name": "from_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_user_id": {
+          "name": "from_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "at": {
+          "name": "at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "for_agent": {
+          "name": "for_agent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "target_agent": {
+          "name": "target_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_by": {
+          "name": "claimed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failed_at": {
+          "name": "failed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "comments_canvas_idx": {
+          "name": "comments_canvas_idx",
+          "columns": [
+            {
+              "expression": "canvas_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.decisions": {
+      "name": "decisions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "canvas_id": {
+          "name": "canvas_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frame_id": {
+          "name": "frame_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_name": {
+          "name": "from_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "at": {
+          "name": "at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "distilled_at": {
+          "name": "distilled_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "decisions_canvas_idx": {
+          "name": "decisions_canvas_idx",
+          "columns": [
+            {
+              "expression": "canvas_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feedback": {
+      "name": "feedback",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canvas_id": {
+          "name": "canvas_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_agent": {
+          "name": "target_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_name": {
+          "name": "from_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_user_id": {
+          "name": "from_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "at": {
+          "name": "at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_by": {
+          "name": "claimed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failed_at": {
+          "name": "failed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "feedback_canvas_idx": {
+          "name": "feedback_canvas_idx",
+          "columns": [
+            {
+              "expression": "canvas_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.frames": {
+      "name": "frames",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "canvas_id": {
+          "name": "canvas_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "x": {
+          "name": "x",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "y": {
+          "name": "y",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "width": {
+          "name": "width",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "height": {
+          "name": "height",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "html": {
+          "name": "html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "demo": {
+          "name": "demo",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "frames_canvas_idx": {
+          "name": "frames_canvas_idx",
+          "columns": [
+            {
+              "expression": "canvas_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_connections": {
+      "name": "github_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "canvas_id": {
+          "name": "canvas_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo": {
+          "name": "repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deploy_url": {
+          "name": "deploy_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "github_connections_canvas_idx": {
+          "name": "github_connections_canvas_idx",
+          "columns": [
+            {
+              "expression": "canvas_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.guideline_versions": {
+      "name": "guideline_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "canvas_id": {
+          "name": "canvas_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "markdown": {
+          "name": "markdown",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "saved_at": {
+          "name": "saved_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "saved_by": {
+          "name": "saved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "guideline_versions_doc_idx": {
+          "name": "guideline_versions_doc_idx",
+          "columns": [
+            {
+              "expression": "canvas_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.guidelines": {
+      "name": "guidelines",
+      "schema": "",
+      "columns": {
+        "canvas_id": {
+          "name": "canvas_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "markdown": {
+          "name": "markdown",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "x": {
+          "name": "x",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "y": {
+          "name": "y",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "guidelines_canvas_id_name_pk": {
+          "name": "guidelines_canvas_id_name_pk",
+          "columns": ["canvas_id", "name"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.integrations": {
+      "name": "integrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_name": {
+          "name": "account_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accounts": {
+          "name": "accounts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connected_at": {
+          "name": "connected_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "integrations_user_provider_idx": {
+          "name": "integrations_user_provider_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.memory_proposals": {
+      "name": "memory_proposals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "canvas_id": {
+          "name": "canvas_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guide_name": {
+          "name": "guide_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guide_title": {
+          "name": "guide_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rule": {
+          "name": "rule",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rationale": {
+          "name": "rationale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "based_on": {
+          "name": "based_on",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "at": {
+          "name": "at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "memory_proposals_canvas_idx": {
+          "name": "memory_proposals_canvas_idx",
+          "columns": [
+            {
+              "expression": "canvas_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.memory_references": {
+      "name": "memory_references",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "canvas_id": {
+          "name": "canvas_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frame_id": {
+          "name": "frame_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "html": {
+          "name": "html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "width": {
+          "name": "width",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "height": {
+          "name": "height",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pinned_by": {
+          "name": "pinned_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pinned_at": {
+          "name": "pinned_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "memory_references_canvas_idx": {
+          "name": "memory_references_canvas_idx",
+          "columns": [
+            {
+              "expression": "canvas_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.model_accounts": {
+      "name": "model_accounts",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan": {
+          "name": "plan",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connected_at": {
+          "name": "connected_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.resident_usage": {
+      "name": "resident_usage",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "used": {
+          "name": "used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sync_edges": {
+      "name": "sync_edges",
+      "schema": "",
+      "columns": {
+        "key_id": {
+          "name": "key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_page": {
+          "name": "from_page",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_page": {
+          "name": "to_page",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_at": {
+          "name": "last_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "sync_edges_key_id_from_page_to_page_pk": {
+          "name": "sync_edges_key_id_from_page_to_page_pk",
+          "columns": ["key_id", "from_page", "to_page"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sync_keys": {
+      "name": "sync_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canvas_id": {
+          "name": "canvas_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "sync_keys_canvas_idx": {
+          "name": "sync_keys_canvas_idx",
+          "columns": [
+            {
+              "expression": "canvas_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sync_keys_secret_idx": {
+          "name": "sync_keys_secret_idx",
+          "columns": [
+            {
+              "expression": "secret",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sync_links": {
+      "name": "sync_links",
+      "schema": "",
+      "columns": {
+        "key_id": {
+          "name": "key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "page": {
+          "name": "page",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_page": {
+          "name": "to_page",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "x": {
+          "name": "x",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "y": {
+          "name": "y",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "width": {
+          "name": "width",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "height": {
+          "name": "height",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "sync_links_page_idx": {
+          "name": "sync_links_page_idx",
+          "columns": [
+            {
+              "expression": "key_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "page",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tasks": {
+      "name": "tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "canvas_id": {
+          "name": "canvas_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto": {
+          "name": "auto",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "queued_by": {
+          "name": "queued_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failed_at": {
+          "name": "failed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pipeline": {
+          "name": "pipeline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stage": {
+          "name": "stage",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attachments": {
+          "name": "attachments",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "queued_by_user_id": {
+          "name": "queued_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "tasks_canvas_idx": {
+          "name": "tasks_canvas_idx",
+          "columns": [
+            {
+              "expression": "canvas_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_access_token": {
+      "name": "oauth_access_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_access_token_access_token_unique": {
+          "name": "oauth_access_token_access_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["access_token"]
+        },
+        "oauth_access_token_refresh_token_unique": {
+          "name": "oauth_access_token_refresh_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["refresh_token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_application": {
+      "name": "oauth_application",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_urls": {
+          "name": "redirect_urls",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_application_client_id_unique": {
+          "name": "oauth_application_client_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["client_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_consent": {
+      "name": "oauth_consent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "consent_given": {
+          "name": "consent_given",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/server/db/migrations/meta/_journal.json
+++ b/server/db/migrations/meta/_journal.json
@@ -85,6 +85,20 @@
       "when": 1788994279174,
       "tag": "0011_backgrounds",
       "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "7",
+      "when": 1789160600561,
+      "tag": "0012_automations",
+      "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "7",
+      "when": 1789165950163,
+      "tag": "0013_integrations_unique",
+      "breakpoints": true
     }
   ]
 }

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -1,4 +1,16 @@
-import { pgTable, text, doublePrecision, bigint, boolean, integer, index, primaryKey, jsonb } from 'drizzle-orm/pg-core'
+import {
+  pgTable,
+  text,
+  doublePrecision,
+  bigint,
+  boolean,
+  integer,
+  index,
+  uniqueIndex,
+  primaryKey,
+  jsonb,
+} from 'drizzle-orm/pg-core'
+import type { Schedule, Step } from '../../shared/automations.ts'
 
 /**
  * One Postgres-dialect schema for every environment: PGlite (embedded, file
@@ -411,3 +423,68 @@ export const backgrounds = pgTable('backgrounds', {
   enabled: boolean('enabled').notNull().default(true),
   createdAt: bigint('created_at', { mode: 'number' }).notNull(),
 })
+
+/** A user's connection to an outside service (Meta today). One row per
+ *  user and provider; the token never leaves the server — API responses
+ *  carry the account list and display fields only. Revocation = row
+ *  deletion. Automations reference the provider, not the row, so a
+ *  reconnect picks the same automations back up. */
+export const integrations = pgTable(
+  'integrations',
+  {
+    id: text('id').primaryKey(),
+    userId: text('user_id').notNull(),
+    /** 'meta' */
+    provider: text('provider').notNull(),
+    accessToken: text('access_token').notNull(),
+    /** epoch ms the token expires; null = the provider said it doesn't */
+    expiresAt: bigint('expires_at', { mode: 'number' }),
+    /** the provider-side identity the token belongs to — display only */
+    accountName: text('account_name'),
+    /** what the connection unlocks: Meta ad accounts the user may pull from */
+    accounts: jsonb('accounts').$type<{ id: string; name: string }[]>().notNull(),
+    connectedAt: bigint('connected_at', { mode: 'number' }).notNull(),
+    updatedAt: bigint('updated_at', { mode: 'number' }).notNull(),
+  },
+  (t) => [uniqueIndex('integrations_user_provider_idx').on(t.userId, t.provider)],
+)
+
+/** A scheduled workflow: `schedule` says when, `steps` say what (see
+ *  shared/automations.ts). Owned by a user; every step names a canvas the
+ *  owner must be able to reach. Cold path — read by the scheduler tick and
+ *  the Automations pages, no in-memory mirror. */
+export const automations = pgTable(
+  'automations',
+  {
+    id: text('id').primaryKey(),
+    ownerId: text('owner_id').notNull(),
+    name: text('name').notNull(),
+    enabled: boolean('enabled').notNull().default(true),
+    schedule: jsonb('schedule').$type<Schedule>().notNull(),
+    steps: jsonb('steps').$type<Step[]>().notNull(),
+    /** when the scheduler fires it next; null while disabled or incomplete */
+    nextRunAt: bigint('next_run_at', { mode: 'number' }),
+    createdAt: bigint('created_at', { mode: 'number' }).notNull(),
+    updatedAt: bigint('updated_at', { mode: 'number' }).notNull(),
+  },
+  (t) => [index('automations_owner_idx').on(t.ownerId), index('automations_next_run_idx').on(t.nextRunAt)],
+)
+
+/** One execution of an automation, kept as a slim log line. */
+export const automationRuns = pgTable(
+  'automation_runs',
+  {
+    id: text('id').primaryKey(),
+    automationId: text('automation_id').notNull(),
+    startedAt: bigint('started_at', { mode: 'number' }).notNull(),
+    endedAt: bigint('ended_at', { mode: 'number' }),
+    /** 'running' | 'ok' | 'failed' */
+    status: text('status').notNull(),
+    summary: text('summary'),
+    error: text('error'),
+    canvasId: text('canvas_id'),
+    /** 'reconnect' when the fix is re-authorising an integration */
+    failure: text('failure'),
+  },
+  (t) => [index('automation_runs_automation_idx').on(t.automationId)],
+)

--- a/server/index.ts
+++ b/server/index.ts
@@ -14,6 +14,8 @@ import { canAccessCanvas, hasDurableCanvasAccess, isAdmin } from './access.ts'
 import { auth, initAuth, syncAdmins, getUserName, PUBLIC_ORIGIN, loginProvidersConfig } from './auth.ts'
 import { adminRouter } from './admin.ts'
 import { communityRouter, parseListing, publishableFrames } from './community.ts'
+import { automationsRouter, startScheduler } from './automations.ts'
+import { integrationsRouter } from './integrations.ts'
 import * as demo from './demo.ts'
 import { db, initDb } from './db/index.ts'
 import * as authSchema from './db/auth-schema.ts'
@@ -589,6 +591,8 @@ function requireFrame(req: express.Request, res: express.Response, frameId: stri
 
 app.use('/api/admin', adminRouter)
 app.use('/api/community', communityRouter)
+app.use('/api/automations', automationsRouter)
+app.use('/api/integrations', integrationsRouter)
 
 /* free-tier meter for the resident team: {used, limit, connected, byoModel} */
 app.get('/api/agent-allowance', (req, res) => {
@@ -1665,4 +1669,6 @@ server.listen(PORT, () => {
       ? '⟡ image generation  on — each user’s connected ChatGPT/OpenAI account, else this server’s OPENAI_API_KEY'
       : '⟡ image generation  on for users with a connected ChatGPT/OpenAI account only (set OPENAI_API_KEY to cover everyone else)',
   )
+  /* automations fire from here: one tick a minute over the due rows */
+  startScheduler()
 })

--- a/server/integrations.ts
+++ b/server/integrations.ts
@@ -1,0 +1,50 @@
+import express from 'express'
+import * as meta from './meta.ts'
+
+/**
+ * The Integrations page's surface, mounted at /api/integrations (behind the
+ * session gate). Connections are per user — an integration is a thing you
+ * hold, and automations you own draw on it. Meta is the only provider today;
+ * the shape leaves room for more without a second routing scheme.
+ */
+export const integrationsRouter = express.Router()
+
+export interface IntegrationsStatus {
+  meta: meta.MetaConnectionInfo & { enabled: boolean }
+}
+
+integrationsRouter.get('/', async (req, res) => {
+  const row = await meta.getConnection(req.user!.id)
+  const status: IntegrationsStatus = { meta: { enabled: meta.metaEnabled(), ...meta.connectionInfo(row) } }
+  res.json(status)
+})
+
+integrationsRouter.post('/meta/start', (req, res) => {
+  if (!meta.metaEnabled()) return res.status(400).json({ error: 'the Meta app is not configured on this server' })
+  res.json({ url: meta.authorizeUrl(meta.signState(req.user!.id)) })
+})
+
+/* Meta's redirect back. The state proves the round-trip began here for THIS
+   signed-in user — a code pasted from someone else's browser binds nothing.
+   Outcomes land on the Integrations page with a visible reason. */
+integrationsRouter.get('/meta/callback', async (req, res) => {
+  const fail = (reason: string) => res.redirect(`/integrations?metaError=${encodeURIComponent(reason)}`)
+  const state = meta.verifyState(String(req.query.state ?? ''))
+  if (!state || state.userId !== req.user!.id) return fail('the Meta handoff expired — try connecting again')
+  const code = String(req.query.code ?? '')
+  if (!code) {
+    const why = String(req.query.error_description ?? req.query.error ?? 'Meta sent no code back')
+    return fail(why)
+  }
+  try {
+    await meta.connect(req.user!.id, code)
+  } catch (err) {
+    return fail(err instanceof Error ? err.message : 'Meta rejected the connection')
+  }
+  res.redirect('/integrations?meta=connected')
+})
+
+integrationsRouter.delete('/meta', async (req, res) => {
+  await meta.disconnect(req.user!.id)
+  res.json({ meta: { enabled: meta.metaEnabled(), connected: false } })
+})

--- a/server/meta.ts
+++ b/server/meta.ts
@@ -1,0 +1,556 @@
+import { createHmac, timingSafeEqual } from 'node:crypto'
+import { and, eq } from 'drizzle-orm'
+import { nanoid } from 'nanoid'
+import { db } from './db/index.ts'
+import { integrations } from './db/schema.ts'
+import { createAsset, fetchRemote } from './assets.ts'
+import { store } from './store.ts'
+import * as actions from './actions.ts'
+import type { Actor, Frame } from '../shared/types.ts'
+import type { PullFilter } from '../shared/automations.ts'
+
+/**
+ * The Meta integration: a user-level OAuth connection to Meta (scope
+ * ads_read) and what it unlocks — pulling ad creatives onto a canvas.
+ *
+ * The token is a long-lived user token (~60 days). It is stored on the
+ * integrations row and never leaves the server; API responses carry the ad
+ * account list and display fields only. When Meta rejects the token the
+ * pull fails with `reconnect`, which the Runs list turns into a button.
+ */
+
+const GRAPH = 'https://graph.facebook.com/v21.0'
+const DIALOG = 'https://www.facebook.com/v21.0/dialog/oauth'
+const SCOPES = 'ads_read'
+const STATE_TTL_MS = 15 * 60_000
+/** ads fetched per pull, across pages — a canvas is not an archive */
+const MAX_ADS = 200
+const PAGE_SIZE = 50
+
+/* same env read as server/auth.ts — not imported, so this module stays
+   loadable in unit tests without the auth stack */
+const PUBLIC_ORIGIN = process.env.BETTER_AUTH_URL || 'http://localhost:4300'
+
+export function metaEnabled(): boolean {
+  return !!(process.env.META_APP_ID && process.env.META_APP_SECRET)
+}
+
+export function redirectUri(): string {
+  return `${PUBLIC_ORIGIN}/api/integrations/meta/callback`
+}
+
+/* ------------------------------------------------------------------ */
+/* Signed OAuth state                                                  */
+
+function secret(): string {
+  return process.env.BETTER_AUTH_SECRET || 'doop-dev-secret-not-for-production'
+}
+
+function sign(payload: string): string {
+  return createHmac('sha256', secret()).update(payload).digest('base64url')
+}
+
+/** Goes out with the authorize link; proves the round-trip began here, for
+ *  this user. Dots would collide with the separator — user ids never carry
+ *  them, but refuse rather than assume. */
+export function signState(userId: string, now = Date.now()): string {
+  if (/[.]/.test(userId)) throw new Error('invalid id')
+  const payload = ['meta-state', userId, String(now + STATE_TTL_MS)].join('.')
+  return `${payload}.${sign(payload)}`
+}
+
+export function verifyState(state: string): { userId: string } | undefined {
+  const parts = state.split('.')
+  if (parts.length !== 4 || parts[0] !== 'meta-state') return undefined
+  const mac = parts.pop()!
+  const payload = parts.join('.')
+  const a = Buffer.from(mac)
+  const b = Buffer.from(sign(payload))
+  if (a.length !== b.length || !timingSafeEqual(a, b)) return undefined
+  if (Number(parts[2]) < Date.now()) return undefined
+  return { userId: parts[1]! }
+}
+
+export function authorizeUrl(state: string): string {
+  const params = new URLSearchParams({
+    client_id: process.env.META_APP_ID ?? '',
+    redirect_uri: redirectUri(),
+    state,
+    scope: SCOPES,
+    response_type: 'code',
+  })
+  return `${DIALOG}?${params}`
+}
+
+/* ------------------------------------------------------------------ */
+/* Graph API                                                           */
+
+export class MetaAuthError extends Error {}
+
+interface GraphError {
+  error?: { message?: string; code?: number; type?: string }
+}
+
+async function graph<T>(path: string, params: Record<string, string>, token?: string): Promise<T> {
+  const url = new URL(`${GRAPH}${path}`)
+  for (const [k, v] of Object.entries(params)) url.searchParams.set(k, v)
+  if (token) url.searchParams.set('access_token', token)
+  const res = await fetch(url, { signal: AbortSignal.timeout(20_000) })
+  const body = (await res.json().catch(() => ({}))) as T & GraphError
+  if (!res.ok || body.error) {
+    const code = body.error?.code
+    const message = body.error?.message ?? `Meta responded ${res.status}`
+    /* 190 = invalid/expired token, 102 = session; 10/200-299 = permission */
+    if (res.status === 401 || code === 190 || code === 102 || body.error?.type === 'OAuthException')
+      throw new MetaAuthError(message)
+    throw new Error(message)
+  }
+  return body
+}
+
+/** Code → short-lived token → long-lived token. */
+export async function exchangeCode(code: string): Promise<{ token: string; expiresAt: number | null }> {
+  const appId = process.env.META_APP_ID ?? ''
+  const appSecret = process.env.META_APP_SECRET ?? ''
+  const short = await graph<{ access_token: string }>('/oauth/access_token', {
+    client_id: appId,
+    client_secret: appSecret,
+    redirect_uri: redirectUri(),
+    code,
+  })
+  const long = await graph<{ access_token: string; expires_in?: number }>('/oauth/access_token', {
+    grant_type: 'fb_exchange_token',
+    client_id: appId,
+    client_secret: appSecret,
+    fb_exchange_token: short.access_token,
+  })
+  return {
+    token: long.access_token,
+    expiresAt: long.expires_in ? Date.now() + long.expires_in * 1000 : null,
+  }
+}
+
+export interface AdAccount {
+  id: string
+  name: string
+}
+
+export async function fetchIdentity(token: string): Promise<{ name: string; accounts: AdAccount[] }> {
+  const me = await graph<{ name?: string }>('/me', { fields: 'name' }, token)
+  const accounts: AdAccount[] = []
+  let after: string | undefined
+  for (let page = 0; page < 5; page++) {
+    const res = await graph<{
+      data: { id: string; name?: string; account_id: string }[]
+      paging?: { cursors?: { after?: string }; next?: string }
+    }>('/me/adaccounts', { fields: 'name,account_id', limit: '100', ...(after ? { after } : {}) }, token)
+    for (const a of res.data) accounts.push({ id: a.id, name: a.name || `Account ${a.account_id}` })
+    after = res.paging?.next ? res.paging.cursors?.after : undefined
+    if (!after) break
+  }
+  return { name: me.name ?? 'Meta account', accounts }
+}
+
+/* ------------------------------------------------------------------ */
+/* Connection rows                                                     */
+
+export type MetaConnection = typeof integrations.$inferSelect
+
+export interface MetaConnectionInfo {
+  connected: boolean
+  accountName?: string
+  accounts?: AdAccount[]
+  connectedAt?: number
+  expiresAt?: number | null
+}
+
+export function connectionInfo(row: MetaConnection | undefined): MetaConnectionInfo {
+  if (!row) return { connected: false }
+  return {
+    connected: true,
+    accountName: row.accountName ?? undefined,
+    accounts: row.accounts,
+    connectedAt: row.connectedAt,
+    expiresAt: row.expiresAt,
+  }
+}
+
+export async function getConnection(userId: string): Promise<MetaConnection | undefined> {
+  const [row] = await db
+    .select()
+    .from(integrations)
+    .where(and(eq(integrations.userId, userId), eq(integrations.provider, 'meta')))
+  return row ?? undefined
+}
+
+/** Finish the OAuth round-trip: swap the code, learn who this is and which
+ *  ad accounts they can read, and (re)place the one Meta row for the user. */
+export async function connect(userId: string, code: string): Promise<MetaConnection> {
+  const { token, expiresAt } = await exchangeCode(code)
+  const identity = await fetchIdentity(token)
+  const now = Date.now()
+  const fresh = {
+    accessToken: token,
+    expiresAt,
+    accountName: identity.name,
+    accounts: identity.accounts,
+    updatedAt: now,
+  }
+  /* one row per user and provider, enforced by the unique index: two
+     callbacks racing each other both land on the same row, last token wins */
+  const [row] = await db
+    .insert(integrations)
+    .values({ id: nanoid(8), userId, provider: 'meta', connectedAt: now, ...fresh })
+    .onConflictDoUpdate({ target: [integrations.userId, integrations.provider], set: fresh })
+    .returning()
+  return row!
+}
+
+export async function disconnect(userId: string): Promise<boolean> {
+  const gone = await db
+    .delete(integrations)
+    .where(and(eq(integrations.userId, userId), eq(integrations.provider, 'meta')))
+    .returning({ id: integrations.id })
+  return gone.length > 0
+}
+
+/* ------------------------------------------------------------------ */
+/* Pulling creatives                                                   */
+
+export interface AdCreative {
+  adId: string
+  name: string
+  headline: string
+  body: string
+  cta: string
+  /** the best image URL known so far — a thumbnail until resolveImages runs */
+  imageUrl: string | null
+  /** the ad image's hash, when the creative has one — the key to the full-size file */
+  imageHash: string | null
+  /** creative id, for the sized-thumbnail fallback */
+  creativeId: string | null
+  /** natural size of the image, once known — the frame follows its aspect */
+  width: number | null
+  height: number | null
+  status: string
+}
+
+interface GraphAd {
+  id: string
+  name?: string
+  effective_status?: string
+  creative?: {
+    id?: string
+    title?: string
+    body?: string
+    image_url?: string
+    image_hash?: string
+    thumbnail_url?: string
+    call_to_action_type?: string
+    object_story_spec?: {
+      link_data?: {
+        message?: string
+        name?: string
+        picture?: string
+        image_hash?: string
+        call_to_action?: { type?: string }
+        /** carousel cards */
+        child_attachments?: { name?: string; description?: string; picture?: string; image_hash?: string }[]
+      }
+      video_data?: {
+        message?: string
+        title?: string
+        image_url?: string
+        image_hash?: string
+        call_to_action?: { type?: string }
+      }
+    }
+    asset_feed_spec?: {
+      titles?: { text?: string }[]
+      bodies?: { text?: string }[]
+      images?: { hash?: string }[]
+      call_to_action_types?: string[]
+    }
+  }
+}
+
+function titleCase(cta: string | undefined): string {
+  if (!cta) return ''
+  return cta
+    .toLowerCase()
+    .split('_')
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(' ')
+}
+
+/** Flatten Meta's several creative shapes into cards. Most ads are one
+ *  card; a dynamic-creative ad (asset feed) yields one card per image and a
+ *  carousel one card per child — each keyed by ad id plus image, so a later
+ *  pull still recognises them. */
+export function toCreatives(ad: GraphAd): AdCreative[] {
+  const c = ad.creative ?? {}
+  const link = c.object_story_spec?.link_data
+  const video = c.object_story_spec?.video_data
+  const feed = c.asset_feed_spec
+  const name = ad.name || `Ad ${ad.id}`
+  const base: AdCreative = {
+    adId: ad.id,
+    name,
+    headline: c.title || link?.name || video?.title || feed?.titles?.[0]?.text || '',
+    body: c.body || link?.message || video?.message || feed?.bodies?.[0]?.text || '',
+    cta: titleCase(
+      c.call_to_action_type ||
+        link?.call_to_action?.type ||
+        video?.call_to_action?.type ||
+        feed?.call_to_action_types?.[0],
+    ),
+    imageUrl: c.image_url || link?.picture || video?.image_url || c.thumbnail_url || null,
+    imageHash: c.image_hash || link?.image_hash || video?.image_hash || feed?.images?.[0]?.hash || null,
+    creativeId: c.id ?? null,
+    width: null,
+    height: null,
+    status: ad.effective_status ?? '',
+  }
+  const feedImages = (feed?.images ?? []).filter((i): i is { hash: string } => !!i.hash)
+  if (feedImages.length > 1) {
+    return feedImages.map((img, i) => ({
+      ...base,
+      adId: `${ad.id}:${img.hash}`,
+      name: `${name} · ${i + 1}`,
+      imageUrl: null,
+      imageHash: img.hash,
+      /* every card has its own image, so no sized-thumbnail fallback */
+      creativeId: null,
+    }))
+  }
+  const cards = link?.child_attachments ?? []
+  if (cards.length > 1) {
+    return cards.map((card, i) => ({
+      ...base,
+      adId: `${ad.id}:${card.image_hash ?? i}`,
+      name: `${name} · ${i + 1}`,
+      headline: card.name || base.headline,
+      body: card.description || base.body,
+      imageUrl: card.picture || null,
+      imageHash: card.image_hash || null,
+      creativeId: null,
+    }))
+  }
+  return [base]
+}
+
+/** The single-card view of an ad — the first card for multi-image ads. */
+export function toCreative(ad: GraphAd): AdCreative {
+  return toCreatives(ad)[0]!
+}
+
+/** Trade thumbnails for the real files. `thumbnail_url` and `picture` are
+ *  64px previews; the full-size image lives behind the creative's image
+ *  hash on the account's ad-image library. Creatives without a hash (video
+ *  covers, some dynamic formats) get a re-sized thumbnail instead. */
+export async function resolveImages(token: string, accountId: string, ads: AdCreative[]): Promise<void> {
+  const hashes = [...new Set(ads.map((a) => a.imageHash).filter((h): h is string => !!h))]
+  const byHash = new Map<string, { url: string; width: number | null; height: number | null }>()
+  for (let i = 0; i < hashes.length; i += 50) {
+    const chunk = hashes.slice(i, i + 50)
+    try {
+      const res = await graph<{
+        data: { hash: string; url?: string; permalink_url?: string; width?: number; height?: number }[]
+      }>(
+        `/${accountId}/adimages`,
+        { hashes: JSON.stringify(chunk), fields: 'hash,url,permalink_url,width,height' },
+        token,
+      )
+      for (const img of res.data) {
+        const url = img.url || img.permalink_url
+        if (url) byHash.set(img.hash, { url, width: img.width ?? null, height: img.height ?? null })
+      }
+    } catch (err) {
+      if (err instanceof MetaAuthError) throw err
+      /* keep the thumbnails for this chunk rather than fail the pull */
+    }
+  }
+  for (const ad of ads) {
+    const full = ad.imageHash ? byHash.get(ad.imageHash) : undefined
+    if (full) {
+      ad.imageUrl = full.url
+      ad.width = full.width
+      ad.height = full.height
+      continue
+    }
+    if (!ad.creativeId) continue
+    try {
+      const sized = await graph<{ thumbnail_url?: string }>(
+        `/${ad.creativeId}`,
+        { fields: 'thumbnail_url', thumbnail_width: '1080', thumbnail_height: '1080' },
+        token,
+      )
+      if (sized.thumbnail_url) ad.imageUrl = sized.thumbnail_url
+    } catch (err) {
+      if (err instanceof MetaAuthError) throw err
+    }
+  }
+}
+
+export async function fetchAds(token: string, accountId: string, filter: PullFilter): Promise<AdCreative[]> {
+  const out: AdCreative[] = []
+  let after: string | undefined
+  while (out.length < MAX_ADS) {
+    const res = await graph<{ data: GraphAd[]; paging?: { cursors?: { after?: string }; next?: string } }>(
+      `/${accountId}/ads`,
+      {
+        fields:
+          'id,name,effective_status,creative{id,title,body,image_url,image_hash,thumbnail_url,call_to_action_type,object_story_spec,asset_feed_spec}',
+        limit: String(PAGE_SIZE),
+        ...(filter === 'active' ? { effective_status: '["ACTIVE"]' } : {}),
+        ...(after ? { after } : {}),
+      },
+      token,
+    )
+    for (const ad of res.data) out.push(...toCreatives(ad))
+    after = res.paging?.next ? res.paging.cursors?.after : undefined
+    if (!after) break
+  }
+  const ads = out.slice(0, MAX_ADS)
+  await resolveImages(token, accountId, ads)
+  return ads
+}
+
+/* ------------------------------------------------------------------ */
+/* Frames                                                              */
+
+const MARKER = 'doop-meta-ad'
+const FRAME_W = 480
+/** the copy block under the image; the image adds its own height */
+const COPY_H = 190
+const GAP = 40
+const COLUMNS = 4
+
+/** The image's height at frame width. Unknown dimensions read as square,
+ *  which is Meta's most common feed format. */
+export function imageHeight(ad: Pick<AdCreative, 'width' | 'height'>): number {
+  if (!ad.width || !ad.height) return FRAME_W
+  return Math.round((FRAME_W * ad.height) / ad.width)
+}
+
+export function frameHeight(ad: Pick<AdCreative, 'width' | 'height'>): number {
+  return imageHeight(ad) + COPY_H
+}
+
+function escapeHtml(text: string): string {
+  return text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;')
+}
+
+/** The ad id a pulled frame carries, if it is one. */
+export function metaFrameMarker(html: string): string | undefined {
+  const m = html.match(new RegExp(`<meta name="${MARKER}" content="([^"]+)"`))
+  return m?.[1]
+}
+
+/** A plain, faithful card: the creative's image with its headline, body and
+ *  CTA underneath — a reference for agents to iterate on, not a redesign. */
+export function creativeHtml(ad: AdCreative, imageSrc: string | null): string {
+  const artH = imageHeight(ad)
+  const image = imageSrc
+    ? `<img class="art" src="${escapeHtml(imageSrc)}" alt="">`
+    : `<div class="art blank">No image on this creative</div>`
+  return `<!doctype html>
+<html><head><meta charset="utf-8">
+<meta name="${MARKER}" content="${escapeHtml(ad.adId)}">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<style>
+  html,body{margin:0;background:#fff;font-family:Inter,-apple-system,Segoe UI,Helvetica,Arial,sans-serif;color:#111}
+  .card{width:${FRAME_W}px;min-height:${frameHeight(ad)}px;display:flex;flex-direction:column}
+  .art{display:block;width:${FRAME_W}px;height:${artH}px;object-fit:contain;background:#f1f1f1}
+  .blank{display:grid;place-items:center;color:#999;font-size:13px}
+  .copy{padding:18px 20px 22px;display:flex;flex-direction:column;gap:8px;flex:1}
+  .name{font-size:11px;letter-spacing:.08em;text-transform:uppercase;color:#8a8a8a}
+  h1{margin:0;font-size:20px;line-height:1.25;font-weight:700}
+  p{margin:0;font-size:14px;line-height:1.5;color:#444;white-space:pre-line}
+  .cta{margin-top:auto;align-self:flex-start;background:#111;color:#fff;font-size:13px;font-weight:600;padding:9px 16px;border-radius:8px}
+</style></head>
+<body><div class="card">
+  ${image}
+  <div class="copy">
+    <div class="name">${escapeHtml(ad.name)}</div>
+    ${ad.headline ? `<h1>${escapeHtml(ad.headline)}</h1>` : ''}
+    ${ad.body ? `<p>${escapeHtml(ad.body)}</p>` : ''}
+    ${ad.cta ? `<span class="cta">${escapeHtml(ad.cta)}</span>` : ''}
+  </div>
+</div></body></html>`
+}
+
+/** Meta's image URLs are signed and expire — copy the bytes into Doop's own
+ *  asset store so the frame keeps rendering. A failed copy still lands the
+ *  frame, with the remote URL as a best effort. */
+async function keepImage(url: string | null, canvasId: string, ownerId: string): Promise<string | null> {
+  if (!url) return null
+  try {
+    /* the asset layer's guarded fetch: SSRF-checked hops, 5 MB cap while streaming */
+    const buf = await fetchRemote(url)
+    const asset = await createAsset(buf, { canvasId, ownerId, uploadedBy: 'Automation' })
+    return `/a/${asset.id}.${asset.ext}`
+  } catch {
+    return url
+  }
+}
+
+export interface PullResult {
+  created: Frame[]
+  /** ads already on the canvas from an earlier pull */
+  skipped: number
+  total: number
+}
+
+/** Land the account's creatives on the canvas as frames, one row grid below
+ *  whatever is already there. Ads already present (by marker) are skipped,
+ *  so a weekly pull only adds what's new. */
+export async function pullCreatives(input: {
+  connection: MetaConnection
+  accountId: string
+  filter: PullFilter
+  canvasId: string
+  ownerId: string
+  actor: Actor
+}): Promise<PullResult> {
+  const canvas = store.getCanvas(input.canvasId)
+  if (!canvas) throw new Error('canvas not found')
+  if (!input.connection.accounts.some((a) => a.id === input.accountId))
+    throw new Error('that ad account is not part of the Meta connection')
+  const ads = await fetchAds(input.connection.accessToken, input.accountId, input.filter)
+  const present = new Set<string>()
+  for (const f of canvas.frames) {
+    const id = metaFrameMarker(f.html)
+    if (id) present.add(id)
+  }
+  const fresh = ads.filter((ad) => !present.has(ad.adId))
+  const bottom = canvas.frames.reduce((my, f) => Math.max(my, f.y + f.height), 0)
+  const startY = canvas.frames.length ? bottom + 80 : 120
+  const created: Frame[] = []
+  let y = startY
+  let rowHeight = 0
+  for (const [i, ad] of fresh.entries()) {
+    const column = i % COLUMNS
+    if (column === 0 && i > 0) {
+      y += rowHeight + GAP
+      rowHeight = 0
+    }
+    const src = await keepImage(ad.imageUrl, input.canvasId, input.ownerId)
+    const height = frameHeight(ad)
+    rowHeight = Math.max(rowHeight, height)
+    const frame = actions.createFrame(
+      input.canvasId,
+      {
+        name: ad.name.slice(0, 80),
+        x: 120 + column * (FRAME_W + GAP),
+        y,
+        width: FRAME_W,
+        height,
+        html: creativeHtml(ad, src),
+      },
+      input.actor,
+    )
+    if (frame) created.push(frame)
+  }
+  return { created, skipped: ads.length - fresh.length, total: ads.length }
+}

--- a/shared/automations.ts
+++ b/shared/automations.ts
@@ -1,0 +1,398 @@
+import { normalizePipeline } from './agents.ts'
+
+/**
+ * Automations: a schedule plus an ordered list of steps that run on it.
+ *
+ * Two step types only. A *pull* step asks an integration for designs and
+ * lands them on a canvas as frames (Meta ad creatives today). An *agent*
+ * step queues a board card for the resident team on a canvas — the same card
+ * a person would write on the Board. Every step names its own canvas: an
+ * agent only ever works on a canvas, so there is no separate canvas node.
+ * Context between steps is implicit — the canvas, and whatever earlier steps
+ * put on it.
+ */
+
+export type ScheduleKind = 'daily' | 'weekdays' | 'weekly'
+
+export interface Schedule {
+  kind: ScheduleKind
+  /** weekly only: 0 = Sunday … 6 = Saturday */
+  weekday: number
+  /** wall-clock time in `tz` */
+  hour: number
+  minute: number
+  /** IANA zone the wall-clock time is read in, e.g. Europe/Berlin */
+  tz: string
+}
+
+export type PullFilter = 'active' | 'all'
+
+export interface PullStep {
+  id: string
+  type: 'pull'
+  provider: 'meta'
+  /** Meta ad account id, e.g. act_1234 — empty until the user picks one */
+  accountId: string
+  filter: PullFilter
+  canvasId: string
+}
+
+export interface AgentStep {
+  id: string
+  type: 'agent'
+  /** short label shown on the node, e.g. "Weekly review"; the prompt is the brief */
+  title: string
+  prompt: string
+  /** the one agent role the card goes to (kept as a list for the card's pipeline shape) */
+  roles: string[]
+  canvasId: string
+}
+
+export type Step = PullStep | AgentStep
+
+export type RunStatus = 'running' | 'ok' | 'failed'
+
+export interface AutomationRun {
+  id: string
+  automationId: string
+  startedAt: number
+  endedAt: number | null
+  status: RunStatus
+  /** one line of what happened: "12 creatives pulled · 1 card queued" */
+  summary: string | null
+  error: string | null
+  /** the first step's canvas — where "Open canvas" leads */
+  canvasId: string | null
+  /** what went wrong, when it's something the user can fix with one click */
+  failure: 'reconnect' | null
+}
+
+export interface Automation {
+  id: string
+  name: string
+  enabled: boolean
+  schedule: Schedule
+  steps: Step[]
+  nextRunAt: number | null
+  lastRun: Pick<AutomationRun, 'id' | 'startedAt' | 'status' | 'summary' | 'failure'> | null
+  createdAt: number
+  updatedAt: number
+}
+
+export const WEEKDAYS = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'] as const
+export const WEEKDAYS_SHORT = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'] as const
+
+export const MAX_STEPS = 6
+export const MAX_NAME = 80
+export const MAX_PROMPT = 4_000
+
+export const DEFAULT_SCHEDULE: Schedule = { kind: 'weekly', weekday: 1, hour: 9, minute: 0, tz: 'UTC' }
+
+/* ------------------------------------------------------------------ */
+/* Schedule math                                                       */
+
+function pad(n: number): string {
+  return String(n).padStart(2, '0')
+}
+
+export function isValidTimeZone(tz: string): boolean {
+  try {
+    new Intl.DateTimeFormat('en-US', { timeZone: tz })
+    return true
+  } catch {
+    return false
+  }
+}
+
+interface WallClock {
+  year: number
+  month: number
+  day: number
+  hour: number
+  minute: number
+  second: number
+  weekday: number
+}
+
+const partsCache = new Map<string, Intl.DateTimeFormat>()
+
+function formatter(tz: string): Intl.DateTimeFormat {
+  let f = partsCache.get(tz)
+  if (!f) {
+    f = new Intl.DateTimeFormat('en-US', {
+      timeZone: tz,
+      hourCycle: 'h23',
+      year: 'numeric',
+      month: 'numeric',
+      day: 'numeric',
+      hour: 'numeric',
+      minute: 'numeric',
+      second: 'numeric',
+      weekday: 'short',
+    })
+    partsCache.set(tz, f)
+  }
+  return f
+}
+
+/** The wall clock in `tz` at the instant `at`. */
+export function wallClock(at: number, tz: string): WallClock {
+  const parts: Record<string, string> = {}
+  for (const p of formatter(tz).formatToParts(new Date(at))) parts[p.type] = p.value
+  return {
+    year: Number(parts.year),
+    month: Number(parts.month),
+    day: Number(parts.day),
+    hour: Number(parts.hour),
+    minute: Number(parts.minute),
+    second: Number(parts.second),
+    weekday: WEEKDAYS_SHORT.indexOf(parts.weekday as (typeof WEEKDAYS_SHORT)[number]),
+  }
+}
+
+/** The zone's UTC offset (ms) at the instant `at`. */
+function offsetAt(at: number, tz: string): number {
+  const w = wallClock(at, tz)
+  const asUtc = Date.UTC(w.year, w.month - 1, w.day, w.hour, w.minute, w.second)
+  return asUtc - Math.floor(at / 1000) * 1000
+}
+
+/** The instant a wall-clock time in `tz` happens. Around a DST jump a
+ *  nonexistent time resolves to the instant an hour later; an ambiguous one
+ *  to its first occurrence. */
+export function zonedTime(tz: string, year: number, month: number, day: number, hour: number, minute: number): number {
+  const guess = Date.UTC(year, month - 1, day, hour, minute)
+  const offset = offsetAt(guess, tz)
+  const result = guess - offset
+  /* the offset can differ at the resolved instant when a DST change sits
+     between the guess and the answer — one correction settles it */
+  const settled = offsetAt(result, tz)
+  return settled === offset ? result : guess - settled
+}
+
+/** The next instant strictly after `after` that the schedule fires. */
+export function nextRunAt(schedule: Schedule, after: number): number {
+  const tz = isValidTimeZone(schedule.tz) ? schedule.tz : 'UTC'
+  const now = wallClock(after, tz)
+  /* walk day by day from today; a weekly schedule fires within 7 days */
+  for (let ahead = 0; ahead <= 8; ahead++) {
+    const dayStart = Date.UTC(now.year, now.month - 1, now.day + ahead)
+    const d = new Date(dayStart)
+    const candidate = zonedTime(
+      tz,
+      d.getUTCFullYear(),
+      d.getUTCMonth() + 1,
+      d.getUTCDate(),
+      schedule.hour,
+      schedule.minute,
+    )
+    if (candidate <= after) continue
+    const weekday = wallClock(candidate, tz).weekday
+    if (schedule.kind === 'weekly' && weekday !== schedule.weekday) continue
+    if (schedule.kind === 'weekdays' && (weekday === 0 || weekday === 6)) continue
+    return candidate
+  }
+  /* unreachable: 8 days always contain every weekday */
+  return after + 7 * 86_400_000
+}
+
+/** The clock as the viewer's locale shows it; falls back to 24h where Intl is missing. */
+export function clockTime(hour: number, minute: number): string {
+  try {
+    return new Date(2000, 0, 1, hour, minute).toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' })
+  } catch {
+    return `${pad(hour)}:${pad(minute)}`
+  }
+}
+
+export function describeSchedule(s: Schedule): string {
+  const time = clockTime(s.hour, s.minute)
+  if (s.kind === 'daily') return `Every day at ${time}`
+  if (s.kind === 'weekdays') return `Weekdays at ${time}`
+  return `Every ${WEEKDAYS[s.weekday] ?? 'Monday'} at ${time}`
+}
+
+/** "Mon 09:00" — the short form for list rows */
+export function shortSchedule(s: Schedule): string {
+  const time = clockTime(s.hour, s.minute)
+  if (s.kind === 'daily') return `Daily ${time}`
+  if (s.kind === 'weekdays') return `Weekdays ${time}`
+  return `${WEEKDAYS_SHORT[s.weekday] ?? 'Mon'} ${time}`
+}
+
+/* ------------------------------------------------------------------ */
+/* Validation                                                          */
+
+function asInt(v: unknown, min: number, max: number, fallback: number): number {
+  const n = typeof v === 'number' ? v : typeof v === 'string' ? Number(v) : NaN
+  if (!Number.isInteger(n) || n < min || n > max) return fallback
+  return n
+}
+
+export function normalizeSchedule(raw: unknown): Schedule {
+  const r = (raw ?? {}) as Partial<Record<keyof Schedule, unknown>>
+  const kind: ScheduleKind = r.kind === 'daily' || r.kind === 'weekdays' ? r.kind : 'weekly'
+  const tz = typeof r.tz === 'string' && isValidTimeZone(r.tz) ? r.tz : DEFAULT_SCHEDULE.tz
+  return {
+    kind,
+    weekday: asInt(r.weekday, 0, 6, DEFAULT_SCHEDULE.weekday),
+    hour: asInt(r.hour, 0, 23, DEFAULT_SCHEDULE.hour),
+    minute: asInt(r.minute, 0, 59, DEFAULT_SCHEDULE.minute),
+    tz,
+  }
+}
+
+function stepId(raw: unknown, index: number): string {
+  return typeof raw === 'string' && /^[A-Za-z0-9_-]{1,24}$/.test(raw) ? raw : `s${index + 1}`
+}
+
+/** Shape-check the steps. Canvas ids are only validated for shape here — the
+ *  server checks the owner can actually reach each one. */
+export function normalizeSteps(raw: unknown): Step[] | string {
+  if (!Array.isArray(raw)) return 'steps must be a list'
+  if (raw.length > MAX_STEPS) return `at most ${MAX_STEPS} steps`
+  const out: Step[] = []
+  raw.forEach((item, i) => {
+    const s = (item ?? {}) as Record<string, unknown>
+    const canvasId = typeof s.canvasId === 'string' ? s.canvasId.trim() : ''
+    if (s.type === 'pull') {
+      out.push({
+        id: stepId(s.id, i),
+        type: 'pull',
+        provider: 'meta',
+        accountId: typeof s.accountId === 'string' ? s.accountId.trim().slice(0, 40) : '',
+        filter: s.filter === 'all' ? 'all' : 'active',
+        canvasId,
+      })
+    } else if (s.type === 'agent') {
+      out.push({
+        id: stepId(s.id, i),
+        type: 'agent',
+        title: typeof s.title === 'string' ? s.title.trim().slice(0, MAX_NAME) : '',
+        prompt: typeof s.prompt === 'string' ? s.prompt.trim().slice(0, MAX_PROMPT) : '',
+        /* one agent per task — the first real role wins */
+        roles: normalizePipeline(s.roles).slice(0, 1),
+        canvasId,
+      })
+    }
+  })
+  if (out.length !== raw.length) return 'each step is a pull or an agent task'
+  return out
+}
+
+/** Why a saved automation cannot run yet — shown inline, and the reason the
+ *  scheduler skips it. Undefined = ready. */
+export function incompleteReason(steps: Step[]): string | undefined {
+  if (steps.length === 0) return 'Add a step'
+  for (const s of steps) {
+    if (!s.canvasId) return 'Pick a canvas for every step'
+    if (s.type === 'pull' && !s.accountId) return 'Pick a Meta ad account'
+    if (s.type === 'agent' && !s.prompt) return 'Write what the agent should do'
+  }
+  return undefined
+}
+
+/* ------------------------------------------------------------------ */
+/* Examples                                                            */
+
+export type ExampleStep = Omit<PullStep, 'id' | 'canvasId'> | Omit<AgentStep, 'id' | 'canvasId'>
+
+export interface AutomationExample {
+  id: string
+  name: string
+  blurb: string
+  schedule: Omit<Schedule, 'tz'>
+  steps: ExampleStep[]
+}
+
+/** The "start from an example" cards. Canvas (and Meta account) are left for
+ *  the user to pick; everything else is filled in. */
+export const AUTOMATION_EXAMPLES: AutomationExample[] = [
+  {
+    id: 'weekly-creatives',
+    name: 'Weekly ad creatives',
+    blurb: 'Pull every active Meta ad onto a canvas each Monday.',
+    schedule: { kind: 'weekly', weekday: 1, hour: 9, minute: 0 },
+    steps: [{ type: 'pull', provider: 'meta', accountId: '', filter: 'active' }],
+  },
+  {
+    id: 'ad-variants',
+    name: 'Ad variants',
+    blurb: 'Pull this week’s creatives, then have Doop spin up five variants of each.',
+    schedule: { kind: 'weekly', weekday: 1, hour: 9, minute: 0 },
+    steps: [
+      { type: 'pull', provider: 'meta', accountId: '', filter: 'active' },
+      {
+        type: 'agent',
+        title: 'Make variants',
+        prompt:
+          'For every ad creative pulled in today, make five variants as new frames next to it: a stronger headline, a different visual hierarchy, a bolder colour treatment, a shorter copy version, and one that leads with social proof. Keep the brand intact.',
+        roles: ['doop'],
+      },
+    ],
+  },
+  {
+    id: 'friday-ux',
+    name: 'Friday UX review',
+    blurb: 'The UX Lead reviews everything that changed this week.',
+    schedule: { kind: 'weekly', weekday: 5, hour: 16, minute: 0 },
+    steps: [
+      {
+        type: 'agent',
+        title: 'Weekly review',
+        prompt:
+          'Review every frame on this canvas as an interface someone has to use. Fix unclear primary actions, muddled hierarchy and missing states. Leave a short note of what you changed.',
+        roles: ['ux'],
+      },
+    ],
+  },
+  {
+    id: 'brand-a11y',
+    name: 'Brand and accessibility check',
+    blurb: 'Bring every frame back on brand and up to WCAG AA.',
+    schedule: { kind: 'weekly', weekday: 3, hour: 10, minute: 0 },
+    steps: [
+      {
+        type: 'agent',
+        title: 'Brand pass',
+        prompt:
+          'Check every frame on this canvas against the brand as established here — palette, type, radii, tone — and against WCAG AA contrast and semantics. Fix what fails without redesigning.',
+        roles: ['brand'],
+      },
+    ],
+  },
+  {
+    id: 'copy-pass',
+    name: 'Weekly copy pass',
+    blurb: 'The Copywriter tightens every headline and label.',
+    schedule: { kind: 'weekly', weekday: 2, hour: 9, minute: 30 },
+    steps: [
+      {
+        type: 'agent',
+        title: 'Copy pass',
+        prompt:
+          'Go through every frame on this canvas and tighten the copy: specific headlines, short labels, concrete CTAs, no filler. Keep every line inside its existing box.',
+        roles: ['copy'],
+      },
+    ],
+  },
+  {
+    id: 'nightly-polish',
+    name: 'Nightly polish',
+    blurb: 'Visual Polish tidies spacing and alignment every evening.',
+    schedule: { kind: 'weekdays', weekday: 1, hour: 22, minute: 0 },
+    steps: [
+      {
+        type: 'agent',
+        title: 'Polish',
+        prompt:
+          'Polish every frame on this canvas: optical alignment, one spacing scale, even type ramp, nothing overflowing at the frame size. Small surgical changes only.',
+        roles: ['polish'],
+      },
+    ],
+  },
+]
+
+export function exampleById(id: string): AutomationExample | undefined {
+  return AUTOMATION_EXAMPLES.find((e) => e.id === id)
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,9 @@ import { Settings } from './pages/Settings'
 import { CanvasPage } from './pages/CanvasPage'
 import { AuthPage } from './pages/AuthPage'
 import { Admin } from './pages/Admin'
+import { Automations } from './pages/Automations'
+import { AutomationEditor } from './pages/AutomationEditor'
+import { Integrations } from './pages/Integrations'
 import { authClient } from './lib/auth'
 import { setName } from './lib/identity'
 import { posthog, syncReplayForUser, suspendAnalyticsWhileImpersonating } from './lib/posthog'
@@ -121,6 +124,12 @@ export function App() {
     <Settings />
   ) : path.startsWith('/community') ? (
     <Community />
+  ) : path.startsWith('/integrations') ? (
+    <Integrations />
+  ) : path.match(/^\/automations\/([^/]+)/) ? (
+    <AutomationEditor automationId={path.match(/^\/automations\/([^/]+)/)![1]!} key={path} />
+  ) : path.startsWith('/automations') ? (
+    <Automations />
   ) : (
     <Home />
   )

--- a/src/components/AutomateShell.tsx
+++ b/src/components/AutomateShell.tsx
@@ -1,0 +1,337 @@
+import { useMemo, useState, type SVGProps } from 'react'
+import { navigate } from '../App'
+import { colorFor, type CanvasMeta } from '../../shared/types'
+import { roleById } from '../../shared/agents'
+import { timeAgo } from '../lib/time'
+import { AgentIcon } from './AgentIcon'
+import { ConnectCard, IconAutomations, IconGrid, IconIntegrations, IconShare, IconUser } from './DashShell'
+import { NavItem } from '../pages/Home'
+import { RoleMark } from './RoleMark'
+import { DashSectionLabel, DashSidebar } from './ui/dash'
+import { Dot } from './ui/dot'
+import { Wordmark } from './ui/wordmark'
+import { fieldVariants } from './ui/input'
+import { cn } from '@/lib/utils'
+
+/**
+ * Pieces the Automations and Integrations pages share with the rest of the
+ * signed-in shell: the Home rail (with these two pages in its main nav), the
+ * provider and trigger marks, and the small controls the node editor is
+ * built from. Visual reference: the "Automations 0/1/5" frames on the Doop
+ * Dashboard canvas.
+ */
+
+export type AutomatePage = 'automations' | 'integrations'
+
+/** an agent that worked this recently is treated as still at the desk */
+const LIVE_WINDOW = 5 * 60 * 1000
+
+/** The Home rail as the design draws it on these pages: canvases nav, then
+ *  Automations and Integrations in the same list, then the agents seen
+ *  across the user's canvases. */
+export function WorkspaceRail({
+  active,
+  canvases,
+  automationCount,
+  integrationCount,
+}: {
+  active: AutomatePage
+  canvases: CanvasMeta[]
+  automationCount?: number
+  integrationCount?: number
+}) {
+  const agents = useMemo(() => {
+    const map = new Map<string, { name: string; lastAt: number }>()
+    for (const c of canvases) {
+      for (const a of c.agents ?? []) {
+        const e = map.get(a.name)
+        if (e) e.lastAt = Math.max(e.lastAt, a.lastAt ?? 0)
+        else map.set(a.name, { name: a.name, lastAt: a.lastAt ?? 0 })
+      }
+    }
+    return [...map.values()].sort((x, y) => y.lastAt - x.lastAt).slice(0, 5)
+  }, [canvases])
+  /* read once per mount: liveness is a rail-level glance, not a clock */
+  const [now] = useState(() => Date.now())
+  const mine = canvases.filter((c) => !c.shared).length
+  const shared = canvases.length - mine
+
+  return (
+    <DashSidebar>
+      <Wordmark size="sm" className="px-2 pb-5 text-[17px]" />
+      <nav className="flex flex-col gap-0.5">
+        <NavItem icon={<IconGrid />} label="All canvases" count={canvases.length} on={false} go={() => navigate('/')} />
+        <NavItem icon={<IconUser />} label="Owned by me" count={mine} on={false} go={() => navigate('/')} />
+        <NavItem icon={<IconShare />} label="Shared with me" count={shared} on={false} go={() => navigate('/')} />
+        <NavItem
+          icon={<IconAutomations />}
+          label="Automations"
+          count={automationCount}
+          on={active === 'automations'}
+          go={() => navigate('/automations')}
+        />
+        <NavItem
+          icon={<IconIntegrations />}
+          label="Integrations"
+          count={integrationCount}
+          on={active === 'integrations'}
+          go={() => navigate('/integrations')}
+        />
+      </nav>
+
+      {agents.length > 0 && (
+        <>
+          <DashSectionLabel>Agents</DashSectionLabel>
+          <div className="flex flex-col gap-0.5">
+            {agents.map((a) => (
+              <div
+                key={a.name}
+                className="flex min-w-0 items-center gap-[9px] px-2.5 py-[5px] text-[13px] text-ink-soft"
+              >
+                <span
+                  className="grid size-[22px] flex-none place-items-center rounded-[7px] bg-paper-deep"
+                  style={{ color: colorFor(a.name) }}
+                >
+                  <AgentIcon name={a.name} size={13} />
+                </span>
+                <span className="truncate">{a.name}</span>
+                {a.lastAt > 0 && now - a.lastAt < LIVE_WINDOW ? (
+                  <Dot size="sm" className="ml-auto bg-[#3f9c52] shadow-[0_0_0_3px_rgba(63,156,82,0.15)]" />
+                ) : (
+                  <span className="ml-auto flex-none font-mono text-[10.5px] text-ink-faint">
+                    {a.lastAt > 0 ? timeAgo(a.lastAt) : ''}
+                  </span>
+                )}
+              </div>
+            ))}
+          </div>
+        </>
+      )}
+
+      <div className="min-h-6 flex-1" />
+      <ConnectCard />
+    </DashSidebar>
+  )
+}
+
+/* ---- marks ---- */
+
+/** The trigger's mark: a clock on an ink tile. */
+export function ClockTile({ size = 24, className }: { size?: number; className?: string }) {
+  const icon = Math.round(size * 0.58)
+  return (
+    <span
+      className={cn('inline-grid flex-none place-items-center rounded-[7px] bg-ink', className)}
+      style={{ width: size, height: size, borderRadius: Math.round(size * 0.29) }}
+      aria-hidden
+    >
+      <svg
+        width={icon}
+        height={icon}
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="#fdfdfc"
+        strokeWidth="1.9"
+        strokeLinecap="round"
+      >
+        <circle cx="12" cy="12" r="8.5" />
+        <path d="M12 7.5V12l3 2" />
+      </svg>
+    </span>
+  )
+}
+
+/** Meta's mark on a paper tile — the provider's own identity, not a Doop role. */
+export function MetaTile({ size = 24, className }: { size?: number; className?: string }) {
+  const icon = Math.round(size * 0.58)
+  return (
+    <span
+      className={cn('inline-grid flex-none place-items-center bg-paper-deep', className)}
+      style={{ width: size, height: size, borderRadius: Math.round(size * 0.29) }}
+      aria-hidden
+    >
+      <MetaLogo width={icon} height={icon} />
+    </span>
+  )
+}
+
+export function MetaLogo(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg viewBox="0 0 24 24" fill="#0866FF" aria-hidden {...props}>
+      <path d="M6.915 4.03c-1.968 0-3.683 1.28-4.871 3.113C.704 9.208 0 11.883 0 14.449c0 .706.07 1.369.21 1.973a6.624 6.624 0 0 0 .265.86 5.297 5.297 0 0 0 .371.761c.696 1.159 1.818 1.927 3.593 1.927 1.497 0 2.633-.671 3.965-2.444.76-1.012 1.144-1.626 2.663-4.32l.756-1.339.186-.325c.061.1.121.196.183.3l2.152 3.595c.724 1.21 1.665 2.556 2.47 3.314 1.046.987 1.992 1.22 3.06 1.22 1.075 0 1.876-.355 2.455-.843a3.743 3.743 0 0 0 .81-.973c.542-.939.861-2.127.861-3.745 0-2.72-.681-5.357-2.084-7.45-1.282-1.912-2.957-2.93-4.716-2.93-1.047 0-2.088.467-3.053 1.308-.652.57-1.257 1.29-1.82 2.05-.69-.875-1.335-1.547-1.958-2.056-1.182-.966-2.315-1.303-3.454-1.303zm10.16 2.053c1.147 0 2.188.758 2.992 1.999 1.132 1.748 1.647 4.195 1.647 6.4 0 1.548-.368 2.9-1.839 2.9-.58 0-1.027-.23-1.664-1.004-.496-.601-1.343-1.878-2.832-4.358l-.617-1.028a44.908 44.908 0 0 0-1.255-1.98c.07-.109.141-.224.211-.327 1.12-1.667 2.118-2.602 3.358-2.602zm-10.201.553c1.265 0 2.058.791 2.675 1.446.307.327.737.871 1.234 1.579l-1.02 1.566c-.757 1.163-1.882 3.017-2.837 4.338-1.191 1.649-1.81 1.817-2.486 1.817-.524 0-1.038-.237-1.383-.794-.263-.426-.464-1.13-.464-2.046 0-2.221.63-4.535 1.66-6.088.454-.687.964-1.226 1.499-1.584.325-.217.65-.234.972-.234z" />
+    </svg>
+  )
+}
+
+type MarkStep = { type: 'pull' } | { type: 'agent'; roles: string[] }
+
+/** The chain that summarises an automation: clock, then a Meta tile per
+ *  pull and a role mark per agent, joined by short dashes when `joined`. */
+export function StepChain({
+  steps,
+  size = 26,
+  joined = true,
+  className,
+}: {
+  steps: MarkStep[]
+  size?: number
+  joined?: boolean
+  className?: string
+}) {
+  const marks: React.ReactNode[] = [<ClockTile key="clock" size={size} />]
+  steps.forEach((s, i) => {
+    if (s.type === 'pull') marks.push(<MetaTile key={`p${i}`} size={size} className="border border-line bg-surface" />)
+    else
+      marks.push(
+        <span key={`a${i}`} className="flex">
+          {s.roles.map((id, j) => (
+            <RoleMark
+              key={id}
+              role={roleById(id)}
+              size={size}
+              className={cn(j > 0 && 'ring-[1.5px] ring-white')}
+              style={j > 0 ? { marginLeft: -Math.round(size * 0.3) } : undefined}
+            />
+          ))}
+        </span>,
+      )
+  })
+  const dash = <span className="h-px w-3 flex-none bg-[#b9b5ac]" aria-hidden />
+  return (
+    <span className={cn('inline-flex items-center', joined ? 'gap-1.5' : 'gap-1', className)}>
+      {marks.map((m, i) => (
+        <span key={i} className="inline-flex items-center gap-1.5">
+          {i > 0 && joined && dash}
+          {m}
+        </span>
+      ))}
+    </span>
+  )
+}
+
+/* ---- controls ---- */
+
+/** The brand-blue switch from the designs, with its mono "ON/OFF" caption. */
+export function Toggle({
+  on,
+  onChange,
+  label,
+  caption = false,
+  disabled,
+}: {
+  on: boolean
+  onChange: (on: boolean) => void
+  label: string
+  caption?: boolean
+  disabled?: boolean
+}) {
+  return (
+    <span className="inline-flex items-center gap-2">
+      {caption && (
+        <span className="font-mono text-[11px] uppercase tracking-[0.08em] text-ink-soft">{on ? 'On' : 'Off'}</span>
+      )}
+      <button
+        type="button"
+        role="switch"
+        aria-checked={on}
+        aria-label={label}
+        disabled={disabled}
+        onClick={(e) => {
+          e.stopPropagation()
+          onChange(!on)
+        }}
+        className={cn(
+          'relative h-5 w-[34px] flex-none rounded-full transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand disabled:opacity-50',
+          on ? 'bg-brand' : 'bg-line',
+        )}
+      >
+        <span
+          className={cn(
+            'absolute top-[2px] size-4 rounded-full bg-white shadow-[0_1px_2px_rgba(0,0,0,0.2)] transition-[left]',
+            on ? 'left-[16px]' : 'left-[2px]',
+          )}
+        />
+      </button>
+    </span>
+  )
+}
+
+/** The bordered "value ▾" control the node sentences are made of. A native
+ *  select underneath keeps the keyboard; the visible part is styled. */
+export function Sel({ className, children, ...props }: React.ComponentProps<'select'>) {
+  return (
+    <span className={cn('relative inline-flex min-w-0', className)}>
+      <select
+        className={cn(
+          fieldVariants({ variant: 'default', inputSize: 'sm' }),
+          'h-[34px] w-full cursor-pointer appearance-none truncate rounded-lg pl-[11px] pr-8 text-[13.5px] font-semibold tracking-[-0.01em]',
+        )}
+        {...props}
+      >
+        {children}
+      </select>
+      <Chevron className="pointer-events-none absolute right-2.5 top-1/2 -translate-y-1/2 text-ink-faint" />
+    </span>
+  )
+}
+
+export function Chevron({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      width="12"
+      height="12"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2.2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+    >
+      <path d="m6 9 6 6 6-6" />
+    </svg>
+  )
+}
+
+/** A canvas's 28×18 preview, or a blank tile when it has no frames yet. */
+export function CanvasThumb({ canvas, className }: { canvas?: CanvasMeta; className?: string }) {
+  return (
+    <span
+      className={cn(
+        'inline-block h-[18px] w-[28px] flex-none overflow-hidden rounded-[3px] border border-line bg-paper-deep',
+        className,
+      )}
+      aria-hidden
+    >
+      {canvas?.previewFrameId && (
+        <img src={`/i/${canvas.previewFrameId}.jpg?preview`} alt="" className="h-full w-full object-cover object-top" />
+      )}
+    </span>
+  )
+}
+
+/** The status dot a run row leads with. */
+export function RunDot({ status, className }: { status: 'running' | 'ok' | 'failed'; className?: string }) {
+  return (
+    <span
+      className={cn(
+        'inline-block size-[7px] flex-none rounded-full',
+        status === 'ok' && 'bg-[#3f9c52]',
+        status === 'failed' && 'bg-accent-ink',
+        status === 'running' && 'animate-pulse bg-[#8B5CF6]',
+        className,
+      )}
+      aria-label={status}
+    />
+  )
+}
+
+/** "Mon, Sep 8 · 9:00 AM" — in the viewer's locale, so the clock reads the
+ *  way their system shows it. */
+export function formatRunTime(at: number): string {
+  const d = new Date(at)
+  const day = d.toLocaleDateString(undefined, { weekday: 'short', day: 'numeric', month: 'short' })
+  const time = d.toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' })
+  return `${day} · ${time}`
+}

--- a/src/components/DashShell.tsx
+++ b/src/components/DashShell.tsx
@@ -20,12 +20,14 @@ import {
 import {
   ChevronLeftIcon,
   ChevronRightIcon,
+  ClockIcon,
   CompassIcon,
   GearIcon,
   GridIcon,
   HelpIcon,
   ListIcon,
   LogOutIcon,
+  PulseIcon,
   ShieldIcon,
   SparkIcon,
   UserIcon,
@@ -155,6 +157,10 @@ export const IconUser = () => <UserIcon {...rail} />
 export const IconShare = () => <UsersIcon {...rail} />
 /** the gallery: a compass — designs to steer by */
 export const IconCommunity = () => <CompassIcon {...rail} />
+/** a clock — things that happen on a schedule */
+export const IconAutomations = () => <ClockIcon {...rail} />
+/** a pulse line — a live connection */
+export const IconIntegrations = () => <PulseIcon {...rail} />
 export const IconSpark = () => <SparkIcon {...rail} />
 export const IconGear = () => <GearIcon {...rail} />
 export const IconShield = () => <ShieldIcon {...rail} />

--- a/src/components/RoleMark.tsx
+++ b/src/components/RoleMark.tsx
@@ -1,15 +1,26 @@
 import type { AgentRole } from '../../shared/agents'
 import { DoopMark } from './Logo'
+import { cn } from '@/lib/utils'
 
 /** A role's badge: a filled circle in the role's crew colour with the white
  *  Doop mark inside, as on the marketing site's team section. `size` is the
  *  circle's diameter; the mark takes about half of it. An unknown role gets a
  *  neutral ink circle so a stale card still reads. */
-export function RoleMark({ role, size = 14 }: { role?: Pick<AgentRole, 'color'>; size?: number }) {
+export function RoleMark({
+  role,
+  size = 14,
+  className,
+  style,
+}: {
+  role?: Pick<AgentRole, 'color'>
+  size?: number
+  className?: string
+  style?: React.CSSProperties
+}) {
   return (
     <span
-      className="inline-grid flex-none place-items-center rounded-full align-middle"
-      style={{ width: size, height: size, background: role?.color ?? 'var(--ink-faint)' }}
+      className={cn('inline-grid flex-none place-items-center rounded-full align-middle', className)}
+      style={{ width: size, height: size, background: role?.color ?? 'var(--ink-faint)', ...style }}
       aria-hidden
     >
       <DoopMark size={Math.round(size * 0.55)} color="#fff" className="block" />

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -1,0 +1,93 @@
+import { useState } from 'react'
+import { navigate } from '../App'
+import { Logo } from './Logo'
+import { Button } from './ui/button'
+import { Input } from './ui/input'
+import { Tooltip } from './ui/tooltip'
+import { cn } from '@/lib/utils'
+
+/**
+ * The top bar of a full-screen working surface — the canvas screen and the
+ * automation editor share it, so a name field, a view switch and an action
+ * cluster look and behave the same on both. Three tiers: desktop is one row
+ * with the full action set, tablet folds text actions into a ••• sheet,
+ * phone wraps to two rows with the name on top.
+ */
+export function TopBar({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="top-bar"
+      className={cn(
+        'z-40 flex h-14 flex-none items-center gap-4 border-b border-line bg-surface px-4 max-md:gap-2.5 max-md:px-3 max-xs:h-[100px] max-xs:flex-wrap max-xs:content-center max-xs:gap-y-2 max-xs:py-2',
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+/** The Doop mark at the left edge: the way back to the level above. */
+export function TopBarHome({ label, to }: { label: string; to: string }) {
+  return (
+    <Tooltip label={label} side="bottom" align="start">
+      <Button
+        variant="bare"
+        size="icon-sm"
+        className="size-9 hover:bg-paper-deep"
+        onClick={() => navigate(to)}
+        aria-label={label}
+      >
+        <Logo className="size-6" />
+      </Button>
+    </Tooltip>
+  )
+}
+
+const titleCls = 'min-w-0 max-w-[240px] sm:min-w-[60px] sm:max-w-[320px]'
+
+/** The editable name in the bar. Edits are local until blur or Enter, then
+ *  `onCommit` gets the trimmed value — never an empty one. */
+export function TopBarTitle({
+  value,
+  onCommit,
+  placeholder = 'Untitled',
+  loading = false,
+}: {
+  value: string
+  onCommit: (name: string) => void
+  placeholder?: string
+  loading?: boolean
+}) {
+  const [draft, setDraft] = useState<string | null>(null)
+  if (loading) return <span className={cn(titleCls, 'px-2 py-[5px] font-display text-[15px] font-semibold')}>…</span>
+  const shown = draft ?? value
+  return (
+    <Input
+      variant="title"
+      inputSize="sm"
+      className={cn(titleCls, 'truncate max-xs:max-w-[calc(100vw-72px)]')}
+      value={shown}
+      placeholder={placeholder}
+      size={Math.max(6, (shown || placeholder).length)}
+      onFocus={() => setDraft(value)}
+      onChange={(e) => setDraft(e.target.value)}
+      onBlur={() => {
+        if (draft !== null && draft.trim() && draft.trim() !== value) onCommit(draft.trim())
+        setDraft(null)
+      }}
+      onKeyDown={(e) => e.key === 'Enter' && (e.target as HTMLInputElement).blur()}
+    />
+  )
+}
+
+/** Hairline between the bar's clusters: actions | presence | sharing. */
+export function BarDivider() {
+  return <span aria-hidden className="mx-1 h-[22px] w-px bg-line-soft" />
+}
+
+/* the bar's button sizes, so every screen's actions line up */
+export const barGhostBtn =
+  'h-[34px] rounded-[7px] bg-surface px-[17px] text-[12.5px] font-semibold hover:border-ink-faint hover:bg-paper-deep'
+export const barIconBtn =
+  'size-[34px] rounded-[7px] bg-surface hover:border-ink-faint hover:bg-paper-deep disabled:opacity-40'
+export const barPrimaryBtn = 'h-[34px] rounded-[7px] px-[13px] text-[12.5px]'

--- a/src/components/ui/icons.tsx
+++ b/src/components/ui/icons.tsx
@@ -9,6 +9,7 @@
 import type { ComponentType, SVGProps } from 'react'
 import {
   Activity,
+  Clock,
   Attachment,
   Brain,
   Compass,
@@ -96,6 +97,7 @@ export const ListIcon = icon(Menu)
 export const UserIcon = icon(User)
 export const UsersIcon = icon(Group)
 export const CompassIcon = icon(Compass)
+export const ClockIcon = icon(Clock)
 export const GearIcon = icon(Settings)
 export const ShieldIcon = icon(Shield)
 export const HelpIcon = icon(HelpCircle)

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,4 +1,5 @@
 import type { ActivityItem, Canvas, CanvasMeta, CommunityCategory, CommunityItem, Frame } from '../../shared/types'
+import type { Automation, AutomationRun, Schedule, Step } from '../../shared/automations'
 
 export type HomeActivity = ActivityItem & { canvasId: string; canvasName: string }
 
@@ -141,6 +142,27 @@ export interface ModelAccountStatus {
 export interface WebsiteImportResult {
   frames: Frame[]
   failures: { url: string; error: string }[]
+}
+
+/** What the server accepts when creating or patching an automation. */
+export interface AutomationInput {
+  name?: string
+  enabled?: boolean
+  schedule?: Schedule
+  steps?: Step[]
+}
+
+/** The Integrations page: per-provider connection state. A provider the
+ *  server has no app credentials for reports `enabled: false`. */
+export interface IntegrationsStatus {
+  meta: {
+    enabled: boolean
+    connected: boolean
+    accountName?: string
+    accounts?: { id: string; name: string }[]
+    connectedAt?: number
+    expiresAt?: number | null
+  }
 }
 import { getIdentity } from './identity'
 
@@ -312,6 +334,21 @@ export const api = {
   resolveComment: (commentId: string) => req(`/api/comments/${commentId}/resolve`, { method: 'POST' }),
   retryComment: (commentId: string) => req(`/api/comments/${commentId}/retry`, { method: 'POST' }),
   retryTaskFeedback: (feedbackId: string) => req(`/api/feedback/${feedbackId}/retry`, { method: 'POST' }),
+  /* automations: scheduled pulls and agent tasks */
+  listAutomations: () => req<Automation[]>('/api/automations'),
+  getAutomation: (id: string) => req<Automation>(`/api/automations/${id}`),
+  createAutomation: (input: AutomationInput) =>
+    req<Automation>('/api/automations', { method: 'POST', body: JSON.stringify(input) }),
+  updateAutomation: (id: string, input: AutomationInput) =>
+    req<Automation>(`/api/automations/${id}`, { method: 'PATCH', body: JSON.stringify(input) }),
+  deleteAutomation: (id: string) => req(`/api/automations/${id}`, { method: 'DELETE' }),
+  runAutomation: (id: string) => req<AutomationRun>(`/api/automations/${id}/run`, { method: 'POST' }),
+  listRuns: (id: string, before?: number) =>
+    req<AutomationRun[]>(`/api/automations/${id}/runs${before ? `?before=${before}` : ''}`),
+  /* integrations: per-user connections to outside services */
+  integrations: () => req<IntegrationsStatus>('/api/integrations'),
+  startMetaConnect: () => req<{ url: string }>('/api/integrations/meta/start', { method: 'POST' }),
+  disconnectMeta: () => req<IntegrationsStatus>('/api/integrations/meta', { method: 'DELETE' }),
 }
 
 export interface AdminCanvas extends CanvasMeta {

--- a/src/pages/AutomationEditor.tsx
+++ b/src/pages/AutomationEditor.tsx
@@ -1,0 +1,1033 @@
+import { useEffect, useRef, useState } from 'react'
+import type { CanvasMeta } from '../../shared/types'
+import { AGENT_ROLES, roleById, roleName } from '../../shared/agents'
+import {
+  AUTOMATION_EXAMPLES,
+  MAX_NAME,
+  MAX_PROMPT,
+  MAX_STEPS,
+  WEEKDAYS,
+  WEEKDAYS_SHORT,
+  incompleteReason,
+  type AgentStep,
+  type Automation,
+  type AutomationExample,
+  type AutomationRun,
+  type PullStep,
+  type Schedule,
+  type Step,
+} from '../../shared/automations'
+import { api, ApiError, type IntegrationsStatus } from '../lib/api'
+import { navigate } from '../App'
+import { posthog } from '../lib/posthog'
+import { BarDivider, TopBar, TopBarHome, TopBarTitle, barGhostBtn, barPrimaryBtn } from '../components/TopBar'
+import {
+  CanvasThumb,
+  Chevron,
+  ClockTile,
+  MetaTile,
+  RunDot,
+  Sel,
+  StepChain,
+  Toggle,
+  formatRunTime,
+} from '../components/AutomateShell'
+import { RoleMark } from '../components/RoleMark'
+import { Button } from '../components/ui/button'
+import { Input } from '../components/ui/input'
+import { Textarea } from '../components/ui/textarea'
+import {
+  Panel,
+  PanelBody,
+  PanelHeader,
+  PanelTab,
+  PanelTabPanel,
+  PanelTabs,
+  PanelTabsRoot,
+} from '../components/ui/panel'
+import { ListItem, ListMeta, ListSummary, ListTitle } from '../components/ui/list'
+import { Skeleton } from '../components/ui/skeleton'
+import { Toast } from '../components/ui/toast'
+import { Tooltip } from '../components/ui/tooltip'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuTrigger,
+} from '../components/ui/dropdown-menu'
+import { PanelCollapseRightIcon, PanelExpandRightIcon, PlayIcon, PulseIcon, XIcon } from '../components/ui/icons'
+import { cn } from '@/lib/utils'
+
+/** A draft is the automation minus what the server owns. */
+type Draft = Pick<Automation, 'name' | 'schedule' | 'steps'>
+
+function draftOf(a: Automation): Draft {
+  return { name: a.name, schedule: a.schedule, steps: a.steps }
+}
+
+function sameDraft(a: Draft, b: Draft): boolean {
+  return JSON.stringify(a) === JSON.stringify(b)
+}
+
+function newStepId(steps: Step[]): string {
+  let n = steps.length + 1
+  while (steps.some((s) => s.id === `s${n}`)) n++
+  return `s${n}`
+}
+
+/** Drag the empty ground (or scroll) to move the chain around, the way the
+ *  canvas pans. The offset lives on the DOM, not in state — a pan should
+ *  never re-render the nodes. Interactive children keep their own gestures. */
+function usePan() {
+  const ground = useRef<HTMLDivElement>(null)
+  const layer = useRef<HTMLDivElement>(null)
+  const offset = useRef({ x: 0, y: 0 })
+  /* a press becomes a pan once it has moved a few pixels — until then a
+     button under the pointer still gets its click */
+  const press = useRef<{ id: number; startX: number; startY: number; x: number; y: number; live: boolean } | null>(null)
+  /* set while the click that ends a pan is still on its way */
+  const swallow = useRef(false)
+
+  useEffect(() => {
+    const el = ground.current
+    if (!el) return
+    const apply = () => {
+      if (layer.current) layer.current.style.transform = `translate(${offset.current.x}px, ${offset.current.y}px)`
+    }
+    /* the runs panel scrolls itself; text fields keep selection and caret */
+    const inPanel = (t: EventTarget | null) => t instanceof Element && !!t.closest('[data-pan-stop]')
+    const textField = (t: EventTarget | null) => t instanceof Element && !!t.closest('input, textarea, select')
+    const onDown = (e: PointerEvent) => {
+      if (e.button !== 0 || inPanel(e.target) || textField(e.target)) return
+      press.current = {
+        id: e.pointerId,
+        startX: e.clientX,
+        startY: e.clientY,
+        x: e.clientX - offset.current.x,
+        y: e.clientY - offset.current.y,
+        live: false,
+      }
+    }
+    const onMove = (e: PointerEvent) => {
+      const p = press.current
+      if (!p || p.id !== e.pointerId) return
+      if (!p.live) {
+        if (Math.hypot(e.clientX - p.startX, e.clientY - p.startY) < 4) return
+        p.live = true
+        el.setPointerCapture(e.pointerId)
+        el.style.cursor = 'grabbing'
+      }
+      offset.current = { x: e.clientX - p.x, y: e.clientY - p.y }
+      apply()
+    }
+    const onUp = (e: PointerEvent) => {
+      const p = press.current
+      if (p?.id !== e.pointerId) return
+      press.current = null
+      el.style.cursor = ''
+      if (p.live) {
+        swallow.current = true
+        setTimeout(() => (swallow.current = false), 0)
+      }
+    }
+    /* a pan that happened must not end as a click on whatever is under the pointer */
+    const onClick = (e: MouseEvent) => {
+      if (!swallow.current) return
+      swallow.current = false
+      e.stopPropagation()
+      e.preventDefault()
+    }
+    const onWheel = (e: WheelEvent) => {
+      if (inPanel(e.target)) return
+      /* a text field with more lines than it shows scrolls itself first */
+      const field = e.target instanceof Element ? e.target.closest('textarea') : null
+      if (field && field.scrollHeight > field.clientHeight) {
+        const atTop = field.scrollTop <= 0 && e.deltaY < 0
+        const atBottom = field.scrollTop + field.clientHeight >= field.scrollHeight - 1 && e.deltaY > 0
+        if (!atTop && !atBottom) return
+      }
+      e.preventDefault()
+      offset.current = { x: offset.current.x - e.deltaX, y: offset.current.y - e.deltaY }
+      apply()
+    }
+    el.addEventListener('click', onClick, true)
+    el.addEventListener('pointerdown', onDown)
+    el.addEventListener('pointermove', onMove)
+    el.addEventListener('pointerup', onUp)
+    el.addEventListener('pointercancel', onUp)
+    el.addEventListener('wheel', onWheel, { passive: false })
+    return () => {
+      el.removeEventListener('click', onClick, true)
+      el.removeEventListener('pointerdown', onDown)
+      el.removeEventListener('pointermove', onMove)
+      el.removeEventListener('pointerup', onUp)
+      el.removeEventListener('pointercancel', onUp)
+      el.removeEventListener('wheel', onWheel)
+    }
+  }, [])
+
+  return { ground, layer }
+}
+
+/**
+ * One automation, in the canvas screen's chrome rather than the dashboard's:
+ * a top bar with the name, a Setup | Runs switch and the run controls, then
+ * the full-width dot grid. Setup draws the schedule and steps as a short
+ * vertical chain of nodes; Runs is the slim log. Every step names its
+ * canvas — the canvas is where the work lands, not a step of its own.
+ */
+export function AutomationEditor({ automationId }: { automationId: string }) {
+  const [automation, setAutomation] = useState<Automation | null>(null)
+  const [missing, setMissing] = useState(false)
+  const [draft, setDraft] = useState<Draft | null>(null)
+  const [canvases, setCanvases] = useState<CanvasMeta[]>([])
+  const [integrations, setIntegrations] = useState<IntegrationsStatus | null>(null)
+  const [saving, setSaving] = useState(false)
+  const [runningNow, setRunningNow] = useState(false)
+  /* the step picker is open below the chain (always, while there are no steps) */
+  const [adding, setAdding] = useState(false)
+  const { ground: panGround, layer: panLayer } = usePan()
+  /* the runs panel remembers whether it was open, like the canvas side panel */
+  const [runsOpen, setRunsOpen] = useState(() => {
+    try {
+      return localStorage.getItem('doop.automations.runs') !== 'closed'
+    } catch {
+      return true
+    }
+  })
+  function toggleRuns(open: boolean) {
+    setRunsOpen(open)
+    try {
+      localStorage.setItem('doop.automations.runs', open ? 'open' : 'closed')
+    } catch {
+      /* private mode */
+    }
+  }
+  const [toast, setToast] = useState<string | null>(null)
+
+  useEffect(() => {
+    api
+      .getAutomation(automationId)
+      .then((a) => {
+        setAutomation(a)
+        setDraft(draftOf(a))
+      })
+      .catch((err) => {
+        if (err instanceof ApiError && err.status === 404) setMissing(true)
+        else console.error(err)
+      })
+    api.listCanvases().then(setCanvases).catch(console.error)
+    api.integrations().then(setIntegrations).catch(console.error)
+  }, [automationId])
+
+  function showToast(message: string) {
+    setToast(message)
+    window.setTimeout(() => setToast(null), 2400)
+  }
+
+  const dirty = !!automation && !!draft && !sameDraft(draftOf(automation), draft)
+
+  async function save(): Promise<Automation | undefined> {
+    if (!draft || !automation || saving) return automation ?? undefined
+    setSaving(true)
+    try {
+      const saved = await api.updateAutomation(automation.id, draft)
+      setAutomation(saved)
+      setDraft(draftOf(saved))
+      posthog.capture('automation_saved', { steps: saved.steps.length })
+      return saved
+    } catch (err) {
+      showToast(err instanceof ApiError && typeof err.body.error === 'string' ? err.body.error : 'Couldn’t save')
+      return undefined
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  /* ⌘S saves — the editor is a form people will expect it from */
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 's' && (e.metaKey || e.ctrlKey)) {
+        e.preventDefault()
+        void save()
+      }
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  })
+
+  /* the name saves on its own, like a canvas rename — it is not part of the
+     draft people expect to confirm with Save */
+  async function rename(name: string) {
+    if (!automation || !draft) return
+    setDraft({ ...draft, name })
+    try {
+      const saved = await api.updateAutomation(automation.id, { name })
+      setAutomation((cur) => (cur ? { ...cur, name: saved.name, updatedAt: saved.updatedAt } : cur))
+    } catch (err) {
+      console.error(err)
+      showToast('Couldn’t rename')
+    }
+  }
+
+  async function setEnabled(enabled: boolean) {
+    if (!automation) return
+    setAutomation({ ...automation, enabled })
+    try {
+      setAutomation(await api.updateAutomation(automation.id, { enabled }))
+    } catch (err) {
+      console.error(err)
+      setAutomation(automation)
+      showToast('Couldn’t save')
+    }
+  }
+
+  async function runNow() {
+    if (!automation || runningNow) return
+    const saved = dirty ? await save() : automation
+    if (!saved) return
+    setRunningNow(true)
+    try {
+      const run = await api.runAutomation(saved.id)
+      posthog.capture('automation_run_now', { status: run.status })
+      setAutomation({ ...saved, lastRun: run })
+    } catch (err) {
+      showToast(err instanceof ApiError && typeof err.body.error === 'string' ? err.body.error : 'Couldn’t run')
+    } finally {
+      setRunningNow(false)
+    }
+  }
+
+  function applyExample(example: AutomationExample) {
+    if (!draft) return
+    setDraft({
+      name: draft.name === 'Untitled automation' ? example.name : draft.name,
+      schedule: { ...example.schedule, tz: draft.schedule.tz },
+      steps: example.steps.map((s, i) => ({ ...s, id: `s${i + 1}`, canvasId: '' }) as Step),
+    })
+  }
+
+  function addStep(type: Step['type']) {
+    if (!draft || draft.steps.length >= MAX_STEPS) return
+    const id = newStepId(draft.steps)
+    /* a new step lands on the canvas the previous one worked on */
+    const canvasId = draft.steps[draft.steps.length - 1]?.canvasId ?? ''
+    const step: Step =
+      type === 'pull'
+        ? { id, type: 'pull', provider: 'meta', accountId: '', filter: 'active', canvasId }
+        : { id, type: 'agent', title: '', prompt: '', roles: ['doop'], canvasId }
+    setDraft({ ...draft, steps: [...draft.steps, step] })
+    setAdding(false)
+  }
+
+  function patchStep(id: string, patch: Partial<PullStep> | Partial<AgentStep>) {
+    if (!draft) return
+    setDraft({ ...draft, steps: draft.steps.map((s) => (s.id === id ? ({ ...s, ...patch } as Step) : s)) })
+  }
+
+  function removeStep(id: string) {
+    if (!draft) return
+    setDraft({ ...draft, steps: draft.steps.filter((s) => s.id !== id) })
+  }
+
+  const incomplete = draft ? incompleteReason(draft.steps) : undefined
+
+  return (
+    <div className="fixed inset-x-0 bottom-0 top-[var(--app-inset,0px)] flex flex-col">
+      <TopBar>
+        <div className="flex min-w-0 items-center gap-1.5 max-xs:basis-full">
+          <TopBarHome label="Automations" to="/automations" />
+          <TopBarTitle
+            loading={!draft}
+            value={draft?.name ?? ''}
+            placeholder="Untitled automation"
+            onCommit={(name) => void rename(name)}
+          />
+        </div>
+        {automation && (
+          <div className="ml-auto flex items-center gap-2.5">
+            <Toggle caption on={automation.enabled} onChange={setEnabled} label="Automation on or off" />
+            <BarDivider />
+            <Button
+              variant="ghost"
+              className={barGhostBtn}
+              disabled={runningNow || !!incomplete}
+              onClick={runNow}
+              title={incomplete ? `${incomplete} first` : 'Run the automation now'}
+            >
+              <PlayIcon className="size-3.5" />
+              {runningNow ? 'Running…' : 'Run now'}
+            </Button>
+            <Button variant="primary" className={barPrimaryBtn} disabled={!dirty || saving} onClick={() => void save()}>
+              {saving ? 'Saving…' : 'Save'}
+            </Button>
+          </div>
+        )}
+      </TopBar>
+
+      <div
+        ref={panGround}
+        className="relative flex-1 touch-none overflow-hidden [background:radial-gradient(circle,var(--dot)_1.2px,transparent_1.2px)_0_0/26px_26px,var(--paper)]"
+      >
+        {missing ? (
+          <div className="mx-auto max-w-[360px] pt-14 text-center">
+            <p className="text-[13.5px] text-ink-soft">That automation doesn’t exist any more.</p>
+            <Button variant="ghost" className="mt-3" onClick={() => navigate('/automations')}>
+              Back to automations
+            </Button>
+          </div>
+        ) : !draft || !automation ? (
+          <div className="mx-auto flex w-[360px] flex-col gap-11 pt-14">
+            <Skeleton className="h-[94px] rounded-[10px]" />
+            <Skeleton index={1} className="h-[240px] rounded-[10px]" />
+          </div>
+        ) : (
+          <>
+            <div ref={panLayer} className="relative h-full will-change-transform">
+              <div className="relative mx-auto flex w-[360px] flex-col pb-24 pt-14">
+                <WhenNode schedule={draft.schedule} onChange={(schedule) => setDraft({ ...draft, schedule })} />
+                {draft.steps.map((step) => (
+                  <div key={step.id} className="flex flex-col">
+                    <Edge />
+                    {step.type === 'pull' ? (
+                      <PullNode
+                        step={step}
+                        canvases={canvases}
+                        integrations={integrations}
+                        onChange={(patch) => patchStep(step.id, patch)}
+                        onRemove={() => removeStep(step.id)}
+                      />
+                    ) : (
+                      <AgentNode
+                        step={step}
+                        canvases={canvases}
+                        onChange={(patch) => patchStep(step.id, patch)}
+                        onRemove={() => removeStep(step.id)}
+                      />
+                    )}
+                  </div>
+                ))}
+                {draft.steps.length === 0 || adding ? (
+                  <>
+                    <Edge />
+                    <StepPicker
+                      onPick={addStep}
+                      onCancel={draft.steps.length > 0 ? () => setAdding(false) : undefined}
+                    />
+                  </>
+                ) : (
+                  <Button
+                    variant="bare"
+                    disabled={draft.steps.length >= MAX_STEPS}
+                    className="mt-5 justify-center text-[12.5px] font-semibold text-ink-faint hover:bg-transparent hover:text-ink"
+                    onClick={() => setAdding(true)}
+                  >
+                    + Add step
+                  </Button>
+                )}
+                {incomplete && draft.steps.length > 0 && (
+                  <p className="mt-3 text-center text-[12px] text-ink-faint">{incomplete} to turn it on.</p>
+                )}
+              </div>
+              {draft.steps.length === 0 && (
+                <aside className="absolute left-[calc(50%+240px)] top-14 hidden w-[260px] lg:block">
+                  <div className="mb-2 font-mono text-[10px] uppercase tracking-[0.12em] text-ink-faint">
+                    Or start from an example
+                  </div>
+                  {AUTOMATION_EXAMPLES.map((e) => (
+                    <button
+                      key={e.id}
+                      type="button"
+                      className="mb-1.5 flex w-full items-center gap-2 rounded-[9px] border border-line bg-surface px-2.5 py-2 text-left text-[12.5px] font-semibold tracking-[-0.01em] transition-colors hover:border-ink-faint"
+                      onClick={() => applyExample(e)}
+                    >
+                      <StepChain steps={e.steps} size={18} joined={false} />
+                      <span className="min-w-0 truncate">{e.name}</span>
+                      <small className="ml-auto font-mono text-[9.5px] font-normal text-ink-faint">
+                        {e.schedule.kind === 'daily'
+                          ? 'daily'
+                          : e.schedule.kind === 'weekdays'
+                            ? 'weekdays'
+                            : WEEKDAYS_SHORT[e.schedule.weekday]}
+                      </small>
+                    </button>
+                  ))}
+                </aside>
+              )}
+            </div>
+            {draft.steps.length > 0 && (
+              <div data-pan-stop className="contents">
+                {runsOpen ? (
+                  <RunsPanel
+                    automation={automation}
+                    canvases={canvases}
+                    dirty={dirty}
+                    onRunNow={runNow}
+                    onClose={() => toggleRuns(false)}
+                  />
+                ) : (
+                  <nav
+                    aria-label="Runs"
+                    className="absolute right-3 top-3 z-[38] flex w-12 flex-col items-center gap-1.5 rounded-[14px] border border-line bg-surface p-1.5 shadow-card max-lg:hidden"
+                  >
+                    <Tooltip label="Expand panel" side="left">
+                      <Button
+                        variant="bare"
+                        size="icon"
+                        aria-label="Expand panel"
+                        className="relative size-[34px] rounded-lg text-ink-soft hover:bg-paper-deep hover:text-ink"
+                        onClick={() => toggleRuns(true)}
+                      >
+                        <PanelExpandRightIcon />
+                      </Button>
+                    </Tooltip>
+                    <span aria-hidden className="my-0.5 h-px w-6 bg-line-soft" />
+                    <Tooltip
+                      label={automation.lastRun ? `Runs · last ${formatRunTime(automation.lastRun.startedAt)}` : 'Runs'}
+                      side="left"
+                    >
+                      <Button
+                        variant="bare"
+                        size="icon"
+                        aria-label="Runs"
+                        className="relative size-[34px] rounded-lg text-ink-soft hover:bg-paper-deep hover:text-ink"
+                        onClick={() => toggleRuns(true)}
+                      >
+                        <PulseIcon />
+                        {automation.lastRun?.status === 'failed' && (
+                          <span className="absolute right-[5px] top-[5px] size-1.5 rounded-full bg-accent-ink shadow-[0_0_0_2px_var(--surface)]" />
+                        )}
+                      </Button>
+                    </Tooltip>
+                  </nav>
+                )}
+              </div>
+            )}
+          </>
+        )}
+      </div>
+      {toast && <Toast>{toast}</Toast>}
+    </div>
+  )
+}
+
+/* ------------------------------------------------------------------ */
+/* Nodes                                                               */
+
+const nodeCls = 'relative rounded-[10px] border border-line bg-surface px-3.5 py-3 shadow-card'
+const kCls = 'font-mono text-[10px] uppercase tracking-[0.12em] text-ink-faint'
+
+/** A port: the small circle where an edge meets a node. */
+function Port({ side, dashed }: { side: 'in' | 'out'; dashed?: boolean }) {
+  return (
+    <span
+      className={cn(
+        'absolute left-1/2 z-10 size-3 -translate-x-1/2 rounded-full border-[1.5px] bg-surface',
+        side === 'in' ? '-top-[7px]' : '-bottom-[7px]',
+        dashed ? 'border-dashed border-ink-faint' : 'border-ink',
+      )}
+      aria-hidden
+    />
+  )
+}
+
+/** The connector between nodes. */
+function Edge() {
+  return <div className="mx-auto h-11 w-px bg-[#b9b5ac]" aria-hidden />
+}
+
+function pad(n: number) {
+  return String(n).padStart(2, '0')
+}
+
+/** "09:00" → the viewer's own clock format ("9:00 AM" or "09:00"). */
+function clockLabel(hhmm: string): string {
+  const [h, m] = hhmm.split(':').map(Number)
+  return new Date(2000, 0, 1, h ?? 0, m ?? 0).toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' })
+}
+
+/** "Every [Monday ▾] at [09:00 ▾]" */
+function WhenNode({ schedule, onChange }: { schedule: Schedule; onChange: (s: Schedule) => void }) {
+  const dayValue =
+    schedule.kind === 'daily' ? 'daily' : schedule.kind === 'weekdays' ? 'weekdays' : String(schedule.weekday)
+  const time = `${pad(schedule.hour)}:${pad(schedule.minute)}`
+  const times: string[] = []
+  for (let h = 0; h < 24; h++) for (const m of [0, 30]) times.push(`${pad(h)}:${pad(m)}`)
+  if (!times.includes(time)) times.push(time)
+  times.sort()
+  return (
+    <div className={cn(nodeCls, 'border-ink')}>
+      <Port side="out" />
+      <div className="flex items-center gap-[9px]">
+        <ClockTile size={24} />
+        <span className={kCls}>When</span>
+        <span className="ml-auto text-[10.5px] text-ink-faint">{schedule.tz.replace(/_/g, ' ')}</span>
+      </div>
+      <div className="mt-2.5 flex items-center gap-2 text-[14px]">
+        <span className="text-ink-soft">Every</span>
+        <Sel
+          aria-label="Which days"
+          value={dayValue}
+          onChange={(e) => {
+            const v = e.target.value
+            if (v === 'daily' || v === 'weekdays') onChange({ ...schedule, kind: v })
+            else onChange({ ...schedule, kind: 'weekly', weekday: Number(v) })
+          }}
+        >
+          {WEEKDAYS.map((d, i) => (
+            <option key={d} value={i}>
+              {d}
+            </option>
+          ))}
+          <option value="weekdays">weekday</option>
+          <option value="daily">day</option>
+        </Sel>
+        <span className="text-ink-soft">at</span>
+        <Sel
+          aria-label="Time"
+          value={time}
+          onChange={(e) => {
+            const [h, m] = e.target.value.split(':').map(Number)
+            onChange({ ...schedule, hour: h ?? 9, minute: m ?? 0 })
+          }}
+        >
+          {times.map((t) => (
+            <option key={t} value={t}>
+              {clockLabel(t)}
+            </option>
+          ))}
+        </Sel>
+      </div>
+    </div>
+  )
+}
+
+/** "into ▾ Canvas" / "on ▾ Canvas": a menu of the user's canvases with
+ *  their previews, in the same bordered control as the other pickers. */
+function CanvasPicker({
+  word,
+  value,
+  canvases,
+  onChange,
+}: {
+  word: string
+  value: string
+  canvases: CanvasMeta[]
+  onChange: (id: string) => void
+}) {
+  const current = canvases.find((c) => c.id === value)
+  return (
+    <div className="mt-2.5 flex items-center gap-2 text-[12.5px] text-ink-soft">
+      <span>{word}</span>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <button
+            type="button"
+            className={cn(
+              'flex h-8 min-w-0 flex-1 items-center gap-2 rounded-lg border border-line bg-surface px-2.5 text-left text-[13.5px] font-semibold tracking-[-0.01em] text-ink transition-colors hover:border-ink-faint focus-visible:outline-2 focus-visible:outline-brand',
+              !current && 'font-medium text-ink-faint',
+            )}
+          >
+            {current && <CanvasThumb canvas={current} />}
+            <span className="min-w-0 flex-1 truncate">{current?.name ?? 'Choose a canvas'}</span>
+            <Chevron className="text-ink-faint" />
+          </button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="start" className="max-h-[320px] w-[300px] overflow-y-auto">
+          {canvases.length === 0 && (
+            <DropdownMenuLabel className="text-[12px] font-normal text-ink-faint">No canvases yet</DropdownMenuLabel>
+          )}
+          {canvases.map((c) => (
+            <DropdownMenuItem
+              key={c.id}
+              onSelect={() => onChange(c.id)}
+              className={cn(c.id === value && 'bg-paper-deep')}
+            >
+              <CanvasThumb canvas={c} />
+              <span className="min-w-0 flex-1 truncate">{c.name}</span>
+            </DropdownMenuItem>
+          ))}
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  )
+}
+
+function RemoveStep({ onRemove }: { onRemove: () => void }) {
+  return (
+    <Tooltip label="Remove step" side="left">
+      <Button
+        variant="bare"
+        size="icon-sm"
+        className="ml-auto size-6 text-ink-faint hover:text-accent-ink"
+        aria-label="Remove step"
+        onClick={onRemove}
+      >
+        <XIcon className="size-3.5" />
+      </Button>
+    </Tooltip>
+  )
+}
+
+function PullNode({
+  step,
+  canvases,
+  integrations,
+  onChange,
+  onRemove,
+}: {
+  step: PullStep
+  canvases: CanvasMeta[]
+  integrations: IntegrationsStatus | null
+  onChange: (patch: Partial<PullStep>) => void
+  onRemove: () => void
+}) {
+  const meta = integrations?.meta
+  const accounts = meta?.accounts ?? []
+  return (
+    <div className={nodeCls}>
+      <Port side="in" />
+      <Port side="out" />
+      <div className="flex items-center gap-[9px]">
+        <MetaTile size={24} />
+        <div className="min-w-0">
+          <div className={kCls}>Pull · Meta Ads</div>
+          <div className="text-[13.5px] font-semibold tracking-[-0.012em]">Ad creatives</div>
+        </div>
+        {meta && (
+          <span
+            className={cn(
+              'ml-auto inline-flex items-center gap-1.5 font-mono text-[10px] tracking-[0.06em]',
+              meta.connected ? 'text-ink-soft' : 'text-ink-faint',
+            )}
+          >
+            <span className={cn('size-[6px] rounded-full', meta.connected ? 'bg-[#3f9c52]' : 'bg-line')} />
+            {meta.connected ? 'connected' : 'not connected'}
+          </span>
+        )}
+        <RemoveStep onRemove={onRemove} />
+      </div>
+      {!meta ? (
+        <div className="mt-2.5 text-[12.5px] text-ink-faint">…</div>
+      ) : !meta.connected ? (
+        <div className="mt-2.5 flex items-center gap-3">
+          <span className="text-[13px] text-ink-soft">Not connected yet</span>
+          <Button variant="solid" size="sm" className="ml-auto h-8" onClick={() => navigate('/integrations')}>
+            Connect Meta
+          </Button>
+        </div>
+      ) : (
+        <div className="mt-2.5 grid grid-cols-[minmax(0,1fr)_minmax(0,1fr)] gap-2.5">
+          <Sel
+            aria-label="Ad account"
+            className={cn(!step.accountId && '[&>select]:text-ink-faint')}
+            value={step.accountId}
+            onChange={(e) => onChange({ accountId: e.target.value })}
+          >
+            <option value="">Ad account</option>
+            {accounts.map((a) => (
+              <option key={a.id} value={a.id}>
+                {a.name} · {a.id.replace(/^act_/, '')}
+              </option>
+            ))}
+          </Sel>
+          <Sel
+            aria-label="Which ads"
+            value={step.filter}
+            onChange={(e) => onChange({ filter: e.target.value as PullStep['filter'] })}
+          >
+            <option value="active">Active ads</option>
+            <option value="all">All ads</option>
+          </Sel>
+        </div>
+      )}
+      <CanvasPicker
+        word="into"
+        value={step.canvasId}
+        canvases={canvases}
+        onChange={(canvasId) => onChange({ canvasId })}
+      />
+    </div>
+  )
+}
+
+function AgentNode({
+  step,
+  canvases,
+  onChange,
+  onRemove,
+}: {
+  step: AgentStep
+  canvases: CanvasMeta[]
+  onChange: (patch: Partial<AgentStep>) => void
+  onRemove: () => void
+}) {
+  /* one agent per task: a pill picks that role, nothing to un-pick */
+  const roles = step.roles
+  return (
+    <div className={nodeCls}>
+      <Port side="in" />
+      <Port side="out" />
+      <div className="flex items-center gap-[9px]">
+        <RoleMark role={roleById(roles[0])} size={24} />
+        <div className="min-w-0 flex-1">
+          <div className={kCls}>Agent task</div>
+          <Input
+            value={step.title}
+            maxLength={MAX_NAME}
+            aria-label="Task title"
+            variant="bare"
+            inputSize="auto"
+            placeholder="Untitled task"
+            className="w-full text-[13.5px] font-semibold tracking-[-0.012em] md:text-[13.5px]"
+            onChange={(e) => onChange({ title: e.target.value })}
+          />
+        </div>
+        <RemoveStep onRemove={onRemove} />
+      </div>
+      <Textarea
+        className="mt-2.5 min-h-[74px] w-full rounded-lg px-[11px] py-2.5 text-[13.5px] leading-[1.5] md:text-[13.5px]"
+        value={step.prompt}
+        maxLength={MAX_PROMPT}
+        placeholder="What should the agent do on this canvas?"
+        onChange={(e) => onChange({ prompt: e.target.value })}
+      />
+      <div className="mt-2.5 flex flex-wrap gap-1">
+        {AGENT_ROLES.map((role) => {
+          const on = roles[0] === role.id
+          return (
+            <Button
+              key={role.id}
+              variant="ghost"
+              size="sm"
+              role="radio"
+              aria-checked={on}
+              className={cn(
+                'gap-1 rounded-full px-2 py-1 text-[11.5px] text-ink-soft hover:border-ink-soft hover:bg-transparent',
+                on && 'border-ink bg-ink text-white hover:border-ink hover:bg-ink hover:text-white',
+              )}
+              title={role.blurb}
+              onClick={() => onChange({ roles: [role.id] })}
+            >
+              <RoleMark role={role} size={13} />
+              {role.name}
+            </Button>
+          )
+        })}
+      </div>
+      <p className="mt-2 text-[11.5px] text-ink-faint">{roleName(roles[0])} picks it up right away</p>
+      <CanvasPicker
+        word="on"
+        value={step.canvasId}
+        canvases={canvases}
+        onChange={(canvasId) => onChange({ canvasId })}
+      />
+    </div>
+  )
+}
+
+/** The step slot: the two things a step can be, as tiles. It is the empty
+ *  automation's first slot and, later, what "+ Add step" opens in place. */
+function StepPicker({ onPick, onCancel }: { onPick: (type: Step['type']) => void; onCancel?: () => void }) {
+  const tile =
+    'flex flex-col items-start gap-2 rounded-[9px] border border-line bg-surface px-3 pb-[11px] pt-3 text-left shadow-card transition-colors hover:border-ink-faint focus-visible:outline-2 focus-visible:outline-brand'
+  return (
+    <div
+      className="relative rounded-[10px] border-[1.5px] border-dashed border-line bg-white/60 p-3.5"
+      onKeyDown={(e) => e.key === 'Escape' && onCancel?.()}
+    >
+      <Port side="in" dashed />
+      <div className="flex items-center">
+        <span className="flex-1 text-center text-[13.5px] font-semibold tracking-[-0.012em]">What should run?</span>
+        {onCancel && (
+          <Button
+            variant="bare"
+            size="icon-sm"
+            className="absolute right-2 top-2 size-6 text-ink-faint hover:text-ink"
+            aria-label="Cancel"
+            onClick={onCancel}
+          >
+            <XIcon className="size-3.5" />
+          </Button>
+        )}
+      </div>
+      <div className="mt-3 grid grid-cols-2 gap-2">
+        <button type="button" className={tile} autoFocus={!!onCancel} onClick={() => onPick('pull')}>
+          <MetaTile size={22} />
+          <b className="text-[13px] font-semibold tracking-[-0.012em]">Integrations</b>
+          <span className="text-[11.5px] leading-[1.45] text-ink-soft">Pull Meta ad creatives onto a canvas.</span>
+        </button>
+        <button type="button" className={tile} onClick={() => onPick('agent')}>
+          <span className="flex">
+            {AGENT_ROLES.slice(0, 4).map((r, i) => (
+              <RoleMark key={r.id} role={r} size={22} className={cn(i > 0 && '-ml-1.5 ring-[1.5px] ring-white')} />
+            ))}
+          </span>
+          <b className="text-[13px] font-semibold tracking-[-0.012em]">Agent task</b>
+          <span className="text-[11.5px] leading-[1.45] text-ink-soft">
+            Give Doop, UX Lead or another role a brief on a canvas.
+          </span>
+        </button>
+      </div>
+    </div>
+  )
+}
+
+/* ------------------------------------------------------------------ */
+/* Runs                                                                */
+
+/** Every run of this automation, newest first, in the same floating panel
+ *  the canvas screen uses for its activity feed. */
+function RunsPanel({
+  automation,
+  canvases,
+  dirty,
+  onRunNow,
+  onClose,
+}: {
+  automation: Automation
+  canvases: CanvasMeta[]
+  dirty: boolean
+  onRunNow: () => void
+  onClose: () => void
+}) {
+  const [runs, setRuns] = useState<AutomationRun[] | null>(null)
+  const [more, setMore] = useState(false)
+  const lastRunId = automation.lastRun?.id
+
+  useEffect(() => {
+    api
+      .listRuns(automation.id)
+      .then((list) => {
+        setRuns(list)
+        setMore(list.length >= 20)
+      })
+      .catch(console.error)
+  }, [automation.id, lastRunId])
+
+  async function older() {
+    const last = runs?.[runs.length - 1]
+    if (!last) return
+    const list = await api.listRuns(automation.id, last.startedAt).catch(() => [])
+    setRuns((cur) => [...(cur ?? []), ...list])
+    setMore(list.length >= 20)
+  }
+
+  const canvasName = (id: string | null) => (id ? canvases.find((c) => c.id === id)?.name : undefined)
+
+  return (
+    <Panel className="inset-y-3 right-3 w-[300px] max-lg:hidden">
+      <PanelTabsRoot value="runs">
+        <PanelHeader>
+          <PanelTabs>
+            <PanelTab value="runs">Runs</PanelTab>
+          </PanelTabs>
+          <Tooltip label="Collapse panel" side="bottom" align="end">
+            <Button
+              variant="bare"
+              size="icon-sm"
+              className="shrink-0 text-ink-faint hover:bg-paper-deep hover:text-ink"
+              aria-label="Collapse panel"
+              onClick={onClose}
+            >
+              <PanelCollapseRightIcon width={13} height={13} />
+            </Button>
+          </Tooltip>
+        </PanelHeader>
+        <PanelTabPanel value="runs">
+          <PanelBody className="py-2">
+            <ListItem className="bg-paper/60">
+              <span className="flex items-center gap-2">
+                <ClockTile size={14} className={cn(!automation.nextRunAt && 'opacity-40')} />
+                <ListTitle className="text-ink-soft">
+                  {automation.nextRunAt && !dirty ? 'Next run' : automation.enabled ? 'Next run' : 'Paused'}
+                </ListTitle>
+                <ListMeta className="ml-auto font-mono">
+                  {automation.nextRunAt && !dirty ? formatRunTime(automation.nextRunAt) : ''}
+                </ListMeta>
+              </span>
+              {!automation.nextRunAt && automation.enabled && (
+                <ListSummary className="whitespace-normal">
+                  {dirty ? 'Save to see when it runs next.' : (incompleteReason(automation.steps) ?? 'Not scheduled.')}
+                </ListSummary>
+              )}
+            </ListItem>
+            {runs === null ? (
+              <div className="px-4 py-3">
+                <Skeleton className="h-10 rounded-md" />
+              </div>
+            ) : runs.length === 0 ? (
+              <div className="px-4 py-3 text-xs leading-[1.5] text-ink-faint">
+                No runs yet.{' '}
+                {automation.nextRunAt
+                  ? 'The first one is on the schedule.'
+                  : 'Finish the setup and turn it on, or run it now.'}
+                {!incompleteReason(automation.steps) && (
+                  <Button variant="ghost" size="sm" className="mt-2.5 block" onClick={onRunNow}>
+                    Run now
+                  </Button>
+                )}
+              </div>
+            ) : (
+              runs.map((r) => (
+                <ListItem key={r.id}>
+                  <span className="flex items-center gap-2">
+                    <RunDot status={r.status} />
+                    <ListTitle>{formatRunTime(r.startedAt)}</ListTitle>
+                    <ListMeta className="ml-auto font-mono">
+                      {r.endedAt ? duration(r.endedAt - r.startedAt) : ''}
+                    </ListMeta>
+                  </span>
+                  <ListSummary
+                    className={cn('whitespace-normal', r.status === 'failed' && 'text-accent-ink')}
+                    title={r.error ?? r.summary ?? undefined}
+                  >
+                    {r.status === 'running'
+                      ? 'Running…'
+                      : r.status === 'failed'
+                        ? (r.error ?? 'Failed')
+                        : (r.summary ?? 'Nothing new')}
+                  </ListSummary>
+                  {r.failure === 'reconnect' ? (
+                    <button
+                      type="button"
+                      className="self-start text-xs font-semibold text-accent-ink hover:underline"
+                      onClick={() => navigate('/integrations')}
+                    >
+                      Reconnect Meta
+                    </button>
+                  ) : r.canvasId && r.status === 'ok' ? (
+                    <button
+                      type="button"
+                      className="self-start text-xs font-semibold text-accent-ink hover:underline"
+                      onClick={() => navigate(`/c/${r.canvasId}`)}
+                    >
+                      Open {canvasName(r.canvasId) ?? 'canvas'} →
+                    </button>
+                  ) : null}
+                </ListItem>
+              ))
+            )}
+            {more && (
+              <button
+                type="button"
+                className="w-full px-4 py-2.5 text-left text-xs text-ink-soft transition-colors hover:bg-paper hover:text-ink"
+                onClick={older}
+              >
+                Show older
+              </button>
+            )}
+          </PanelBody>
+        </PanelTabPanel>
+      </PanelTabsRoot>
+    </Panel>
+  )
+}
+
+function duration(ms: number): string {
+  const s = Math.max(1, Math.round(ms / 1000))
+  if (s < 60) return `${s}s`
+  const m = Math.floor(s / 60)
+  return `${m}m ${s % 60}s`
+}

--- a/src/pages/Automations.tsx
+++ b/src/pages/Automations.tsx
@@ -1,0 +1,351 @@
+import { useEffect, useState } from 'react'
+import type { CanvasMeta } from '../../shared/types'
+import { roleById } from '../../shared/agents'
+import {
+  AUTOMATION_EXAMPLES,
+  describeSchedule,
+  type Automation,
+  type AutomationExample,
+  type Step,
+} from '../../shared/automations'
+import { api } from '../lib/api'
+import { navigate } from '../App'
+import { posthog } from '../lib/posthog'
+import { AccountMenu, IconGrid } from '../components/DashShell'
+import {
+  CanvasThumb,
+  ClockTile,
+  MetaTile,
+  RunDot,
+  StepChain,
+  Toggle,
+  WorkspaceRail,
+  formatRunTime,
+} from '../components/AutomateShell'
+import { RoleMark } from '../components/RoleMark'
+import { Button } from '../components/ui/button'
+import { Skeleton } from '../components/ui/skeleton'
+import { Toast } from '../components/ui/toast'
+import { ConfirmDialog } from '../components/ui/alert-dialog'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '../components/ui/dropdown-menu'
+import { MoreHorizontalIcon, TrashIcon } from '../components/ui/icons'
+import { DashContent, DashHeader, DashLayout, DashMain, DashTitle } from '../components/ui/dash'
+import { cn } from '@/lib/utils'
+
+/** The browser's zone — what "Monday 09:00" means to the person setting it up. */
+export function localTimeZone(): string {
+  try {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC'
+  } catch {
+    return 'UTC'
+  }
+}
+
+/** "every Monday 09:00" — the schedule as the list rows say it */
+function everyLine(a: Automation): string {
+  return describeSchedule(a.schedule)
+    .replace(/^Every /, 'every ')
+    .replace(' at ', ' ')
+}
+
+/**
+ * Automations overview. Every automation the user owns as one row — on/off,
+ * what it does, where, when it last ran and when it runs next. With nothing
+ * set up yet the page leads with examples, since a blank list says nothing
+ * about what the feature is for.
+ */
+export function Automations() {
+  const [items, setItems] = useState<Automation[] | null>(null)
+  const [canvases, setCanvases] = useState<CanvasMeta[]>([])
+  const [metaConnected, setMetaConnected] = useState(false)
+  const [busy, setBusy] = useState(false)
+  const [remove, setRemove] = useState<Automation | null>(null)
+  const [toast, setToast] = useState<string | null>(null)
+
+  useEffect(() => {
+    api.listAutomations().then(setItems).catch(console.error)
+    api.listCanvases().then(setCanvases).catch(console.error)
+    api
+      .integrations()
+      .then((s) => setMetaConnected(s.meta.connected))
+      .catch(console.error)
+  }, [])
+
+  function showToast(message: string) {
+    setToast(message)
+    window.setTimeout(() => setToast(null), 2400)
+  }
+
+  async function create(example?: AutomationExample) {
+    if (busy) return
+    setBusy(true)
+    try {
+      const tz = localTimeZone()
+      const created = example
+        ? await api.createAutomation({
+            name: example.name,
+            schedule: { ...example.schedule, tz },
+            steps: example.steps.map((s, i) => ({ ...s, id: `s${i + 1}`, canvasId: '' }) as Step),
+          })
+        : await api.createAutomation({
+            name: 'Untitled automation',
+            schedule: { kind: 'weekly', weekday: 1, hour: 9, minute: 0, tz },
+            steps: [],
+          })
+      posthog.capture('automation_created', { example: example?.id ?? null })
+      navigate(`/automations/${created.id}`)
+    } catch (error) {
+      console.error(error)
+      showToast('Couldn’t create the automation')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  async function toggle(a: Automation, enabled: boolean) {
+    setItems((list) => list?.map((x) => (x.id === a.id ? { ...x, enabled } : x)) ?? null)
+    try {
+      const saved = await api.updateAutomation(a.id, { enabled })
+      setItems((list) => list?.map((x) => (x.id === a.id ? saved : x)) ?? null)
+    } catch (error) {
+      console.error(error)
+      setItems((list) => list?.map((x) => (x.id === a.id ? a : x)) ?? null)
+      showToast('Couldn’t save')
+    }
+  }
+
+  async function destroy(a: Automation) {
+    try {
+      await api.deleteAutomation(a.id)
+      posthog.capture('automation_deleted')
+      setItems((list) => list?.filter((x) => x.id !== a.id) ?? null)
+    } catch (error) {
+      console.error(error)
+      showToast('Couldn’t delete')
+    }
+  }
+
+  const canvasById = (id: string) => canvases.find((c) => c.id === id)
+  const empty = items !== null && items.length === 0
+
+  return (
+    <DashLayout>
+      <WorkspaceRail
+        active="automations"
+        canvases={canvases}
+        automationCount={items?.length}
+        integrationCount={metaConnected ? 1 : 0}
+      />
+      <DashMain>
+        <DashHeader>
+          <span className="flex-1" />
+          <Button variant="primary" className="min-h-10 md:min-h-0" disabled={busy} onClick={() => create()}>
+            + New automation
+          </Button>
+          <AccountMenu />
+        </DashHeader>
+
+        <DashContent>
+          <DashTitle className="mb-[26px]">
+            Automations<em className="not-italic text-brand">.</em>
+          </DashTitle>
+
+          {items === null ? (
+            <div className="flex flex-col gap-2">
+              {[0, 1, 2].map((i) => (
+                <Skeleton key={i} index={i} className="h-14 rounded-[12px]" />
+              ))}
+            </div>
+          ) : empty ? (
+            <>
+              <div className="flex flex-col items-center gap-2.5 rounded-[18px] border-[1.5px] border-dashed border-line px-6 py-[34px] text-center">
+                <div className="mb-2.5 flex items-center gap-2.5">
+                  <ClockTile size={36} />
+                  <span className="h-px w-[22px] bg-[#b9b5ac]" aria-hidden />
+                  <MetaTile size={36} className="border border-line bg-surface" />
+                  <span className="h-px w-[22px] bg-[#b9b5ac]" aria-hidden />
+                  <span className="grid size-9 place-items-center rounded-[10px] border border-line bg-surface text-ink">
+                    <IconGrid />
+                  </span>
+                </div>
+                <h3 className="text-[18px] font-semibold tracking-[-0.015em]">Nothing runs on its own yet</h3>
+                <p className="max-w-[420px] text-[13.5px] leading-[1.5] text-ink-soft">
+                  Pull designs in on a schedule, or hand a canvas to an agent every week.
+                </p>
+                <Button variant="primary" className="mt-2.5" disabled={busy} onClick={() => create()}>
+                  + New automation
+                </Button>
+              </div>
+              <Examples onUse={create} busy={busy} />
+            </>
+          ) : (
+            <div className="overflow-hidden rounded-[14px] border border-line bg-surface shadow-card">
+              <div className="hidden grid-cols-[52px_minmax(0,1.7fr)_minmax(0,1fr)_minmax(0,1fr)_minmax(0,0.8fr)_36px] items-center gap-3 border-b border-line-soft px-4 py-2.5 font-mono text-[10px] uppercase tracking-[0.12em] text-ink-faint md:grid">
+                <span />
+                <span>Automation</span>
+                <span>Canvas</span>
+                <span>Last run</span>
+                <span>Next run</span>
+                <span />
+              </div>
+              {items.map((a) => {
+                const first = a.steps[0]
+                const canvasIds = [...new Set(a.steps.map((s) => s.canvasId).filter(Boolean))]
+                const canvas = canvasIds[0] ? canvasById(canvasIds[0]) : undefined
+                return (
+                  <div
+                    key={a.id}
+                    role="link"
+                    tabIndex={0}
+                    className="grid cursor-pointer grid-cols-[52px_minmax(0,1fr)_36px] items-center gap-3 border-b border-line-soft px-4 py-3 transition-colors last:border-b-0 hover:bg-paper md:grid-cols-[52px_minmax(0,1.7fr)_minmax(0,1fr)_minmax(0,1fr)_minmax(0,0.8fr)_36px]"
+                    onClick={() => navigate(`/automations/${a.id}`)}
+                    onKeyDown={(e) => e.key === 'Enter' && navigate(`/automations/${a.id}`)}
+                  >
+                    <Toggle on={a.enabled} onChange={(on) => toggle(a, on)} label={`${a.name} on or off`} />
+                    <div className="flex min-w-0 items-center gap-2.5">
+                      {first?.type === 'pull' ? (
+                        <MetaTile size={24} className="border border-line bg-surface" />
+                      ) : first ? (
+                        <span className="grid size-6 flex-none place-items-center rounded-[7px] border border-line bg-surface">
+                          <RoleMark role={roleById(first.roles[0])} size={14} />
+                        </span>
+                      ) : (
+                        <ClockTile size={24} />
+                      )}
+                      <span className="min-w-0 truncate text-[13.5px] text-ink-soft">
+                        <b className="font-semibold text-ink">{a.name}</b>
+                        {first?.type === 'agent' && first.roles.length === 1 && <> · @{first.roles[0]}</>} ·{' '}
+                        {everyLine(a)}
+                      </span>
+                    </div>
+                    <span className="hidden min-w-0 items-center gap-2.5 text-[13px] text-ink-soft md:flex">
+                      {canvasIds.length ? (
+                        <>
+                          <CanvasThumb canvas={canvas} className="h-[22px] w-[34px]" />
+                          <span className="truncate">
+                            {canvas?.name ?? 'Canvas'}
+                            {canvasIds.length > 1 ? ` +${canvasIds.length - 1}` : ''}
+                          </span>
+                        </>
+                      ) : (
+                        <em className="not-italic text-ink-faint">Pick a canvas</em>
+                      )}
+                    </span>
+                    <span className="hidden min-w-0 items-center gap-2 text-[13px] text-ink-soft md:flex">
+                      {a.lastRun ? (
+                        <>
+                          <RunDot status={a.lastRun.status} />
+                          <span className="truncate">
+                            {a.lastRun.status === 'running'
+                              ? 'Running'
+                              : a.lastRun.status === 'failed'
+                                ? 'Failed'
+                                : formatRunTime(a.lastRun.startedAt)}
+                            {a.lastRun.status === 'ok' && a.lastRun.summary ? ` · ${a.lastRun.summary}` : ''}
+                          </span>
+                          {a.lastRun.status === 'failed' && (
+                            <b
+                              className="font-semibold text-accent-ink"
+                              onClick={(e) => {
+                                e.stopPropagation()
+                                navigate(a.lastRun?.failure === 'reconnect' ? '/integrations' : `/automations/${a.id}`)
+                              }}
+                            >
+                              {a.lastRun.failure === 'reconnect' ? 'Reconnect' : 'Fix'}
+                            </b>
+                          )}
+                        </>
+                      ) : (
+                        <span className="text-ink-faint">Never</span>
+                      )}
+                    </span>
+                    <span
+                      className={cn(
+                        'hidden font-mono text-[11px] md:block',
+                        a.nextRunAt ? 'text-ink-soft' : 'text-ink-faint',
+                      )}
+                    >
+                      {a.nextRunAt ? formatRunTime(a.nextRunAt) : a.enabled ? 'finish setup' : 'paused'}
+                    </span>
+                    <DropdownMenu>
+                      <DropdownMenuTrigger asChild>
+                        <button
+                          type="button"
+                          aria-label={`Actions for ${a.name}`}
+                          className="grid size-8 place-items-center rounded-full text-ink-faint transition-colors hover:bg-paper-deep hover:text-ink"
+                          onClick={(e) => e.stopPropagation()}
+                        >
+                          <MoreHorizontalIcon className="size-4" />
+                        </button>
+                      </DropdownMenuTrigger>
+                      <DropdownMenuContent className="w-[170px]" onClick={(e) => e.stopPropagation()}>
+                        <DropdownMenuItem tone="danger" onSelect={() => setRemove(a)}>
+                          <TrashIcon className="size-4" /> Delete
+                        </DropdownMenuItem>
+                      </DropdownMenuContent>
+                    </DropdownMenu>
+                  </div>
+                )
+              })}
+            </div>
+          )}
+        </DashContent>
+      </DashMain>
+      <ConfirmDialog
+        open={!!remove}
+        onOpenChange={(open) => !open && setRemove(null)}
+        title={`Delete “${remove?.name ?? 'automation'}”?`}
+        description="It stops running and its run history goes with it. Frames it already created stay on their canvases."
+        confirmLabel="Delete"
+        destructive
+        onConfirm={() => {
+          if (remove) void destroy(remove)
+          setRemove(null)
+        }}
+      />
+      {toast && <Toast>{toast}</Toast>}
+    </DashLayout>
+  )
+}
+
+/** The example cards: a chain of marks, a name, one line, the schedule and
+ *  "Use". The editor's empty slot shows the same set as compact rows. */
+export function Examples({ onUse, busy }: { onUse: (example: AutomationExample) => void; busy?: boolean }) {
+  return (
+    <section className="mt-[30px]">
+      <h2 className="font-mono text-[10px] uppercase tracking-[0.12em] text-ink-faint">Start from an example</h2>
+      <div className="mt-3 grid grid-cols-1 gap-3.5 sm:grid-cols-2 xl:grid-cols-3">
+        {AUTOMATION_EXAMPLES.map((e) => (
+          <div
+            key={e.id}
+            role="button"
+            tabIndex={0}
+            className="group flex cursor-pointer flex-col gap-2 rounded-[12px] border border-line bg-surface px-4 pb-3.5 pt-4 shadow-card transition-[translate,border-color] duration-150 hover:-translate-y-[3px] hover:border-ink-faint focus-visible:outline-2 focus-visible:outline-brand"
+            onClick={() => !busy && onUse(e)}
+            onKeyDown={(ev) => {
+              if (ev.key === 'Enter' || ev.key === ' ') {
+                ev.preventDefault()
+                if (!busy) onUse(e)
+              }
+            }}
+          >
+            <StepChain steps={e.steps} size={26} />
+            <b className="mt-1 text-[14px] font-semibold tracking-[-0.012em]">{e.name}</b>
+            <p className="text-[12.5px] leading-[1.5] text-ink-soft">{e.blurb}</p>
+            <div className="mt-auto flex items-center pt-1.5 font-mono text-[10.5px] text-ink-faint">
+              {describeSchedule({ ...e.schedule, tz: 'UTC' }).replace(' at ', ' ')}
+              <b className="ml-auto font-sans text-[12.5px] font-semibold text-ink group-hover:text-accent-ink">
+                Use →
+              </b>
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
+  )
+}

--- a/src/pages/CanvasPage.tsx
+++ b/src/pages/CanvasPage.tsx
@@ -12,7 +12,8 @@ import {
   type SyncKeyInfo,
 } from '../lib/api'
 import { navigate } from '../App'
-import { DoopMark, Logo } from '../components/Logo'
+import { DoopMark } from '../components/Logo'
+import { BarDivider, TopBar, TopBarHome, TopBarTitle } from '../components/TopBar'
 import { ensureTab } from '../lib/desktop'
 import { Stage } from '../components/Stage'
 import { Board } from '../components/Board'
@@ -276,19 +277,9 @@ export function CanvasPage({ canvasId }: { canvasId: string }) {
           into the ••• sheet so the name and the view switch keep their room.
           Phone (< xs): two rows, the name on top, the switch and the actions
           below it, each at its natural width. */}
-      <div className="z-40 flex h-14 flex-none items-center gap-4 border-b border-line bg-surface px-4 max-md:gap-2.5 max-md:px-3 max-xs:h-[100px] max-xs:flex-wrap max-xs:content-center max-xs:gap-y-2 max-xs:py-2">
+      <TopBar>
         <div className="flex min-w-0 items-center gap-1.5 max-xs:basis-full">
-          <Tooltip label="All canvases" side="bottom" align="start">
-            <Button
-              variant="bare"
-              size="icon-sm"
-              className="size-9 hover:bg-paper-deep"
-              onClick={() => navigate('/')}
-              aria-label="All canvases"
-            >
-              <Logo className="size-6" />
-            </Button>
-          </Tooltip>
+          <TopBarHome label="All canvases" to="/" />
           <CanvasName />
           <Badge className="max-md:hidden" title="Canvas id — agents use this with the MCP tools">
             {canvasId}
@@ -414,7 +405,7 @@ export function CanvasPage({ canvasId }: { canvasId: string }) {
             </Button>
           </Tooltip>
         </div>
-      </div>
+      </TopBar>
 
       <div className="relative flex-1 overflow-hidden">
         {view === 'board' ? (
@@ -636,11 +627,6 @@ export function CanvasPage({ canvasId }: { canvasId: string }) {
       )}
     </div>
   )
-}
-
-/* hairline between the top bar's clusters: actions | presence | sharing */
-function BarDivider() {
-  return <span aria-hidden className="mx-1 h-[22px] w-px bg-line-soft" />
 }
 
 function ImportModal({
@@ -1558,30 +1544,17 @@ function GithubSection({
 }
 
 /* The canvas title doubles as its rename field. */
-const canvasNameCls = 'min-w-0 max-w-[240px] sm:min-w-[60px] sm:max-w-[320px]'
-
 function CanvasName() {
   const canvas = useStore((s) => s.canvas)
-  const [draft, setDraft] = useState<string | null>(null)
-  if (!canvas)
-    return <span className={cn(canvasNameCls, 'px-2 py-[5px] font-display text-[15px] font-semibold')}>…</span>
   return (
-    <Input
-      variant="title"
-      inputSize="sm"
-      className={cn(canvasNameCls, 'truncate max-xs:max-w-[calc(100vw-72px)]')}
-      value={draft ?? canvas.name}
-      size={Math.max(6, (draft ?? canvas.name).length)}
-      onFocus={() => setDraft(canvas.name)}
-      onChange={(e) => setDraft(e.target.value)}
-      onBlur={() => {
-        if (draft !== null && draft.trim() && draft !== canvas.name) {
-          api.renameCanvas(canvas.id, draft.trim()).catch(console.error)
-          useStore.getState().renameCanvasLocal(draft.trim())
-        }
-        setDraft(null)
+    <TopBarTitle
+      loading={!canvas}
+      value={canvas?.name ?? ''}
+      onCommit={(name) => {
+        if (!canvas) return
+        api.renameCanvas(canvas.id, name).catch(console.error)
+        useStore.getState().renameCanvasLocal(name)
       }}
-      onKeyDown={(e) => e.key === 'Enter' && (e.target as HTMLInputElement).blur()}
     />
   )
 }

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -11,7 +11,9 @@ import { ShareModal } from '../components/ShareModal'
 import {
   AccountMenu,
   ConnectCard,
+  IconAutomations,
   IconCommunity,
+  IconIntegrations,
   IconGrid,
   IconList,
   IconShare,
@@ -225,6 +227,8 @@ export function Home() {
             on={scope === 'shared'}
             go={() => setScope('shared')}
           />
+          <NavItem icon={<IconAutomations />} label="Automations" on={false} go={() => navigate('/automations')} />
+          <NavItem icon={<IconIntegrations />} label="Integrations" on={false} go={() => navigate('/integrations')} />
         </nav>
 
         <DashSectionLabel>Explore</DashSectionLabel>

--- a/src/pages/Integrations.tsx
+++ b/src/pages/Integrations.tsx
@@ -1,0 +1,197 @@
+import { useEffect, useState } from 'react'
+import type { CanvasMeta } from '../../shared/types'
+import type { Automation } from '../../shared/automations'
+import { api, type IntegrationsStatus } from '../lib/api'
+import { posthog } from '../lib/posthog'
+import { AccountMenu } from '../components/DashShell'
+import { MetaTile, WorkspaceRail } from '../components/AutomateShell'
+import { Button } from '../components/ui/button'
+import { Callout } from '../components/ui/callout'
+import { Skeleton } from '../components/ui/skeleton'
+import { Toast } from '../components/ui/toast'
+import { ConfirmDialog } from '../components/ui/alert-dialog'
+import { DashContent, DashHeader, DashLayout, DashMain, DashTitle } from '../components/ui/dash'
+import { cn } from '@/lib/utils'
+
+/**
+ * Integrations: the outside services this account is connected to, one
+ * card each. Connections are per user, not per canvas — an automation you
+ * own draws on them wherever it runs. Meta is the only provider today.
+ */
+export function Integrations() {
+  const [status, setStatus] = useState<IntegrationsStatus | null>(null)
+  const [canvases, setCanvases] = useState<CanvasMeta[]>([])
+  const [automations, setAutomations] = useState<Automation[]>([])
+  const [busy, setBusy] = useState(false)
+  const [confirmDisconnect, setConfirmDisconnect] = useState(false)
+  const [toast, setToast] = useState<string | null>(null)
+  /* read once: the warning is about the week ahead, not this render */
+  const [soon] = useState(() => Date.now() + 7 * 86_400_000)
+  /* the OAuth round-trip lands back here with its outcome in the query;
+     read it once (initialisers run twice under StrictMode, so the URL is
+     cleaned in an effect, not here) */
+  const [notice] = useState(() => {
+    const q = new URLSearchParams(location.search)
+    const error = q.get('metaError')
+    const connected = q.get('meta') === 'connected'
+    return error
+      ? { tone: 'error' as const, text: error }
+      : connected
+        ? { tone: 'success' as const, text: 'Meta connected.' }
+        : null
+  })
+
+  useEffect(() => {
+    api.integrations().then(setStatus).catch(console.error)
+    api.listCanvases().then(setCanvases).catch(console.error)
+    api.listAutomations().then(setAutomations).catch(console.error)
+    if (notice) history.replaceState(null, '', location.pathname)
+  }, [notice])
+
+  function showToast(message: string) {
+    setToast(message)
+    window.setTimeout(() => setToast(null), 2400)
+  }
+
+  async function connect() {
+    if (busy) return
+    setBusy(true)
+    try {
+      const { url } = await api.startMetaConnect()
+      posthog.capture('integration_connect_started', { provider: 'meta' })
+      location.assign(url)
+    } catch (error) {
+      console.error(error)
+      showToast('Couldn’t start the Meta connection')
+      setBusy(false)
+    }
+  }
+
+  async function disconnect() {
+    setBusy(true)
+    try {
+      setStatus(await api.disconnectMeta())
+      posthog.capture('integration_disconnected', { provider: 'meta' })
+    } catch (error) {
+      console.error(error)
+      showToast('Couldn’t disconnect')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const meta = status?.meta
+  const usedBy = automations.filter((a) => a.steps.some((s) => s.type === 'pull')).length
+
+  return (
+    <DashLayout>
+      <WorkspaceRail
+        active="integrations"
+        canvases={canvases}
+        automationCount={automations.length}
+        integrationCount={meta?.connected ? 1 : 0}
+      />
+      <DashMain>
+        <DashHeader>
+          <span className="flex-1" />
+          <AccountMenu />
+        </DashHeader>
+
+        <DashContent>
+          <DashTitle className="mb-[26px]">
+            Integrations<em className="not-italic text-brand">.</em>
+          </DashTitle>
+
+          {notice && (
+            <Callout tone={notice.tone} className="mb-4 max-w-[720px]">
+              {notice.text}
+            </Callout>
+          )}
+
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3">
+            {!meta ? (
+              <Skeleton className="min-h-[150px] rounded-[14px]" />
+            ) : (
+              <div className="flex min-h-[150px] flex-col gap-3 rounded-[14px] border border-line bg-surface px-[18px] pb-4 pt-[18px] shadow-card">
+                <div className="flex items-center gap-[11px]">
+                  <MetaTile size={36} />
+                  <div className="min-w-0">
+                    <div className="text-[15px] font-semibold tracking-[-0.012em]">Meta Ads</div>
+                    <div className="mt-0.5 truncate text-[12px] text-ink-soft">
+                      {meta.connected
+                        ? `${meta.accountName ?? 'Meta'} · ${meta.accounts?.length ?? 0} ad ${
+                            meta.accounts?.length === 1 ? 'account' : 'accounts'
+                          }`
+                        : 'Pull ad creatives onto a canvas'}
+                    </div>
+                  </div>
+                  <span
+                    className={cn(
+                      'ml-auto inline-flex flex-none items-center gap-1.5 font-mono text-[10px] uppercase tracking-[0.1em]',
+                      meta.connected ? 'text-ink-soft' : 'text-ink-faint',
+                    )}
+                  >
+                    <span className={cn('size-[7px] rounded-full', meta.connected ? 'bg-[#3f9c52]' : 'bg-line')} />
+                    {meta.connected ? 'connected' : 'not connected'}
+                  </span>
+                </div>
+                {meta.connected && meta.expiresAt && meta.expiresAt < soon && (
+                  <p className="text-[11.5px] text-accent-ink">
+                    Meta’s access expires soon — reconnect to keep pulls running.
+                  </p>
+                )}
+                {!meta.enabled && (
+                  <p className="text-[11.5px] text-ink-faint">
+                    Not configured on this server — set META_APP_ID and META_APP_SECRET.
+                  </p>
+                )}
+                <div className="mt-auto flex items-center gap-2">
+                  <span className="flex-1 text-[12px] text-ink-faint">
+                    {meta.connected
+                      ? usedBy > 0
+                        ? `Used by ${usedBy} ${usedBy === 1 ? 'automation' : 'automations'}`
+                        : 'Not used by an automation yet'
+                      : ''}
+                  </span>
+                  {meta.connected ? (
+                    <>
+                      <Button variant="bare" size="sm" disabled={busy || !meta.enabled} onClick={connect}>
+                        Reconnect
+                      </Button>
+                      <Button
+                        variant="bare"
+                        size="sm"
+                        className="text-ink-soft"
+                        disabled={busy}
+                        onClick={() => setConfirmDisconnect(true)}
+                      >
+                        Disconnect
+                      </Button>
+                    </>
+                  ) : (
+                    <Button variant="default" size="sm" disabled={busy || !meta.enabled} onClick={connect}>
+                      Connect
+                    </Button>
+                  )}
+                </div>
+              </div>
+            )}
+          </div>
+        </DashContent>
+      </DashMain>
+      <ConfirmDialog
+        open={confirmDisconnect}
+        onOpenChange={(open) => !open && setConfirmDisconnect(false)}
+        title="Disconnect Meta?"
+        description="Automations that pull from Meta will fail until you connect again. Frames already on your canvases stay."
+        confirmLabel="Disconnect"
+        destructive
+        onConfirm={() => {
+          setConfirmDisconnect(false)
+          void disconnect()
+        }}
+      />
+      {toast && <Toast>{toast}</Toast>}
+    </DashLayout>
+  )
+}

--- a/tests/automations.test.ts
+++ b/tests/automations.test.ts
@@ -1,0 +1,318 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { Client, startServer, type Server } from './harness.ts'
+import {
+  AUTOMATION_EXAMPLES,
+  describeSchedule,
+  incompleteReason,
+  nextRunAt,
+  normalizeSchedule,
+  normalizeSteps,
+  wallClock,
+} from '../shared/automations.ts'
+import {
+  creativeHtml,
+  frameHeight,
+  imageHeight,
+  metaFrameMarker,
+  signState,
+  toCreative,
+  toCreatives,
+  verifyState,
+} from '../server/meta.ts'
+
+/* ------------------------------------------------------------------ */
+/* Pure: schedule math                                                 */
+
+describe('nextRunAt', () => {
+  /* 2026-09-09 is a Wednesday */
+  const wed = Date.UTC(2026, 8, 9, 12, 0)
+
+  it('fires next Monday 09:00 in the zone, not in UTC', () => {
+    const at = nextRunAt({ kind: 'weekly', weekday: 1, hour: 9, minute: 0, tz: 'Europe/Berlin' }, wed)
+    const w = wallClock(at, 'Europe/Berlin')
+    expect([w.weekday, w.hour, w.minute]).toEqual([1, 9, 0])
+    expect(new Date(at).toISOString()).toBe('2026-09-14T07:00:00.000Z') // CEST = UTC+2
+  })
+
+  it('same day when the time is still ahead, next occurrence when it has passed', () => {
+    const daily = { kind: 'daily' as const, weekday: 0, hour: 15, minute: 30, tz: 'UTC' }
+    expect(new Date(nextRunAt(daily, wed)).toISOString()).toBe('2026-09-09T15:30:00.000Z')
+    const later = Date.UTC(2026, 8, 9, 15, 30)
+    expect(new Date(nextRunAt(daily, later)).toISOString()).toBe('2026-09-10T15:30:00.000Z')
+  })
+
+  it('weekdays skips the weekend', () => {
+    const fri = Date.UTC(2026, 8, 11, 20, 0)
+    const at = nextRunAt({ kind: 'weekdays', weekday: 0, hour: 9, minute: 0, tz: 'UTC' }, fri)
+    expect(new Date(at).toISOString()).toBe('2026-09-14T09:00:00.000Z')
+  })
+
+  it('survives a DST change between now and the run', () => {
+    /* Berlin leaves DST on 2026-10-25; a Monday 09:00 after it is UTC+1 */
+    const before = Date.UTC(2026, 9, 23, 12, 0)
+    const at = nextRunAt({ kind: 'weekly', weekday: 1, hour: 9, minute: 0, tz: 'Europe/Berlin' }, before)
+    expect(new Date(at).toISOString()).toBe('2026-10-26T08:00:00.000Z')
+  })
+
+  it('falls back to UTC for a zone it does not know', () => {
+    const at = nextRunAt({ kind: 'daily', weekday: 0, hour: 9, minute: 0, tz: 'Mars/Olympus' }, wed)
+    expect(new Date(at).toISOString()).toBe('2026-09-10T09:00:00.000Z')
+  })
+})
+
+describe('normalize', () => {
+  it('coerces a schedule and rejects out-of-range fields', () => {
+    expect(normalizeSchedule({ kind: 'nope', weekday: 9, hour: '7', minute: 61, tz: 'Nowhere/Here' })).toEqual({
+      kind: 'weekly',
+      weekday: 1,
+      hour: 7,
+      minute: 0,
+      tz: 'UTC',
+    })
+    /* the clock reads in the runner's locale: 16:00 or 4:00 PM */
+    expect(describeSchedule(normalizeSchedule({ kind: 'weekly', weekday: 5, hour: 16, minute: 0 }))).toMatch(
+      /^Every Friday at (16:00|4:00 PM)$/,
+    )
+  })
+
+  it('keeps only real steps, with real roles', () => {
+    const steps = normalizeSteps([
+      { type: 'pull', accountId: 'act_1', filter: 'everything', canvasId: 'c1' },
+      { type: 'agent', prompt: ' Review it ', roles: ['bogus', 'ux', 'doop'], canvasId: 'c1' },
+    ])
+    expect(steps).toEqual([
+      { id: 's1', type: 'pull', provider: 'meta', accountId: 'act_1', filter: 'active', canvasId: 'c1' },
+      { id: 's2', type: 'agent', title: '', prompt: 'Review it', roles: ['ux'], canvasId: 'c1' },
+    ])
+    expect(normalizeSteps([{ type: 'webhook' }])).toBe('each step is a pull or an agent task')
+  })
+
+  it('says what is missing before an automation can run', () => {
+    expect(incompleteReason([])).toBe('Add a step')
+    expect(incompleteReason([{ id: 's1', type: 'agent', title: '', prompt: 'x', roles: ['doop'], canvasId: '' }])).toBe(
+      'Pick a canvas for every step',
+    )
+    expect(
+      incompleteReason([{ id: 's1', type: 'pull', provider: 'meta', accountId: '', filter: 'active', canvasId: 'c' }]),
+    ).toBe('Pick a Meta ad account')
+    expect(
+      incompleteReason([{ id: 's1', type: 'agent', title: '', prompt: 'x', roles: ['doop'], canvasId: 'c' }]),
+    ).toBeUndefined()
+  })
+
+  it('every example is complete once a canvas is picked', () => {
+    for (const e of AUTOMATION_EXAMPLES) {
+      const steps = normalizeSteps(e.steps.map((s) => ({ ...s, canvasId: 'c', accountId: 'act_1' })))
+      expect(typeof steps).not.toBe('string')
+      if (typeof steps !== 'string') expect(incompleteReason(steps)).toBeUndefined()
+    }
+  })
+})
+
+/* ------------------------------------------------------------------ */
+/* Pure: Meta                                                          */
+
+describe('meta', () => {
+  it('signs a state only its own user can redeem, for a while', () => {
+    const state = signState('user-1')
+    expect(verifyState(state)).toEqual({ userId: 'user-1' })
+    expect(verifyState(state.slice(0, -2) + 'xx')).toBeUndefined()
+    expect(verifyState(signState('user-1', Date.now() - 16 * 60_000))).toBeUndefined()
+  })
+
+  it('flattens the several creative shapes into one card', () => {
+    expect(
+      toCreative({
+        id: '9',
+        name: 'Spring sale',
+        effective_status: 'ACTIVE',
+        creative: {
+          object_story_spec: {
+            link_data: {
+              name: 'Big headline',
+              message: 'Body copy',
+              picture: 'https://x/y.jpg',
+              image_hash: 'abc123',
+              call_to_action: { type: 'SHOP_NOW' },
+            },
+          },
+        },
+      }),
+    ).toEqual({
+      adId: '9',
+      name: 'Spring sale',
+      headline: 'Big headline',
+      body: 'Body copy',
+      cta: 'Shop Now',
+      imageUrl: 'https://x/y.jpg',
+      imageHash: 'abc123',
+      creativeId: null,
+      width: null,
+      height: null,
+      status: 'ACTIVE',
+    })
+  })
+
+  it('expands dynamic-creative and carousel ads into one card per image', () => {
+    const feed = toCreatives({
+      id: '7',
+      name: 'Dynamic',
+      creative: { asset_feed_spec: { titles: [{ text: 'T' }], images: [{ hash: 'a' }, { hash: 'b' }, { hash: 'c' }] } },
+    })
+    expect(feed.map((c) => [c.adId, c.name, c.imageHash])).toEqual([
+      ['7:a', 'Dynamic · 1', 'a'],
+      ['7:b', 'Dynamic · 2', 'b'],
+      ['7:c', 'Dynamic · 3', 'c'],
+    ])
+    const carousel = toCreatives({
+      id: '8',
+      name: 'Carousel',
+      creative: {
+        object_story_spec: {
+          link_data: {
+            message: 'Shared body',
+            child_attachments: [
+              { name: 'Card one', image_hash: 'x' },
+              { name: 'Card two', image_hash: 'y', description: 'Own body' },
+            ],
+          },
+        },
+      },
+    })
+    expect(carousel.map((c) => [c.adId, c.headline, c.body])).toEqual([
+      ['8:x', 'Card one', 'Shared body'],
+      ['8:y', 'Card two', 'Own body'],
+    ])
+    /* a single-image ad stays one card */
+    expect(toCreatives({ id: '9', creative: { image_hash: 'z' } })).toHaveLength(1)
+  })
+
+  it('sizes the frame to the image, whatever its aspect ratio', () => {
+    expect(imageHeight({ width: null, height: null })).toBe(480)
+    expect(imageHeight({ width: 1080, height: 1920 })).toBe(853)
+    expect(imageHeight({ width: 1080, height: 1350 })).toBe(600)
+    expect(frameHeight({ width: 1920, height: 1080 })).toBe(270 + 190)
+  })
+
+  it('stamps the ad id into the frame so a later pull can skip it', () => {
+    const html = creativeHtml(
+      {
+        adId: '42',
+        name: 'A <b>',
+        headline: 'H',
+        body: 'B',
+        cta: 'Learn More',
+        imageUrl: null,
+        imageHash: null,
+        creativeId: null,
+        width: null,
+        height: null,
+        status: 'ACTIVE',
+      },
+      null,
+    )
+    expect(metaFrameMarker(html)).toBe('42')
+    expect(html).toContain('A &lt;b&gt;')
+    expect(html).not.toContain('<b>')
+  })
+})
+
+/* ------------------------------------------------------------------ */
+/* REST                                                                */
+
+const PORT = 4994
+
+let server: Server
+let owner: Client
+let other: Client
+
+beforeAll(async () => {
+  server = await startServer(PORT, { BETTER_AUTH_URL: `http://localhost:${PORT}` })
+  owner = new Client(server)
+  await owner.signUp('owner@test.dev', 'Olive Owner')
+  other = new Client(server)
+  await other.signUp('other@test.dev', 'Otto Other')
+}, 60_000)
+
+afterAll(() => server?.stop())
+
+it('creates, completes, runs and lists an automation for its owner only', async () => {
+  const canvas = await (await owner.post('/api/canvases', { name: 'Ads' })).json()
+
+  /* starts empty: saved, but not scheduled */
+  const created = await (
+    await owner.post('/api/automations', {
+      name: 'Friday review',
+      schedule: { kind: 'weekly', weekday: 5, hour: 16, minute: 0, tz: 'Europe/Berlin' },
+      steps: [],
+    })
+  ).json()
+  expect(created).toMatchObject({ name: 'Friday review', enabled: true, steps: [], nextRunAt: null, lastRun: null })
+
+  /* a canvas the owner cannot reach is refused */
+  const foreign = await (await other.post('/api/canvases', { name: 'Not yours' })).json()
+  const refused = await owner.patch(`/api/automations/${created.id}`, {
+    steps: [{ type: 'agent', prompt: 'Review', roles: ['ux'], canvasId: foreign.id }],
+  })
+  expect(refused.status).toBe(400)
+
+  /* completing it schedules it */
+  const saved = await (
+    await owner.patch(`/api/automations/${created.id}`, {
+      steps: [{ type: 'agent', prompt: 'Review every frame', roles: ['ux'], canvasId: canvas.id }],
+    })
+  ).json()
+  expect(saved.steps).toEqual([
+    { id: 's1', type: 'agent', title: '', prompt: 'Review every frame', roles: ['ux'], canvasId: canvas.id },
+  ])
+  expect(saved.nextRunAt).toBeGreaterThan(Date.now())
+  expect(new Date(saved.nextRunAt).getUTCDay()).toBe(5)
+
+  /* off = no next run; on again = scheduled again */
+  expect((await (await owner.patch(`/api/automations/${created.id}`, { enabled: false })).json()).nextRunAt).toBeNull()
+  /* a rename carries only the name — it must not switch the automation back on */
+  const renamed = await (await owner.patch(`/api/automations/${created.id}`, { name: 'Friday UX review' })).json()
+  expect(renamed).toMatchObject({ name: 'Friday UX review', enabled: false, nextRunAt: null })
+  expect(renamed.steps).toHaveLength(1)
+  expect(
+    (await (await owner.patch(`/api/automations/${created.id}`, { enabled: true })).json()).nextRunAt,
+  ).not.toBeNull()
+
+  /* run now: the test server has no model account, so the agent step fails
+     cleanly and the run says why */
+  const run = await (await owner.post(`/api/automations/${created.id}/run`)).json()
+  expect(run).toMatchObject({ automationId: created.id, status: 'failed', canvasId: canvas.id })
+  expect(run.error).toMatch(/no model account/)
+  expect(run.endedAt).toBeGreaterThanOrEqual(run.startedAt)
+
+  const runs = await (await owner.get(`/api/automations/${created.id}/runs`)).json()
+  expect(runs).toHaveLength(1)
+  expect(runs[0].id).toBe(run.id)
+
+  const [listed] = await (await owner.get('/api/automations')).json()
+  expect(listed.lastRun).toMatchObject({ id: run.id, status: 'failed' })
+
+  /* private to the owner */
+  expect((await other.get(`/api/automations/${created.id}`)).status).toBe(404)
+  expect(await (await other.get('/api/automations')).json()).toEqual([])
+  expect((await other.delete(`/api/automations/${created.id}`)).status).toBe(404)
+
+  expect((await owner.delete(`/api/automations/${created.id}`)).status).toBe(200)
+  expect((await owner.get(`/api/automations/${created.id}`)).status).toBe(404)
+})
+
+it('reports Meta as not connected and not configured on a bare server', async () => {
+  const status = await (await owner.get('/api/integrations')).json()
+  expect(status).toEqual({ meta: { enabled: false, connected: false } })
+  expect((await owner.post('/api/integrations/meta/start')).status).toBe(400)
+  /* a pull step without a connection fails with the one-click fix named */
+  const canvas = await (await owner.post('/api/canvases', { name: 'Pulls' })).json()
+  const a = await (
+    await owner.post('/api/automations', {
+      name: 'Pull',
+      steps: [{ type: 'pull', accountId: 'act_1', filter: 'active', canvasId: canvas.id }],
+    })
+  ).json()
+  const run = await (await owner.post(`/api/automations/${a.id}/run`)).json()
+  expect(run).toMatchObject({ status: 'failed', failure: 'reconnect' })
+})

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -35,7 +35,8 @@ export default defineConfig({
          the one that serves the login page and that MCP clients connect to */
       '/api': { target: api },
       '/mcp': { target: api },
-      '/i': { target: api },
+      /* frame images only — a bare '/i' prefix would swallow /integrations */
+      '/i/': { target: api },
       '/a/': { target: api },
       '/u/': { target: api },
       '/ingest': { target: api },


### PR DESCRIPTION
## Summary
Cherry-pick (`-x`) of private #168, which merged after #145 was cut. Adds the Automations and Integrations pages, the scheduler, the Meta ad-creative pull, and migrations `0012_automations` and `0013_integrations_unique` (copied verbatim with their snapshots).

With this the shared tree is byte-identical to private except the two-line private seam in `server/index.ts`.

## Test plan
- [x] `bun run typecheck`, `bun run lint`, `bun run format:check`
- [x] `bun run test` (41 files, 391 tests)
- [x] `bun run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)