### PR TITLE
fix: one-click copy button for the frame's HTML code

### DIFF
--- a/src/components/Inspector.tsx
+++ b/src/components/Inspector.tsx
@@ -34,9 +34,10 @@ export function Inspector({
   const [draft, setDraft] = useState(frame.html)
   const [saveState, setSaveState] = useState<'idle' | 'dirty' | 'saved'>('idle')
   const [copiedUrl, setCopiedUrl] = useState(false)
-  const [copiedHtml, setCopiedHtml] = useState(false)
+  const [htmlCopy, setHtmlCopy] = useState<'idle' | 'copied' | 'failed'>('idle')
   const textareaRef = useRef<HTMLTextAreaElement>(null)
   const saveTimer = useRef<number | null>(null)
+  const copyTimer = useRef<number | null>(null)
   const frameId = useRef(frame.id)
 
   /* switching frames resets the draft; otherwise pull in remote html
@@ -49,7 +50,17 @@ export function Inspector({
       setDraft(frame.html)
       setSaveState('idle')
     }
+    /* a copy confirmation belongs to the frame it was copied from */
+    if (switched) setHtmlCopy('idle')
   }, [frame.id, frame.html, draft])
+
+  /* the confirmation timer must not fire after the panel is gone */
+  useEffect(
+    () => () => {
+      if (copyTimer.current) window.clearTimeout(copyTimer.current)
+    },
+    [],
+  )
 
   function onHtmlChange(value: string) {
     setDraft(value)
@@ -62,6 +73,20 @@ export function Inspector({
       setSaveState('saved')
       window.setTimeout(() => setSaveState((s) => (s === 'saved' ? 'idle' : s)), 1500)
     }, 700)
+  }
+
+  async function copyHtml() {
+    /* one timer only, so an older copy can't clear the newest tick early */
+    if (copyTimer.current) window.clearTimeout(copyTimer.current)
+    try {
+      await navigator.clipboard.writeText(draft)
+      setHtmlCopy('copied')
+      copyTimer.current = window.setTimeout(() => setHtmlCopy('idle'), 1500)
+    } catch (caught) {
+      console.error(caught)
+      /* a failure stays up until the next attempt, so it can be read */
+      setHtmlCopy('failed')
+    }
   }
 
   function commitMeta(patch: Partial<Frame>) {
@@ -144,10 +169,11 @@ export function Inspector({
           <span>{'</>'} HTML</span>
         </PanelDisclosure>
         <CollapsibleContent className="relative flex min-h-0 flex-col">
+          {/* pr-11 keeps the copy button's corner clear of the code, as CodeBlock does */}
           <Textarea
             ref={textareaRef}
             variant="bare"
-            className="h-[320px] flex-none bg-[#17171b] p-3.5 font-mono text-xs leading-[1.55] text-[#e9e9ee] [tab-size:2] max-md:h-auto max-md:min-h-[160px] max-md:flex-1 md:text-xs"
+            className="h-[320px] flex-none bg-[#17171b] py-3.5 pl-3.5 pr-11 font-mono text-xs leading-[1.55] text-[#e9e9ee] [tab-size:2] max-md:h-auto max-md:min-h-[160px] max-md:flex-1 md:text-xs"
             value={draft}
             spellCheck={false}
             placeholder="<!doctype html>…"
@@ -157,15 +183,15 @@ export function Inspector({
             type="button"
             className="absolute right-2 top-2 rounded-[6px] bg-white/[0.08] px-2 py-1 text-[11px] text-[#e9e9ee] transition-colors hover:bg-white/[0.18]"
             title="Copy the frame's full HTML"
-            onClick={() => {
-              navigator.clipboard.writeText(draft).then(() => {
-                setCopiedHtml(true)
-                window.setTimeout(() => setCopiedHtml(false), 1500)
-              }, console.error)
-            }}
+            onClick={copyHtml}
           >
-            {copiedHtml ? '✓' : 'copy'}
+            {htmlCopy === 'copied' ? '✓' : 'copy'}
           </button>
+          {htmlCopy === 'failed' && (
+            <p className="px-3.5 py-2 text-[11px] text-accent-ink">
+              Couldn’t copy the HTML. Select it in the editor and copy it by hand.
+            </p>
+          )}
         </CollapsibleContent>
       </Collapsible>
       <footer className="flex items-center justify-between border-t border-line-soft px-4 py-2.5">

--- a/src/components/Inspector.tsx
+++ b/src/components/Inspector.tsx
@@ -34,6 +34,7 @@ export function Inspector({
   const [draft, setDraft] = useState(frame.html)
   const [saveState, setSaveState] = useState<'idle' | 'dirty' | 'saved'>('idle')
   const [copiedUrl, setCopiedUrl] = useState(false)
+  const [copiedHtml, setCopiedHtml] = useState(false)
   const textareaRef = useRef<HTMLTextAreaElement>(null)
   const saveTimer = useRef<number | null>(null)
   const frameId = useRef(frame.id)
@@ -142,7 +143,7 @@ export function Inspector({
         <PanelDisclosure>
           <span>{'</>'} HTML</span>
         </PanelDisclosure>
-        <CollapsibleContent className="flex min-h-0 flex-col">
+        <CollapsibleContent className="relative flex min-h-0 flex-col">
           <Textarea
             ref={textareaRef}
             variant="bare"
@@ -152,6 +153,19 @@ export function Inspector({
             placeholder="<!doctype html>…"
             onChange={(e) => onHtmlChange(e.target.value)}
           />
+          <button
+            type="button"
+            className="absolute right-2 top-2 rounded-[6px] bg-white/[0.08] px-2 py-1 text-[11px] text-[#e9e9ee] transition-colors hover:bg-white/[0.18]"
+            title="Copy the frame's full HTML"
+            onClick={() => {
+              navigator.clipboard.writeText(draft).then(() => {
+                setCopiedHtml(true)
+                window.setTimeout(() => setCopiedHtml(false), 1500)
+              }, console.error)
+            }}
+          >
+            {copiedHtml ? '✓' : 'copy'}
+          </button>
         </CollapsibleContent>
       </Collapsible>
       <footer className="flex items-center justify-between border-t border-line-soft px-4 py-2.5">


### PR DESCRIPTION
fixes #113

the export row already give one-click PNG, JPG and "Copy image URL", but the `</> HTML` panel below it only show a raw editable textarea — to get the code out you have to click in, select all, then copy, which is slow for a big frame.

this add a small "copy" button in the corner of the HTML textarea, same style and behavior as the existing copy button in `CodeBlock` (used elsewhere for copyable commands) — click it, it copy the current html to clipboard and show a checkmark for a bit.

i keep it small on purpose: the issue also suggest syntax highlighting for the code preview, but that's a bigger change (would probably need a real highlighter lib) so i leave that out and just do the one-click copy part, which is the main ask.

no test added — i look through the repo and there isn't a component-level test for any UI file (the whole `tests/` folder is server-side logic tests only), so this follow what's already there. verified manually against the existing `bun run typecheck`, `lint`, `format:check` and `build`, plus the full `bun run test` suite (391 tests, all still pass).

note: i used Claude Code to help write and check this.